### PR TITLE
Fix rookie C mistake committed in revision d076653b as part of

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2219,9 +2219,10 @@ print_interval_results(struct iperf_test *test, struct iperf_stream *sp, cJSON *
 	    /* Interval, TCP with retransmits. */
 	    if (test->json_output)
 		cJSON_AddItemToArray(json_interval_streams, iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  snd_cwnd:  %d  omitted: %b", (int64_t) sp->socket, (double) st, (double) et, (double) irp->interval_duration, (int64_t) irp->bytes_transferred, bandwidth * 8, (int64_t) irp->interval_retrans, (int64_t) irp->snd_cwnd, irp->omitted));
-	    else
+	    else {
 		unit_snprintf(cbuf, UNIT_LEN, irp->snd_cwnd, 'A');
 		iprintf(test, report_bw_retrans_cwnd_format, sp->socket, st, et, ubuf, nbuf, irp->interval_retrans, cbuf, irp->omitted?report_omitted:"");
+	    }
 	} else {
 	    /* Interval, TCP without retransmits. */
 	    if (test->json_output)


### PR DESCRIPTION
Issue #99.

This caused random output to be displayed on the client's stdout in
--json mode.

Pointed out by: @bltierney
Pointy hat to:  @bmah888
