### PR TITLE
fix has_sendfile ifdef, use the correct defined constant

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -221,11 +221,11 @@ Nwrite(int fd, const char *buf, size_t count, int prot)
 int
 has_sendfile(void)
 {
-#if defined(HAS_SENDFILE)
+#if defined(HAVE_SENDFILE)
     return 1;
-#else /* HAS_SENDFILE */
+#else /* HAVE_SENDFILE */
     return 0;
-#endif /* HAS_SENDFILE */
+#endif /* HAVE_SENDFILE */
 
 }
 


### PR DESCRIPTION
Hi,

On linux you get an error saying "sendfile not supported on this OS" . Reason is has_sendfile() checks for HAS_SENDFILE instead of HAVE_SENDFILE which is what the configuration script creates, also used correctly elsewhere in the file.

thanks,
Ran
