### PR TITLE
Update the license in the bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,12 +1,21 @@
 #!/bin/sh
 #
-#      $Id: bootstrap.sh 446 2008-04-21 04:07:15Z boote $
-#
 #########################################################################
 #									#
 #			   Copyright (C)  2003				#
 #	     			Internet2				#
-#			   All Rights Reserved				#
+#                                                                       #
+#  Licensed under the Apache License, Version 2.0 (the "License");      #
+#  you may not use this file except in compliance with the License.     #
+#  You may obtain a copy of the License at                              #
+#                                                                       #
+#  http://www.apache.org/licenses/LICENSE-2.0                           #
+#                                                                       #
+#  Unless required by applicable law or agreed to in writing, software  #
+#  distributed under the License is distributed on an "AS IS" BASIS,    #
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or      #
+#  implied. See the License for the specific language governing         #
+#  permissions and limitations under the License.                       #
 #									#
 #########################################################################
 #


### PR DESCRIPTION
Sets the license in bootstrap.sh to the apache license (matching what Internet2 has re-licensed their code to).
