### PR TITLE
Add -a flag to specify authentication.

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -205,6 +205,8 @@ struct iperf_test
     TAILQ_HEAD(xbind_addrhead, xbind_entry) xbind_addrs; /* all -X opts */
     int       bind_port;                        /* --cport option */
     int       server_port;
+    char      *authentication;                  /* If set, client and server authentication string must match for test to run */
+    char      *client_authentication;           /* When sent from the client, the server stores token here, so comparison can be made */
     int       omit;                             /* duration of omit period (-O flag) */
     int       duration;                         /* total duration of test (-t flag) */
     char     *diskfile_name;			/* -F option */

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -95,6 +95,7 @@ int	iperf_get_test_get_server_output( struct iperf_test* ipt );
 char*	iperf_get_test_bind_address ( struct iperf_test* ipt );
 int	iperf_get_test_udp_counters_64bit( struct iperf_test* ipt );
 int	iperf_get_test_one_off( struct iperf_test* ipt );
+char* iperf_get_test_authentication( struct iperf_test* ipt );
 
 /* Setter routines for some fields inside iperf_test. */
 void	iperf_set_verbose( struct iperf_test* ipt, int verbose );
@@ -120,6 +121,7 @@ void	iperf_set_test_get_server_output( struct iperf_test* ipt, int get_server_ou
 void	iperf_set_test_bind_address( struct iperf_test* ipt, char *bind_address );
 void	iperf_set_test_udp_counters_64bit( struct iperf_test* ipt, int udp_counters_64bit );
 void	iperf_set_test_one_off( struct iperf_test* ipt, int one_off );
+void    iperf_set_test_authentication( struct iperf_test* ipt, char *authentication );
 
 /**
  * exchange_parameters - handles the param_Exchange part for client

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -86,6 +86,7 @@ iperf_server_listen(struct iperf_test *test)
     if (!test->json_output) {
 	iprintf(test, "-----------------------------------------------------------\n");
 	iprintf(test, "Server listening on %d\n", test->server_port);
+    iprintf(test, "Server Authentication:%s\n", test->authentication);
     }
 
     // This needs to be changed to reflect if client has different window size


### PR DESCRIPTION
If a server is started with an authentication token, only clients who specify the same authentication token are able to run tests.

This is a pretty basic change, and provides _some_ small level of protection from unauthorized iperf server use, but is vulnerable to an attacker snooping the authentication token on the wire between client and server. I started to investigate the use of a hashing function to protect the credential, but wanted to see what other iperf3 users and developers thought.

Future Work:
- Better error reporting when the wrong password is used. Right now it
  just cuts off the socket abruptly, same as other errors.
- Hash the passwords before sending across the wire, and before
  comparing. This way, the secret is never exposed in between the client
  and server. Maybe digest auth is a different flag that you can specify.
- Devise a way to prevent replay attacks, in case hashed credential string is captured in transit.

Thanks,
Cody Hanson
