### PR TITLE
Two more casts for tolower() to silence compiler warnings

### DIFF
--- a/src/cjson.c
+++ b/src/cjson.c
@@ -58,10 +58,10 @@ static int cJSON_strcasecmp( const char *s1, const char *s2 )
 		return ( s1 == s2 ) ? 0 : 1;
 	if ( ! s2 )
 		return 1;
-	for ( ; tolower(*s1) == tolower(*s2); ++s1, ++s2)
+	for ( ; tolower((u_char)*s1) == tolower((u_char)*s2); ++s1, ++s2)
 		if( *s1 == 0 )
 			return 0;
-	return tolower(*(const unsigned char *)s1) - tolower(*(const unsigned char *)s2);
+	return tolower((u_char)*s1) - tolower((u_char)*s2);
 }
 
 

--- a/src/units.c
+++ b/src/units.c
@@ -58,6 +58,7 @@
 #include <stdint.h>
 #endif
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/time.h>
 #include <netinet/tcp.h>
 
@@ -261,7 +262,7 @@ extern    "C"
 	{
 	    inNum *= 8;
 	}
-	switch    (toupper(inFormat))
+	switch    (toupper((u_char)inFormat))
 	{
 	case 'B':
 	    conv = UNIT_CONV;


### PR DESCRIPTION
Add casts for the two remaining tolower() uses, since
tolower() is undefined for negative character values
(except for -1).

Also simplify the existing casts for tolower() uses.