### PR TITLE
Add support for NetBSD systems which have TCP_INFO implemented.

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -66,8 +66,9 @@ struct iperf_interval_results
     int       cnt_error;
 
     int omitted;
-#if defined(linux) || defined(__FreeBSD__)
-    struct tcp_info tcpInfo;	/* getsockopt(TCP_INFO) for Linux and FreeBSD */
+#if (defined(linux) || defined(__FreeBSD__) || defined(__NetBSD__)) && \
+	defined(TCP_INFO)
+    struct tcp_info tcpInfo; /* getsockopt(TCP_INFO) for Linux, {Free,Net}BSD */
 #else
     /* Just placeholders, never accessed. */
     char *tcpInfo;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -369,6 +369,10 @@ const char report_tcpInfo[] =
 const char report_tcpInfo[] =
 "event=TCP_Info CWND=%u RCV_WIND=%u SND_SSTHRESH=%u RTT=%u\n";
 #endif
+#if defined(__NetBSD__)
+const char report_tcpInfo[] =
+"event=TCP_Info CWND=%u RCV_WIND=%u SND_SSTHRESH=%u RTT=%u\n";
+#endif
 
 
 #ifdef HAVE_QUAD_SUPPORT

--- a/src/tcp_info.c
+++ b/src/tcp_info.c
@@ -61,7 +61,8 @@
 int
 has_tcpinfo(void)
 {
-#if defined(linux) || defined(__FreeBSD__)
+#if (defined(linux) || defined(__FreeBSD__) || defined(__NetBSD__)) \
+	&& defined(TCP_INFO)
     return 1;
 #else
     return 0;
@@ -81,8 +82,9 @@ has_tcpinfo_retransmits(void)
     return 1;
 #else
 #if defined(__FreeBSD__) && __FreeBSD_version >= 600000
-    /* return 1; */
-    return 0;	/* FreeBSD retransmit reporting doesn't actually work yet */
+    return 1; /* Should work now */
+#elif defined(__NetBSD__) && defined(TCP_INFO)
+    return 1;
 #else
     return 0;
 #endif
@@ -93,7 +95,8 @@ has_tcpinfo_retransmits(void)
 void
 save_tcpinfo(struct iperf_stream *sp, struct iperf_interval_results *irp)
 {
-#if defined(linux) || defined(__FreeBSD__)
+#if (defined(linux) || defined(__FreeBSD__) || defined(__NetBSD__)) && \
+	defined(TCP_INFO)
     socklen_t tcp_info_length = sizeof(struct tcp_info);
 
     if (getsockopt(sp->socket, IPPROTO_TCP, TCP_INFO, (void *)&irp->tcpInfo, &tcp_info_length) < 0)
@@ -114,12 +117,12 @@ get_total_retransmits(struct iperf_interval_results *irp)
 {
 #if defined(linux) && defined(TCP_MD5SIG)
     return irp->tcpInfo.tcpi_total_retrans;
-#else
-#if defined(__FreeBSD__) && __FreeBSD_version >= 600000
-    return irp->tcpInfo.__tcpi_retransmits;
+#elif defined(__FreeBSD__) && __FreeBSD_version >= 600000
+    return irp->tcpInfo.tcpi_snd_rexmitpack;
+#elif defined(__NetBSD__) && defined(TCP_INFO)
+    return irp->tcpInfo.tcpi_snd_rexmitpack;
 #else
     return -1;
-#endif
 #endif
 }
 
@@ -132,12 +135,12 @@ get_snd_cwnd(struct iperf_interval_results *irp)
 {
 #if defined(linux) && defined(TCP_MD5SIG)
     return irp->tcpInfo.tcpi_snd_cwnd * irp->tcpInfo.tcpi_snd_mss;
-#else
-#if defined(__FreeBSD__) && __FreeBSD_version >= 600000
+#elif defined(__FreeBSD__) && __FreeBSD_version >= 600000
+    return irp->tcpInfo.tcpi_snd_cwnd * irp->tcpInfo.tcpi_snd_mss;
+#elif defined(__NetBSD__) && defined(TCP_INFO)
     return irp->tcpInfo.tcpi_snd_cwnd * irp->tcpInfo.tcpi_snd_mss;
 #else
     return -1;
-#endif
 #endif
 }
 
@@ -150,8 +153,9 @@ get_rtt(struct iperf_interval_results *irp)
 {
 #if defined(linux) && defined(TCP_MD5SIG)
     return irp->tcpInfo.tcpi_rtt;
-#else
-#if defined(__FreeBSD__) && __FreeBSD_version >= 600000
+#elif defined(__FreeBSD__) && __FreeBSD_version >= 600000
+    return irp->tcpInfo.tcpi_rtt;
+#elif defined(__NetBSD__) && defined(TCP_INFO)
     return irp->tcpInfo.tcpi_rtt;
 #else
     return -1;
@@ -170,6 +174,10 @@ build_tcpinfo_message(struct iperf_interval_results *r, char *message)
 	    r->tcpInfo.tcpi_rtt, r->tcpInfo.tcpi_reordering);
 #endif
 #if defined(__FreeBSD__)
+    sprintf(message, report_tcpInfo, r->tcpInfo.tcpi_snd_cwnd,
+	    r->tcpInfo.tcpi_rcv_space, r->tcpInfo.tcpi_snd_ssthresh, r->tcpInfo.tcpi_rtt);
+#endif
+#if defined(__NetBSD__) && defined(TCP_INFO)
     sprintf(message, report_tcpInfo, r->tcpInfo.tcpi_snd_cwnd,
 	    r->tcpInfo.tcpi_rcv_space, r->tcpInfo.tcpi_snd_ssthresh, r->tcpInfo.tcpi_rtt);
 #endif


### PR DESCRIPTION
This adds support for using TCP_INFO on NetBSD if it's present.
It also enables use of TCP_INFO on FreeBSD, and fixes the "get cwnd" code
to pull info from the right field.

This pull request supersedes pull request #244 
