### PR TITLE
Add tmp_path in order to make the template path workable on iOS.

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -202,7 +202,7 @@ struct iperf_test
     struct protocol *protocol;
     signed char state;
     char     *server_hostname;                  /* -c option */
-    char     *tmp_path;                         /* -c option */
+    char     *template;                         /* -c option */
     char     *bind_address;                     /* first -B option */
     TAILQ_HEAD(xbind_addrhead, xbind_entry) xbind_addrs; /* all -X opts */
     int       bind_port;                        /* --cport option */

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -202,6 +202,7 @@ struct iperf_test
     struct protocol *protocol;
     signed char state;
     char     *server_hostname;                  /* -c option */
+    char     *tmp_path;                         /* -c option */
     char     *bind_address;                     /* first -B option */
     TAILQ_HEAD(xbind_addrhead, xbind_entry) xbind_addrs; /* all -X opts */
     int       bind_port;                        /* --cport option */

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -210,6 +210,12 @@ iperf_get_test_server_hostname(struct iperf_test *ipt)
     return ipt->server_hostname;
 }
 
+char*
+iperf_get_test_tmp_path(struct iperf_test *ipt)
+{
+    return ipt->tmp_path;
+}
+
 int
 iperf_get_test_protocol_id(struct iperf_test *ipt)
 {
@@ -370,6 +376,12 @@ void
 iperf_set_test_server_hostname(struct iperf_test *ipt, char *server_hostname)
 {
     ipt->server_hostname = strdup(server_hostname);
+}
+
+void
+iperf_set_test_tmp_path(struct iperf_test *ipt, char *tmp_path)
+{
+    ipt->tmp_path = strdup(tmp_path);
 }
 
 void
@@ -1869,6 +1881,8 @@ iperf_free_test(struct iperf_test *test)
 
     if (test->server_hostname)
 	free(test->server_hostname);
+    if (test->tmp_path)
+    free(test->tmp_path);
     if (test->bind_address)
 	free(test->bind_address);
     if (!TAILQ_EMPTY(&test->xbind_addrs)) {
@@ -2574,7 +2588,13 @@ iperf_new_stream(struct iperf_test *test, int s)
 {
     int i;
     struct iperf_stream *sp;
-    char template[] = "/tmp/iperf3.XXXXXX";
+    
+    char template[1024];
+    if (test->tmp_path) {
+        strcpy(template, strcat(test->tmp_path, "/iperf3.XXXXXX"));
+    } else {
+        strcpy(template, "/tmp/iperf3.XXXXXX");
+    }
 
     h_errno = 0;
 

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -211,9 +211,9 @@ iperf_get_test_server_hostname(struct iperf_test *ipt)
 }
 
 char*
-iperf_get_test_tmp_path(struct iperf_test *ipt)
+iperf_get_test_template(struct iperf_test *ipt)
 {
-    return ipt->tmp_path;
+    return ipt->template;
 }
 
 int
@@ -379,9 +379,9 @@ iperf_set_test_server_hostname(struct iperf_test *ipt, char *server_hostname)
 }
 
 void
-iperf_set_test_tmp_path(struct iperf_test *ipt, char *tmp_path)
+iperf_set_test_template(struct iperf_test *ipt, char *template)
 {
-    ipt->tmp_path = strdup(tmp_path);
+    ipt->template = strdup(template);
 }
 
 void
@@ -1881,8 +1881,8 @@ iperf_free_test(struct iperf_test *test)
 
     if (test->server_hostname)
 	free(test->server_hostname);
-    if (test->tmp_path)
-    free(test->tmp_path);
+    if (test->template)
+    free(test->template);
     if (test->bind_address)
 	free(test->bind_address);
     if (!TAILQ_EMPTY(&test->xbind_addrs)) {
@@ -1897,6 +1897,7 @@ iperf_free_test(struct iperf_test *test)
             free(xbe);
         }
     }
+    if (test->settings)
     free(test->settings);
     if (test->title)
 	free(test->title);
@@ -2590,10 +2591,11 @@ iperf_new_stream(struct iperf_test *test, int s)
     struct iperf_stream *sp;
     
     char template[1024];
-    if (test->tmp_path) {
-        strcpy(template, strcat(test->tmp_path, "/iperf3.XXXXXX"));
+    if (test->template) {
+        snprintf(template, strlen(test->template), "%s", test->template);
     } else {
-        strcpy(template, "/tmp/iperf3.XXXXXX");
+        char buf[] = "/tmp/iperf3.XXXXXX";
+        snprintf(template, strlen(buf), "%s", buf);
     }
 
     h_errno = 0;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -88,6 +88,7 @@ double	iperf_get_test_stats_interval( struct iperf_test* ipt );
 int	iperf_get_test_num_streams( struct iperf_test* ipt );
 int	iperf_get_test_server_port( struct iperf_test* ipt );
 char*	iperf_get_test_server_hostname( struct iperf_test* ipt );
+char*	iperf_get_test_tmp_path( struct iperf_test* ipt );
 int	iperf_get_test_protocol_id( struct iperf_test* ipt );
 int	iperf_get_test_json_output( struct iperf_test* ipt );
 char*	iperf_get_test_json_output_string ( struct iperf_test* ipt );
@@ -113,6 +114,7 @@ void	iperf_set_test_socket_bufsize( struct iperf_test* ipt, int socket_bufsize )
 void	iperf_set_test_num_streams( struct iperf_test* ipt, int num_streams );
 void	iperf_set_test_role( struct iperf_test* ipt, char role );
 void	iperf_set_test_server_hostname( struct iperf_test* ipt, char* server_hostname );
+void    iperf_set_test_tmp_path( struct iperf_test *ipt, char *tmp_path );
 void	iperf_set_test_reverse( struct iperf_test* ipt, int reverse );
 void	iperf_set_test_json_output( struct iperf_test* ipt, int json_output );
 int	iperf_has_zerocopy( void );

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -88,7 +88,7 @@ double	iperf_get_test_stats_interval( struct iperf_test* ipt );
 int	iperf_get_test_num_streams( struct iperf_test* ipt );
 int	iperf_get_test_server_port( struct iperf_test* ipt );
 char*	iperf_get_test_server_hostname( struct iperf_test* ipt );
-char*	iperf_get_test_tmp_path( struct iperf_test* ipt );
+char*	iperf_get_test_template( struct iperf_test* ipt );
 int	iperf_get_test_protocol_id( struct iperf_test* ipt );
 int	iperf_get_test_json_output( struct iperf_test* ipt );
 char*	iperf_get_test_json_output_string ( struct iperf_test* ipt );
@@ -114,7 +114,7 @@ void	iperf_set_test_socket_bufsize( struct iperf_test* ipt, int socket_bufsize )
 void	iperf_set_test_num_streams( struct iperf_test* ipt, int num_streams );
 void	iperf_set_test_role( struct iperf_test* ipt, char role );
 void	iperf_set_test_server_hostname( struct iperf_test* ipt, char* server_hostname );
-void    iperf_set_test_tmp_path( struct iperf_test *ipt, char *tmp_path );
+void    iperf_set_test_template( struct iperf_test *ipt, char *template );
 void	iperf_set_test_reverse( struct iperf_test* ipt, int reverse );
 void	iperf_set_test_json_output( struct iperf_test* ipt, int json_output );
 int	iperf_has_zerocopy( void );


### PR DESCRIPTION
Since "/tmp/iperf3.XXXXXX" is not allowed to access on iOS device (although working on simulator), I added a tmp_path variable to redirect the template to other place inside the application sandbox. The calling is shown as below.

	NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"iperf3"];
	[[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:nil];
	char buf[PATH_MAX];
    [path getCString:buf maxLength:PATH_MAX encoding:NSUTF8StringEncoding];
                
	struct iperf_test *test = iperf_new_test();
	if (!test) {
		iperf_errexit(NULL, "create new test error - %s", iperf_strerror(i_errno));
	}
	// ...
	iperf_set_test_tmp_path(test, buf);