### PR TITLE
Fix bug in iperf_new_stream leading to EINVAL

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2592,10 +2592,10 @@ iperf_new_stream(struct iperf_test *test, int s)
     
     char template[1024];
     if (test->template) {
-        snprintf(template, strlen(test->template), "%s", test->template);
+        snprintf(template, sizeof(template) / sizeof(char), "%s", test->template);
     } else {
         char buf[] = "/tmp/iperf3.XXXXXX";
-        snprintf(template, strlen(buf), "%s", buf);
+        snprintf(template, sizeof(template) / sizeof(char), "%s", buf);
     }
 
     h_errno = 0;


### PR DESCRIPTION
The commit 9a3775091b7a23c38053f7fffb8d53d49fcce02f introduced a bug in `iperf_new_stream` in `iperf_api.c`. The last character of the template is cut off due to incorrect use of `snprintf` ([here](https://github.com/esnet/iperf/commit/9a3775091b7a23c38053f7fffb8d53d49fcce02f#diff-109ce0347bb7c189bead5f3b4da4f468R2595) and [here](https://github.com/esnet/iperf/commit/9a3775091b7a23c38053f7fffb8d53d49fcce02f#diff-109ce0347bb7c189bead5f3b4da4f468R2598)). As the last six characters of the template must be `"XXXXXX"`, `mkstemp` produces the error `EINVAL` and tests fail with the message "Invalid argument".

The second argument to `snprintf` should not be the length of the data to print (`strlen(test->template)` or `strlen(buf)`, respectively) but the size of the output buffer in chars: `sizeof(template) / sizeof(char)`.