### PR TITLE
Honor $TMPDIR

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2594,8 +2594,9 @@ iperf_new_stream(struct iperf_test *test, int s)
     if (test->template) {
         snprintf(template, sizeof(template) / sizeof(char), "%s", test->template);
     } else {
-        char buf[] = "/tmp/iperf3.XXXXXX";
-        snprintf(template, sizeof(template) / sizeof(char), "%s", buf);
+        char *tmpdir = getenv("TMPDIR");
+        snprintf(template, sizeof(template) / sizeof(char), "%s/iperf3.XXXXXX",
+                 tmpdir ? tmpdir : "/tmp");
     }
 
     h_errno = 0;


### PR DESCRIPTION
Some OSes, such as Android, do not have a /tmp directory.  If the user sets $TMPDIR, honor that setting, otherwise default to /tmp.

For Android, `TMPDIR=/data/local/tmp` was tested.

@Dji75 does this help with the /tmp issue you were seeing on Cygwin (bug #295)?
