### PR TITLE
fix server crash for intervals with 0 duration

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2518,6 +2518,11 @@ print_interval_results(struct iperf_test *test, struct iperf_stream *sp, cJSON *
 	iperf_err(test, "print_interval_results error: interval_results is NULL");
         return;
     }
+    if (irp->interval_duration == 0) {
+        /* server may end-up with 0 duration interval if it receives TEST_END right
+           after beginning new interval */
+        return;
+    }
     if (!test->json_output) {
 	/* First stream? */
 	if (sp == SLIST_FIRST(&test->streams)) {


### PR DESCRIPTION
The 0 duration interval can occur if the server and client
have small skew in intervals. The server may start new interval and then
immediately receive TEST_END.
When this happens the bandwidth is NaN and the unit_snprintf crashes with
invalid index in label_bit (or label_byte).

Fixes #388