### PR TITLE
Add fix for #412

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -152,7 +152,9 @@ struct iperf_stream
     double    jitter;
     double    prev_transit;
     int       outoforder_packets;
+    int       omitted_outoforder_packets;
     int       cnt_error;
+    int       omitted_cnt_error;
     uint64_t  target;
 
     struct sockaddr_storage local_addr;

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -87,6 +87,7 @@ struct iperf_stream_result
     iperf_size_t bytes_sent;
     iperf_size_t bytes_received_this_interval;
     iperf_size_t bytes_sent_this_interval;
+    iperf_size_t bytes_sent_omit;
     int stream_prev_total_retrans;
     int stream_retrans;
     int stream_prev_total_sacks;
@@ -98,6 +99,7 @@ struct iperf_stream_result
     int stream_max_snd_cwnd;
     struct timeval start_time;
     struct timeval end_time;
+    struct timeval start_time_fixed;
     TAILQ_HEAD(irlisthead, iperf_interval_results) interval_results;
     void     *data;
 };

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2339,7 +2339,7 @@ iperf_print_results(struct iperf_test *test)
         }
 
 	unit_snprintf(ubuf, UNIT_LEN, (double) bytes_sent, 'A');
-	bandwidth = (double) bytes_received / (double) end_time;
+	bandwidth = (double) bytes_sent / (double) end_time;
 	unit_snprintf(nbuf, UNIT_LEN, bandwidth, test->settings->unit_format);
 	if (test->protocol->id == Ptcp || test->protocol->id == Psctp) {
 	    if (test->sender_has_retransmits) {
@@ -2386,7 +2386,7 @@ iperf_print_results(struct iperf_test *test)
 	}
 
 	unit_snprintf(ubuf, UNIT_LEN, (double) bytes_received, 'A');
-	bandwidth = (double) bytes_sent / (double) end_time;
+	bandwidth = (double) bytes_received / (double) end_time;
 	unit_snprintf(nbuf, UNIT_LEN, bandwidth, test->settings->unit_format);
 	if (test->protocol->id == Ptcp || test->protocol->id == Psctp) {
 	    if (test->json_output)

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2386,7 +2386,7 @@ iperf_print_results(struct iperf_test *test)
 	}
 
 	unit_snprintf(ubuf, UNIT_LEN, (double) bytes_received, 'A');
-	bandwidth = (double) bytes_received / (double) end_time;
+	bandwidth = (double) bytes_sent / (double) end_time;
 	unit_snprintf(nbuf, UNIT_LEN, bandwidth, test->settings->unit_format);
 	if (test->protocol->id == Ptcp || test->protocol->id == Psctp) {
 	    if (test->json_output)
@@ -2401,7 +2401,7 @@ iperf_print_results(struct iperf_test *test)
         unit_snprintf(ubuf, UNIT_LEN, (double) total_sent, 'A');
 	/* If no tests were run, arbitrariliy set bandwidth to 0. */
 	if (end_time > 0.0) {
-	    bandwidth = (double) total_received / (double) end_time;
+	    bandwidth = (double) total_sent / (double) end_time;
 	}
 	else {
 	    bandwidth = 0.0;


### PR DESCRIPTION
This prevents negative loss counters with UDP when omit is used. Instead of clearing cnt_errors and outoforder_packets when the omit interval expires, this approach uses omitted_cnt_errors and omitted_outoforder_packets to track what should be excluded. This is the approach already used by the packet_count.