### PR TITLE
DEREF_AFTER_NULL in src/iperf_error.c

### DIFF
--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -74,7 +74,8 @@ iperf_errexit(struct iperf_test *test, const char *format, ...)
 	    fprintf(stderr, "iperf3: %s\n", str);
 	}
     va_end(argp);
-    iperf_delete_pidfile(test);
+    if (test)
+        iperf_delete_pidfile(test);
     exit(1);
 }
 


### PR DESCRIPTION
DEREF_AFTER_NULL: pointer ‘test’ at line:77 is passed as an argument to function iperf_delete_pidfile(), in which it is dereferenced at iperf_api.c:2832.
Pointer ‘test’ can be NULL and dereferencing a NULL pointer causes seg-fault.

Applied Fix: pointer ‘test’ is checked for NULL before passing it to function iperf_delete_pidfile().