### PR TITLE
Safe programming practice. Added va_end.

### DIFF
--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -349,10 +349,13 @@ iperf_json_printf(const char *format, ...)
 		j = cJSON_CreateString(va_arg(argp, char *));
 		break;
 		default:
+		va_end(argp);
 		return NULL;
 	    }
-	    if (j == NULL)
-		return NULL;
+	    if (j == NULL) {
+	    	va_end(argp);
+	    	return NULL;
+	    }
 	    cJSON_AddItemToObject(o, name, j);
 	    np = name;
 	    break;


### PR DESCRIPTION
In file iperf_util.c:
Function 'va_start' is called at line:327. But, 'va_end' is not called before returning from function 'iperf_json_printf()' at line:352 and line:355. 
The va_end performs cleanup for the argp object initialized by a call to va_start. If va_end is not called before a function that calls va_start returns, the behavior is undefined.

Applied Fix: added va_end before returning from the function.