### PR TITLE
Fix for #404

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -334,6 +334,7 @@ enum {
     IESETSCTPNSTREAM= 138,  //  Unable to set SCTP number of streams (check perror)
     IESETSCTPBINDX= 139,    // Unable to process sctp_bindx() parameters
     IESETPACING= 140,       // Unable to set socket pacing rate
+    IEBADCOOKIE = 141,
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -139,38 +139,46 @@ iperf_accept(struct iperf_test *test)
         return -1;
     }
 
-    if (test->ctrl_sck == -1) {
-        /* Server free, accept new client */
-        test->ctrl_sck = s;
-        if (Nread(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
-            i_errno = IERECVCOOKIE;
-            return -1;
-        }
-	FD_SET(test->ctrl_sck, &test->read_set);
-	if (test->ctrl_sck > test->max_fd) test->max_fd = test->ctrl_sck;
+	if (test->ctrl_sck == -1) {
+		/* Server free, accept new client */
 
-	if (iperf_set_send_state(test, PARAM_EXCHANGE) != 0)
-            return -1;
-        if (iperf_exchange_parameters(test) < 0)
-            return -1;
-	if (test->server_affinity != -1) 
-	    if (iperf_setaffinity(test, test->server_affinity) != 0)
+		if (Nread(s, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
+			i_errno = IERECVCOOKIE;
+			iperf_err(test, "Rejected connection - recv cookie");
+			close(s);						
+			return -1;
+		}
+		test->ctrl_sck = s;
+
+		FD_SET(test->ctrl_sck, &test->read_set);
+		if (test->ctrl_sck > test->max_fd)
+			test->max_fd = test->ctrl_sck;
+
+		if (iperf_set_send_state(test, PARAM_EXCHANGE) != 0)
+			return -1;
+		if (iperf_exchange_parameters(test) < 0)
+			return -1;
+		if (test->server_affinity != -1)
+			if (iperf_setaffinity(test, test->server_affinity) != 0)
+				return -1;
+		if (test->on_connect)
+			test->on_connect(test);
+	} else {
+		/*
+		 * Don't try to read from the socket.  It could block an ongoing test.
+		 * Just send ACCESS_DENIED.
+		 */
+		if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Ptcp) < 0) {
+			i_errno = IESENDMESSAGE;
+		} else {
+			i_errno = IEBADCOOKIE;
+			iperf_err(test, "Rejected connection - bad cookie");	
+		}
+		close(s);
 		return -1;
-        if (test->on_connect)
-            test->on_connect(test);
-    } else {
-	/*
-	 * Don't try to read from the socket.  It could block an ongoing test. 
-	 * Just send ACCESS_DENIED.
-	 */
-        if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Ptcp) < 0) {
-            i_errno = IESENDMESSAGE;
-            return -1;
-        }
-        close(s);
-    }
+	}
 
-    return 0;
+	return 0;
 }
 
 
@@ -483,11 +491,16 @@ iperf_run_server(struct iperf_test *test)
 	if (result > 0) {
             if (FD_ISSET(test->listener, &read_set)) {
                 if (test->state != CREATE_STREAMS) {
+			FD_CLR(test->listener, &read_set);
                     if (iperf_accept(test) < 0) {
+			//In case of non critical error we want to ignore connection
+			//and not affect a running test
+			if((test->ctrl_sck == -1) || (i_errno == IEBADCOOKIE)
+				|| (i_errno == IESENDMESSAGE) || (i_errno == IEACCEPT))
+				continue;
 			cleanup_server(test);
-                        return -1;
+			return -1;
                     }
-                    FD_CLR(test->listener, &read_set);
                 }
             }
             if (FD_ISSET(test->ctrl_sck, &read_set)) {
@@ -502,11 +515,10 @@ iperf_run_server(struct iperf_test *test)
                 if (FD_ISSET(test->prot_listener, &read_set)) {
     
                     if ((s = test->protocol->accept(test)) < 0) {
-			cleanup_server(test);
-                        return -1;
+			iprintf(test, "Connection failed: %d", i_errno);
+			iflush(test);
 		    }
-
-                    if (!is_closed(s)) {
+                   else if (!is_closed(s)) {
                         sp = iperf_new_stream(test, s);
                         if (!sp) {
 			    cleanup_server(test);

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -114,15 +114,19 @@ iperf_tcp_accept(struct iperf_test * test)
 
     if (Nread(s, cookie, COOKIE_SIZE, Ptcp) < 0) {
         i_errno = IERECVCOOKIE;
+        close(s);
         return -1;
     }
 
     if (strcmp(test->cookie, cookie) != 0) {
         if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Ptcp) < 0) {
             i_errno = IESENDMESSAGE;
-            return -1;
+        }
+        else {
+        	i_errno = IEBADCOOKIE;
         }
         close(s);
+        return -1;
     }
 
     return s;


### PR DESCRIPTION
#404

added leniency to rogue connections while server is running in cases of mid test as well as no test running. Issue seemed to be caused by invalid cookies & closing the test socket when calling server cleanup. The changes I made here solved my issue. 
