### PR TITLE
Properly setting the no_fq_socket_pacing option when not compiled in

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1843,6 +1843,10 @@ iperf_defaults(struct iperf_test *testp)
     testp->stats_interval = testp->reporter_interval = 1;
     testp->num_streams = 1;
 
+#if ! defined(HAVE_SO_MAX_PACING_RATE)
+    testp->no_fq_socket_pacing = 1;
+#endif
+
     testp->settings->domain = AF_UNSPEC;
     testp->settings->unit_format = 'a';
     testp->settings->socket_bufsize = 0;    /* use autotuning */


### PR DESCRIPTION
When HAVE_SO_MAX_PACING_RATE is not defined, the test param no_fq_socket_pacing is left at 0, which implies that it's enabled (and may trip up code elsewhere that's looking at that flag, but still needs to be included in the codebase if HAVE_SO_MAX_PACING_RATE is not defined).