### PR TITLE
Change pacing timer from 100ms to 1ms

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1200,8 +1200,8 @@ iperf_create_send_timers(struct iperf_test * test)
         sp->green_light = 1;
 	if (test->settings->rate != 0) {
 	    cd.p = sp;
-	    sp->send_timer = tmr_create((struct timeval*) 0, send_timer_proc, cd, 100000L, 1);
-	    /* (Repeat every tenth second - arbitrary often value.) */
+	    /* (Repeat every millisecond - arbitrary value to provide smooth pacing.) */
+	    sp->send_timer = tmr_create((struct timeval*) 0, send_timer_proc, cd, 1000L, 1);
 	    if (sp->send_timer == NULL) {
 		i_errno = IEINITTEST;
 		return -1;


### PR DESCRIPTION
This changes the hardcoded timer used for pacing tcp transmission on non-fq systems and udp on all systems to a much higher-resolution.  This greatly reduces the size of the bursts, to smoothen out the transmission of packets, to reduce buffer overflows on the network path.