### PR TITLE
Separate out application-level and fair-queueing-based pacing

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -110,7 +110,8 @@ struct iperf_settings
     int       domain;               /* AF_INET or AF_INET6 */
     int       socket_bufsize;       /* window size for TCP */
     int       blksize;              /* size of read/writes (-l) */
-    uint64_t  rate;                 /* target data rate */
+    uint64_t  rate;                 /* target data rate for application pacing*/
+    uint64_t  fqrate;               /* target data rate for FQ pacing*/
     int       burst;                /* packets per burst */
     int       mss;                  /* for TCP MSS */
     int       ttl;                  /* IP TTL option */
@@ -243,7 +244,6 @@ struct iperf_test
     int	      get_server_output;		/* --get-server-output */
     int	      udp_counters_64bit;		/* --use-64-bit-udp-counters */
     int       forceflush; /* --forceflush - flushing output at every interval */
-    int       no_fq_socket_pacing;	  /* --no-fq-socket-pacing */
     int	      multisend;
 
     char     *json_output_string; /* rendered JSON output if json_output is set */

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -107,14 +107,23 @@ It will send the given number of packets without pausing, even if that
 temporarily exceeds the specified bandwidth limit.
 Setting the target bandwidth to 0 will disable bandwidth limits
 (particularly useful for UDP tests).
-On platforms supporting the \fCSO_MAX_PACING_RATE\fR socket option
-(currently only Linux), fair-queueing socket-level pacing, implemented in
-the kernel, will be used.
-On other platforms, iperf3 will implement its own rate control.
+This bandwidth limit is implemented internally inside iperf3, and is
+available on all platforms.
+Compare with the \--fq-rate flag.
+.TP
+.BR --fq-rate " \fIn\fR[KM]"
+Set a rate to be used with fair-queueing based socket-level pacing,
+in bits per second.
+This pacing (if specified) will be in addition to any pacing due to
+iperf3's internal bandwidth pacing (\-b flag), and both can be
+specified for the same test.
+Only available on platforms supporting the
+\fCSO_MAX_PACING_RATE\fR socket option (currently only Linux).
+The default is no fair-queueing based pacing.
 .TP
 .BR --no-fq-socket-pacing
-disable the use of fair-queueing based socket-level pacing with the -b
-option, and rely on iperf3's internal rate control.
+This option is deprecated and will be removed.
+It is equivalent to specifying --fq-rate=0.
 .TP
 .BR -t ", " --time " \fIn\fR"
 time in seconds to transmit for (default 10 secs)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -51,7 +51,8 @@ struct iperf_stream;
 #define OPT_CLIENT_PORT 5
 #define OPT_NUMSTREAMS 6
 #define OPT_FORCEFLUSH 7
-#define OPT_NO_FQ_SOCKET_PACING 9
+#define OPT_NO_FQ_SOCKET_PACING 9 /* UNUSED */
+#define OPT_FQ_RATE 10
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -129,7 +129,7 @@ const char usage_longstr[] = "Usage: iperf [-s|-c host] [options]\n"
                            "                            (default %d Mbit/sec for UDP, unlimited for TCP)\n"
                            "                            (optional slash and packet count for burst mode)\n"
 #if defined(HAVE_SO_MAX_PACING_RATE)
-                           "  --fq-rate #               enable fair-queuing based socket pacing in\n"
+                           "  --fq-rate #[KMG]          enable fair-queuing based socket pacing in\n"
 			   "                            bits/sec (Linux only)\n"
 #endif
                            "  -t, --time      #         time in seconds to transmit for (default %d secs)\n"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -154,7 +154,7 @@ const char usage_longstr[] = "Usage: iperf [-s|-c host] [options]\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
 #if defined(HAVE_SO_MAX_PACING_RATE)
-                           "  --no-fq-socket-pacing     disable fair-queuing based socket pacing\n"
+                           "  --fq-rate N               enable and set fair-queuing based socket pacing\n"
 			   "                            (Linux only)\n"
 #endif
 

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -128,6 +128,10 @@ const char usage_longstr[] = "Usage: iperf [-s|-c host] [options]\n"
                            "  -b, --bandwidth #[KMG][/#] target bandwidth in bits/sec (0 for unlimited)\n"
                            "                            (default %d Mbit/sec for UDP, unlimited for TCP)\n"
                            "                            (optional slash and packet count for burst mode)\n"
+#if defined(HAVE_SO_MAX_PACING_RATE)
+                           "  --fq-rate #               enable fair-queuing based socket pacing in\n"
+			   "                            bits/sec (Linux only)\n"
+#endif
                            "  -t, --time      #         time in seconds to transmit for (default %d secs)\n"
                            "  -n, --bytes     #[KMG]    number of bytes to transmit (instead of -t)\n"
                            "  -k, --blockcount #[KMG]   number of blocks (packets) to transmit (instead of -t or -n)\n"
@@ -153,10 +157,6 @@ const char usage_longstr[] = "Usage: iperf [-s|-c host] [options]\n"
                            "  -T, --title str           prefix every output line with this string\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
-#if defined(HAVE_SO_MAX_PACING_RATE)
-                           "  --fq-rate N               enable and set fair-queuing based socket pacing\n"
-			   "                            (Linux only)\n"
-#endif
 
 #ifdef NOT_YET_SUPPORTED /* still working on these */
 #endif

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -236,22 +236,21 @@ iperf_tcp_listen(struct iperf_test *test)
 	    printf("SO_SNDBUF is %u\n", opt);
 	}
 #if defined(HAVE_SO_MAX_PACING_RATE)
-    /* If socket pacing is available and not disabled, try it. */
-    if (! test->no_fq_socket_pacing) {
+    /* If fq socket pacing is specified, enable it. */
+    if (test->settings->fqrate) {
 	/* Convert bits per second to bytes per second */
-	unsigned int rate = test->settings->rate / 8;
-	if (rate > 0) {
+	unsigned int fqrate = test->settings->fqrate / 8;
+	if (fqrate > 0) {
 	    if (test->debug) {
-		printf("Setting fair-queue socket pacing to %u\n", rate);
+		printf("Setting fair-queue socket pacing to %u\n", fqrate);
 	    }
-	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &rate, sizeof(rate)) < 0) {
-		warning("Unable to set socket pacing, using application pacing instead");
-		test->no_fq_socket_pacing = 1;
+	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &fqrate, sizeof(fqrate)) < 0) {
+		warning("Unable to set socket pacing");
 	    }
 	}
     }
 #endif /* HAVE_SO_MAX_PACING_RATE */
-    if (test->no_fq_socket_pacing) {
+    {
 	unsigned int rate = test->settings->rate / 8;
 	if (rate > 0) {
 	    if (test->debug) {
@@ -498,22 +497,21 @@ iperf_tcp_connect(struct iperf_test *test)
 #endif /* HAVE_FLOWLABEL */
 
 #if defined(HAVE_SO_MAX_PACING_RATE)
-    /* If socket pacing is available and not disabled, try it. */
-    if (! test->no_fq_socket_pacing) {
+    /* If socket pacing is specified try to enable it. */
+    if (test->settings->fqrate) {
 	/* Convert bits per second to bytes per second */
-	unsigned int rate = test->settings->rate / 8;
-	if (rate > 0) {
+	unsigned int fqrate = test->settings->fqrate / 8;
+	if (fqrate > 0) {
 	    if (test->debug) {
-		printf("Setting fair-queue socket pacing to %u\n", rate);
+		printf("Setting fair-queue socket pacing to %u\n", fqrate);
 	    }
-	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &rate, sizeof(rate)) < 0) {
-		warning("Unable to set socket pacing, using application pacing instead");
-		test->no_fq_socket_pacing = 1;
+	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &fqrate, sizeof(fqrate)) < 0) {
+		warning("Unable to set socket pacing");
 	    }
 	}
     }
 #endif /* HAVE_SO_MAX_PACING_RATE */
-    if (test->no_fq_socket_pacing) {
+    {
 	unsigned int rate = test->settings->rate / 8;
 	if (rate > 0) {
 	    if (test->debug) {

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -275,22 +275,21 @@ iperf_udp_accept(struct iperf_test *test)
     }
 
 #if defined(HAVE_SO_MAX_PACING_RATE)
-    /* If socket pacing is available and not disabled, try it. */
-    if (! test->no_fq_socket_pacing) {
+    /* If socket pacing is specified, try it. */
+    if (test->settings->fqrate) {
 	/* Convert bits per second to bytes per second */
-	unsigned int rate = test->settings->rate / 8;
-	if (rate > 0) {
+	unsigned int fqrate = test->settings->fqrate / 8;
+	if (fqrate > 0) {
 	    if (test->debug) {
-		printf("Setting fair-queue socket pacing to %u\n", rate);
+		printf("Setting fair-queue socket pacing to %u\n", fqrate);
 	    }
-	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &rate, sizeof(rate)) < 0) {
-		warning("Unable to set socket pacing, using application pacing instead");
-		test->no_fq_socket_pacing = 1;
+	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &fqrate, sizeof(fqrate)) < 0) {
+		warning("Unable to set socket pacing");
 	    }
 	}
     }
 #endif /* HAVE_SO_MAX_PACING_RATE */
-    if (test->no_fq_socket_pacing) {
+    {
 	unsigned int rate = test->settings->rate / 8;
 	if (rate > 0) {
 	    if (test->debug) {
@@ -412,21 +411,20 @@ iperf_udp_connect(struct iperf_test *test)
 
 #if defined(HAVE_SO_MAX_PACING_RATE)
     /* If socket pacing is available and not disabled, try it. */
-    if (! test->no_fq_socket_pacing) {
+    if (test->settings->fqrate) {
 	/* Convert bits per second to bytes per second */
-	unsigned int rate = test->settings->rate / 8;
-	if (rate > 0) {
+	unsigned int fqrate = test->settings->fqrate / 8;
+	if (fqrate > 0) {
 	    if (test->debug) {
-		printf("Setting fair-queue socket pacing to %u\n", rate);
+		printf("Setting fair-queue socket pacing to %u\n", fqrate);
 	    }
-	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &rate, sizeof(rate)) < 0) {
-		warning("Unable to set socket pacing, using application pacing instead");
-		test->no_fq_socket_pacing = 1;
+	    if (setsockopt(s, SOL_SOCKET, SO_MAX_PACING_RATE, &fqrate, sizeof(fqrate)) < 0) {
+		warning("Unable to set socket pacing");
 	    }
 	}
     }
 #endif /* HAVE_SO_MAX_PACING_RATE */
-    if (test->no_fq_socket_pacing) {
+    {
 	unsigned int rate = test->settings->rate / 8;
 	if (rate > 0) {
 	    if (test->debug) {


### PR DESCRIPTION
Fixes that make application-level pacing and fair queueing, per-socket pacing behave sanely and interact in a reasonable (if very manual) way.

 