### PR TITLE
Fix title not being reset on test reset

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2112,6 +2112,7 @@ iperf_reset_test(struct iperf_test *test)
     memset(test->cookie, 0, COOKIE_SIZE);
     test->multisend = 10;	/* arbitrary */
     test->udp_counters_64bit = 0;
+    test->title = NULL;
 
     /* Free output line buffers, if any (on the server only) */
     struct iperf_textline *t;


### PR DESCRIPTION
Also reset test->title in iperf_reset_test to make sure a successive testrun doesn't inherit the pervious testruns title.

This fixes bug #500 - tested on Centos 7.