### PR TITLE
Fix header includes and build failures on musl

### DIFF
--- a/src/cjson.h
+++ b/src/cjson.h
@@ -19,9 +19,14 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
+#include "iperf_config.h"
 
 #ifndef cJSON__h
 #define cJSON__h
+
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
 
 #ifdef __cplusplus
 extern "C"

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -36,6 +36,7 @@
 #endif
 #include <sys/select.h>
 #include <sys/socket.h>
+#define _GNU_SOURCE
 #include <netinet/tcp.h>
 
 #if defined(HAVE_CPUSET_SETAFFINITY)

--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -35,7 +35,6 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <netdb.h>
-#include <netinet/tcp.h>
 #include <sys/time.h>
 #include <sys/select.h>
 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -44,7 +44,6 @@
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif
-#include <netinet/tcp.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sched.h>

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -526,7 +526,7 @@ iperf_run_server(struct iperf_test *test)
 			    } 
 			}
 			{
-			    int len = TCP_CA_NAME_MAX;
+			    socklen_t len = TCP_CA_NAME_MAX;
 			    char ca[TCP_CA_NAME_MAX + 1];
 			    if (getsockopt(s, IPPROTO_TCP, TCP_CONGESTION, ca, &len) < 0) {
 				close(s);

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -35,7 +35,6 @@
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <netdb.h>
-#include <netinet/tcp.h>
 #include <sys/time.h>
 #include <sys/select.h>
 

--- a/src/main.c
+++ b/src/main.c
@@ -41,10 +41,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
-#ifdef HAVE_STDINT_H
-#include <stdint.h>
-#endif
-#include <netinet/tcp.h>
 
 #include "iperf.h"
 #include "iperf_api.h"

--- a/src/t_timer.c
+++ b/src/t_timer.c
@@ -24,6 +24,11 @@
  * This code is distributed under a BSD style license, see the LICENSE
  * file for complete information.
  */
+#include "iperf_config.h"
+
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/tcp_info.c
+++ b/src/tcp_info.c
@@ -48,7 +48,6 @@
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <netinet/tcp.h>
 #include <string.h>
 #include <netinet/in.h>
 #include <errno.h>

--- a/src/units.c
+++ b/src/units.c
@@ -60,7 +60,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/time.h>
-#include <netinet/tcp.h>
 
 
 #include "iperf.h"


### PR DESCRIPTION
- include stdint.h in files where its types are used
- getsockopt expects socklen_t instead of int as its fifth argument
- remove includes of headers already included in iperf.h
- sort header includes alphabetically
- fixes #331 and closes #344 

Signed-off-by: Moritz Kick <f1rebird@users.noreply.github.com>