### PR TITLE
Remove unused hstrerror(), bad nanosleep() message in configure.ac (#503)

### DIFF
--- a/configure
+++ b/configure
@@ -12311,69 +12311,6 @@ exit 1
 fi
 
 
-# Solaris puts hstrerror in -lresolv
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing hstrerror" >&5
-$as_echo_n "checking for library containing hstrerror... " >&6; }
-if ${ac_cv_search_hstrerror+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_func_search_save_LIBS=$LIBS
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char hstrerror ();
-int
-main ()
-{
-return hstrerror ();
-  ;
-  return 0;
-}
-_ACEOF
-for ac_lib in '' resolv; do
-  if test -z "$ac_lib"; then
-    ac_res="none required"
-  else
-    ac_res=-l$ac_lib
-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
-  fi
-  if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_search_hstrerror=$ac_res
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext
-  if ${ac_cv_search_hstrerror+:} false; then :
-  break
-fi
-done
-if ${ac_cv_search_hstrerror+:} false; then :
-
-else
-  ac_cv_search_hstrerror=no
-fi
-rm conftest.$ac_ext
-LIBS=$ac_func_search_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_hstrerror" >&5
-$as_echo "$ac_cv_search_hstrerror" >&6; }
-ac_res=$ac_cv_search_hstrerror
-if test "$ac_res" != no; then :
-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
-
-else
-
-echo "nanosleep() required for timing operations."
-exit 1
-
-fi
-
-
 # On illumos we need -lsocket
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
 $as_echo_n "checking for library containing socket... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -69,12 +69,6 @@ echo "nanosleep() required for timing operations."
 exit 1
 ])
 
-# Solaris puts hstrerror in -lresolv
-AC_SEARCH_LIBS(hstrerror, [resolv], [], [
-echo "nanosleep() required for timing operations."
-exit 1
-])
-
 # On illumos we need -lsocket
 AC_SEARCH_LIBS(socket, [socket], [], [
 echo "socket()"

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2751,8 +2751,6 @@ iperf_new_stream(struct iperf_test *test, int s)
         snprintf(template, sizeof(template) / sizeof(char), "%s", buf);
     }
 
-    h_errno = 0;
-
     sp = (struct iperf_stream *) malloc(sizeof(struct iperf_stream));
     if (!sp) {
         i_errno = IECREATESTREAM;

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -367,11 +367,8 @@ iperf_strerror(int i_errno)
 
     if (herr || perr)
         strncat(errstr, ": ", len - strlen(errstr) - 1);
-    if (h_errno && herr) {
-        strncat(errstr, hstrerror(h_errno), len - strlen(errstr) - 1);
-    } else if (errno && perr) {
+    if (errno && perr)
         strncat(errstr, strerror(errno), len - strlen(errstr) - 1);
-    }
 
     return errstr;
 }


### PR DESCRIPTION
Per comments of #503, `hstrerror()` is not used, but is preventing `./configure --host=i686-w64-mingw32` command from finishing.