### PR TITLE
add tcp rttvar to stream info

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -80,6 +80,7 @@ struct iperf_interval_results
     TAILQ_ENTRY(iperf_interval_results) irlistentries;
     void     *custom_data;
     int rtt;
+    int rttvar;
 };
 
 struct iperf_stream_result

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2217,6 +2217,8 @@ iperf_stats_callback(struct iperf_test *test)
 		    }
 		    rp->stream_sum_rtt += temp.rtt;
 		    rp->stream_count_rtt++;
+
+		    temp.rttvar = get_rttvar(&temp);
 		}
 	    }
 	} else {
@@ -2678,7 +2680,7 @@ print_interval_results(struct iperf_test *test, struct iperf_stream *sp, cJSON *
 	if (test->sender && test->sender_has_retransmits) {
 	    /* Interval, TCP with retransmits. */
 	    if (test->json_output)
-		cJSON_AddItemToArray(json_interval_streams, iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  snd_cwnd:  %d  rtt:  %d  omitted: %b", (int64_t) sp->socket, (double) st, (double) et, (double) irp->interval_duration, (int64_t) irp->bytes_transferred, bandwidth * 8, (int64_t) irp->interval_retrans, (int64_t) irp->snd_cwnd, (int64_t) irp->rtt, irp->omitted));
+		cJSON_AddItemToArray(json_interval_streams, iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  snd_cwnd:  %d  rtt:  %d  rttvar: %d  omitted: %b", (int64_t) sp->socket, (double) st, (double) et, (double) irp->interval_duration, (int64_t) irp->bytes_transferred, bandwidth * 8, (int64_t) irp->interval_retrans, (int64_t) irp->snd_cwnd, (int64_t) irp->rtt, (int64_t) irp->rttvar, irp->omitted));
 	    else {
 		unit_snprintf(cbuf, UNIT_LEN, irp->snd_cwnd, 'A');
 		iperf_printf(test, report_bw_retrans_cwnd_format, sp->socket, st, et, ubuf, nbuf, irp->interval_retrans, cbuf, irp->omitted?report_omitted:"");

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -207,6 +207,7 @@ void save_tcpinfo(struct iperf_stream *sp, struct iperf_interval_results *irp);
 long get_total_retransmits(struct iperf_interval_results *irp);
 long get_snd_cwnd(struct iperf_interval_results *irp);
 long get_rtt(struct iperf_interval_results *irp);
+long get_rttvar(struct iperf_interval_results *irp);
 void print_tcpinfo(struct iperf_test *test);
 void build_tcpinfo_message(struct iperf_interval_results *r, char *message);
 

--- a/src/tcp_info.c
+++ b/src/tcp_info.c
@@ -162,6 +162,24 @@ get_rtt(struct iperf_interval_results *irp)
 }
 
 /*************************************************************/
+/*
+ * Return rttvar in usec.
+ */
+long
+get_rttvar(struct iperf_interval_results *irp)
+{
+#if defined(linux) && defined(TCP_MD5SIG)
+    return irp->tcpInfo.tcpi_rttvar;
+#elif defined(__FreeBSD__) && __FreeBSD_version >= 600000
+    return irp->tcpInfo.tcpi_rttvar;
+#elif defined(__NetBSD__) && defined(TCP_INFO)
+    return irp->tcpInfo.tcpi_rttvar;
+#else
+    return -1;
+#endif
+}
+
+/*************************************************************/
 void
 build_tcpinfo_message(struct iperf_interval_results *r, char *message)
 {


### PR DESCRIPTION
This commit adds tcp_info rttvar to JSON output, as discussed in #525