### PR TITLE
Fix build after #517

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,8 @@ libiperf_la_SOURCES     = \
                         iperf_api.c \
                         iperf_api.h \
                         iperf_error.c \
+                        iperf_auth.h \
+                        iperf_auth.c \
 			iperf_client_api.c \
                         iperf_locale.c \
                         iperf_locale.h \


### PR DESCRIPTION
After PR #517 got merged build is broken if you run ./bootstrap.sh before ./configure .

This is from Ubuntu 17.04 server:
```
 ./bootstrap.sh
 ./configure
 make
 <snip>...

 /bin/bash ../libtool  --tag=CC   --mode=link gcc -g -g -O2 -Wall -g  -o iperf3 iperf3-main.o libiperf.la -lssl -lcrypto -lm
libtool: link: gcc -g -g -O2 -Wall -g -o .libs/iperf3 iperf3-main.o  ./.libs/libiperf.so -lssl -lcrypto -lm
./.libs/libiperf.so: undefined reference to `encode_auth_setting'
./.libs/libiperf.so: undefined reference to `check_authentication'
./.libs/libiperf.so: undefined reference to `decode_auth_setting'
./.libs/libiperf.so: undefined reference to `test_load_private_key'
./.libs/libiperf.so: undefined reference to `iperf_getpass'
./.libs/libiperf.so: undefined reference to `test_load_pubkey'
collect2: error: ld returned 1 exit status
Makefile:788: recipe for target 'iperf3' failed
make[2]: *** [iperf3] Error 1
make[2]: Leaving directory '/home/asavah/myrepos/iperf/src'
Makefile:640: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/home/asavah/myrepos/iperf/src'
Makefile:387: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```

To fix this iperf_auth.h and iperf_auth.c need to be added to src/Makefile.am , exactly the same was already done for src/Makefile.in