### PR TITLE
Fix various problems with summary statistics

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -102,6 +102,8 @@ struct iperf_stream_result
     struct timeval start_time;
     struct timeval end_time;
     struct timeval start_time_fixed;
+    double sender_time;
+    double receiver_time;
     TAILQ_HEAD(irlisthead, iperf_interval_results) interval_results;
     void     *data;
 };

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2526,7 +2526,7 @@ iperf_print_results(struct iperf_test *test)
     struct iperf_stream *sp = NULL;
     iperf_size_t bytes_sent, total_sent = 0;
     iperf_size_t bytes_received, total_received = 0;
-    double start_time, end_time = 0.0, avg_jitter = 0.0, lost_percent;
+    double start_time, end_time = 0.0, avg_jitter = 0.0, lost_percent = 0.0;
     double sender_time, receiver_time;
     double bandwidth;
 

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -383,6 +383,8 @@ const char report_local[] = "local";
 const char report_remote[] = "remote";
 const char report_sender[] = "sender";
 const char report_receiver[] = "receiver";
+const char report_sender_not_available_format[] = "[%3d] (sender statistics not available)\n";
+const char report_receiver_not_available_format[] = "[%3d] (receiver statistics not available)\n";
 
 #if defined(linux)
 const char report_tcpInfo[] =

--- a/src/iperf_locale.h
+++ b/src/iperf_locale.h
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014, The Regents of the University of
+ * iperf, Copyright (c) 2014, 2017, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -95,6 +95,8 @@ extern const char report_local[] ;
 extern const char report_remote[] ;
 extern const char report_sender[] ;
 extern const char report_receiver[] ;
+extern const char report_sender_not_available_format[];
+extern const char report_receiver_not_available_format[];
 
 extern const char report_tcpInfo[] ;
 extern const char report_tcpInfo[] ;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:  master

* Issues fixed (if any):  #560, possibly #238

* Brief description of code changes (suitable for use as a commit message):

Reduce / eliminate ambiguity with UDP summary statistics by printing sending and receiving statistics on separate lines (rather than smashing them all together).  (fixes #560)

The server side cannot print summary statistics from the client due to the ordering of messages on the control channel.  Therefore, on the server side, don't attempt to print the (not very meaningful and potentially misleading) statistics corresponding to the client.  (fixes #560)

Due to network latency and jitter, each side can have a different idea of the duration of the test.  There was a bug in the summary statistics code where each side used its own duration in computing the bandwidths for both summaries.  To fix this, exchange test durations and use the appropriate ending times to compute the appropriate bandwidths, etc. for each summary.  This makes the summaries printed by the client and server consistent.  (fixes #238)

