### PR TITLE
Pacing timer

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -9,9 +9,10 @@
     correct test durations for all protocols (#560, #238).
 
   * Application-level bandwidth pacing (--bandwidth option) is now
-    checked every millisecond, instead of of every tenth of a second,
-    to provide smoother traffic behavior when using application
-    pacing.  (#460)
+    checked every millisecond by default, instead of of every tenth of
+    a second, to provide smoother traffic behavior when using
+    application pacing.  (#460) The pacing can be tuned via the use of
+    the --pacing-timer option.
 
   * A new --dscp option allows specifying the DSCP value to be used
     for outgoing packets (#508).  The TOS byte value is now printed in

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -116,6 +116,7 @@ struct iperf_settings
     int       blksize;              /* size of read/writes (-l) */
     uint64_t  rate;                 /* target data rate for application pacing*/
     uint64_t  fqrate;               /* target data rate for FQ pacing*/
+    int	      pacing_timer;	    /* pacing timer in microseconds */
     int       burst;                /* packets per burst */
     int       mss;                  /* for TCP MSS */
     int       ttl;                  /* IP TTL option */

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -124,6 +124,16 @@ This bandwidth limit is implemented internally inside iperf3, and is
 available on all platforms.
 Compare with the \--fq-rate flag.
 .TP
+.BR --pacing-timer " \fIn\fR[KMG]"
+set pacing timer interval in microseconds (default 1000 microseconds,
+or 1 ms).
+This controls iperf3's internal pacing timer for the -b/--bandwidth
+option.
+The timer fires at the interval set by this parameter.
+Smaller values of the pacing timer parameter smooth out the traffic
+emitted by iperf3, but potentially at the cost of performance due to
+more frequent timer processing.
+.TP
 .BR --fq-rate " \fIn\fR[KM]"
 Set a rate to be used with fair-queueing based socket-level pacing,
 in bits per second.

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -58,6 +58,7 @@ struct iperf_stream;
 #define OPT_CLIENT_RSA_PUBLIC_KEY 13
 #define OPT_SERVER_RSA_PRIVATE_KEY 14
 #define OPT_SERVER_AUTHORIZED_USERS 15
+#define OPT_PACING_TIMER 16
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -134,6 +134,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -b, --bandwidth #[KMG][/#] target bandwidth in bits/sec (0 for unlimited)\n"
                            "                            (default %d Mbit/sec for UDP, unlimited for TCP)\n"
                            "                            (optional slash and packet count for burst mode)\n"
+			   "  --pacing-timer #[KMG]     set the timing for pacing, in microseconds (default 1000)\n"
 #if defined(HAVE_SO_MAX_PACING_RATE)
                            "  --fq-rate #[KMG]          enable fair-queuing based socket pacing in\n"
 			   "                            bits/sec (Linux only)\n"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

Add --pacing-timer option to control the granularity of the timer used for the --bandwidth option.  Follow-on to #460.
