### PR TITLE
Fix a heap corruption issue leading to a server-side crash.

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -440,6 +440,7 @@ cleanup_server(struct iperf_test *test)
     }
     if (test->congestion_used != NULL) {
         free(test->congestion_used);
+	test->congestion_used = NULL;
     }
     if (test->timer != NULL) {
         tmr_cancel(test->timer);


### PR DESCRIPTION
Commit 5ab2132c (PR #551) fixed, among other things, a memory
leak.  The solution, however, causes a hazard where a free() of
an invalid pointer can corrupt the heap.  We've observed this
fairly repeatably while running the test_commands.sh script on
CentOS 7.

To remedy this, we NULL out a pointer after the object it
pointed to has been free-d, just like a number of other similar
objects.

