### PR TITLE
Improve error handling and documentation for -f/--format.

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -23,7 +23,7 @@ establish both a server and a client.
 set server port to listen on/connect to to \fIn\fR (default 5201)
 .TP
 .BR -f ", " --format " "
-[kmKM]   format to report: Kbits, Mbits, KBytes, MBytes
+[kmgtKMGT]   format to report: Kbits/Mbits/Gbits/Tbits
 .TP
 .BR -i ", " --interval " \fIn\fR"
 pause \fIn\fR seconds between periodic bandwidth reports;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -709,7 +709,25 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 test->server_port = atoi(optarg);
                 break;
             case 'f':
-                test->settings->unit_format = *optarg;
+		if (!optarg) {
+		    i_errno = IEBADFORMAT;
+		    return -1;
+		}
+		test->settings->unit_format = *optarg;
+		if (test->settings->unit_format == 'k' ||
+		    test->settings->unit_format == 'K' ||
+		    test->settings->unit_format == 'm' ||
+		    test->settings->unit_format == 'M' ||
+		    test->settings->unit_format == 'g' ||
+		    test->settings->unit_format == 'G' ||
+		    test->settings->unit_format == 't' ||
+		    test->settings->unit_format == 'T') {
+			break;
+		}
+		else {
+		    i_errno = IEBADFORMAT;
+		    return -1;
+		}
                 break;
             case 'i':
                 /* XXX: could potentially want separate stat collection and reporting intervals,

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -302,6 +302,7 @@ enum {
     IEBADTOS = 21,	    // Bad TOS value
     IESETCLIENTAUTH = 22,   // Bad configuration of client authentication
     IESETSERVERAUTH = 23,   // Bad configuration of server authentication
+    IEBADFORMAT = 24,	    // Bad format argument to -f
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -137,6 +137,9 @@ iperf_strerror(int int_errno)
         case IESETSERVERAUTH:
              snprintf(errstr, len, "you must specify path to a valid private rsa server to be used and a user credential file");
             break;
+	case IEBADFORMAT:
+	    snprintf(errstr, len, "bad format specifier (valid formats are in the set [kmgtKMGT])");
+	    break;
         case IEMSS:
             snprintf(errstr, len, "TCP MSS too large (maximum = %d bytes)", MAX_MSS);
             break;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -98,7 +98,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "       iperf3 [-h|--help] [-v|--version]\n\n"
                            "Server or Client:\n"
                            "  -p, --port      #         server port to listen on/connect to\n"
-                           "  -f, --format    [kmgKMG]  format to report: Kbits, Mbits, KBytes, MBytes\n"
+                           "  -f, --format   [kmgtKMGT] format to report: Kbits, Mbits, Gbits, Tbits\n"
                            "  -i, --interval  #         seconds between periodic bandwidth reports\n"
                            "  -F, --file name           xmit/recv the specified file\n"
 #if defined(HAVE_CPU_AFFINITY)


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:  All

* Issues fixed (if any):  #566

* Brief description of code changes (suitable for use as a commit message):
Improve error handling and documentation for -f/--format.
We now reject all invalid format characters given as the
argument to the -f/--format flag.  All valid characters are now
documented in the usage message and manual page.



