### PR TITLE
fix free on uninitialized var found by clang

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -143,6 +143,7 @@ iperf_tcp_listen(struct iperf_test *test)
     int saved_errno;
     int rcvbuf_actual, sndbuf_actual;
 
+    res = NULL;
     s = test->listener;
 
     /*


### PR DESCRIPTION
the two calls to freeaddrinfo(res) are made on an uninitialized var
if you do not pass the test on socket options