### PR TITLE
Grab TCP PMTU during tests (on Linux only).  Towards #569.

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -81,6 +81,7 @@ struct iperf_interval_results
     void     *custom_data;
     int rtt;
     int rttvar;
+    int pmtu;
 };
 
 struct iperf_stream_result

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2407,6 +2407,7 @@ iperf_stats_callback(struct iperf_test *test)
 		    rp->stream_count_rtt++;
 
 		    temp.rttvar = get_rttvar(&temp);
+		    temp.pmtu = get_pmtu(&temp);
 		}
 	    }
 	} else {
@@ -3032,7 +3033,7 @@ print_interval_results(struct iperf_test *test, struct iperf_stream *sp, cJSON *
 	if (test->sender && test->sender_has_retransmits) {
 	    /* Interval, TCP with retransmits. */
 	    if (test->json_output)
-		cJSON_AddItemToArray(json_interval_streams, iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  snd_cwnd:  %d  rtt:  %d  rttvar: %d  omitted: %b", (int64_t) sp->socket, (double) st, (double) et, (double) irp->interval_duration, (int64_t) irp->bytes_transferred, bandwidth * 8, (int64_t) irp->interval_retrans, (int64_t) irp->snd_cwnd, (int64_t) irp->rtt, (int64_t) irp->rttvar, irp->omitted));
+		cJSON_AddItemToArray(json_interval_streams, iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  snd_cwnd:  %d  rtt:  %d  rttvar: %d  pmtu: %d  omitted: %b", (int64_t) sp->socket, (double) st, (double) et, (double) irp->interval_duration, (int64_t) irp->bytes_transferred, bandwidth * 8, (int64_t) irp->interval_retrans, (int64_t) irp->snd_cwnd, (int64_t) irp->rtt, (int64_t) irp->rttvar, (int64_t) irp->pmtu, irp->omitted));
 	    else {
 		unit_snprintf(cbuf, UNIT_LEN, irp->snd_cwnd, 'A');
 		iperf_printf(test, report_bw_retrans_cwnd_format, sp->socket, st, et, ubuf, nbuf, irp->interval_retrans, cbuf, irp->omitted?report_omitted:"");

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -214,6 +214,7 @@ long get_total_retransmits(struct iperf_interval_results *irp);
 long get_snd_cwnd(struct iperf_interval_results *irp);
 long get_rtt(struct iperf_interval_results *irp);
 long get_rttvar(struct iperf_interval_results *irp);
+long get_pmtu(struct iperf_interval_results *irp);
 void print_tcpinfo(struct iperf_test *test);
 void build_tcpinfo_message(struct iperf_interval_results *r, char *message);
 

--- a/src/tcp_info.c
+++ b/src/tcp_info.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014, The Regents of the University of
+ * iperf, Copyright (c) 2014, 2017, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -174,6 +174,20 @@ get_rttvar(struct iperf_interval_results *irp)
     return irp->tcpInfo.tcpi_rttvar;
 #elif defined(__NetBSD__) && defined(TCP_INFO)
     return irp->tcpInfo.tcpi_rttvar;
+#else
+    return -1;
+#endif
+}
+
+/*************************************************************/
+/*
+ * Return PMTU in bytes.
+ */
+long
+get_pmtu(struct iperf_interval_results *irp)
+{
+#if defined(linux) && defined(TCP_MD5SIG)
+    return irp->tcpInfo.tcpi_pmtu;
 #else
     return -1;
 #endif


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:  all

* Issues fixed (if any):  #569 (partly)

* Brief description of code changes (suitable for use as a commit message):

Just the PMTU portion of #569.
