### PR TITLE
Issue 216

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -110,6 +110,37 @@ This software contains source code (src/net.{c,h}) that is:
 
 =====
 
+This software contains source code (src/net.c) that is:
+
+/*
+ * Copyright (c) 2001 Eric Jackson <ericj@monkey.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+=====
+
 This software contains source code (src/queue.h) that is:
 
   /*

--- a/configure
+++ b/configure
@@ -12583,6 +12583,20 @@ $as_echo "#define const /**/" >>confdefs.h
 fi
 
 
+# Check for poll.h (it's in POSIX so everyone should have it?)
+for ac_header in poll.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "poll.h" "ac_cv_header_poll_h" "$ac_includes_default"
+if test "x$ac_cv_header_poll_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_POLL_H 1
+_ACEOF
+
+fi
+
+done
+
+
 # Check for SCTP support
 for ac_header in sys/socket.h
 do :

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# iperf, Copyright (c) 2014, 2015, 2016, The Regents of the University of
+# iperf, Copyright (c) 2014, 2015, 2016, 2017, The Regents of the University of
 # California, through Lawrence Berkeley National Laboratory (subject
 # to receipt of any required approvals from the U.S. Dept. of
 # Energy).  All rights reserved.
@@ -84,6 +84,9 @@ exit 1
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
+
+# Check for poll.h (it's in POSIX so everyone should have it?)
+AC_CHECK_HEADERS([poll.h])
 
 # Check for SCTP support
 AC_CHECK_HEADERS([sys/socket.h])

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -128,6 +128,7 @@ struct iperf_settings
     char      unit_format;          /* -f */
     int       num_ostreams;         /* SCTP initmsg settings */
     char      *authtoken;           /* Authentication token */
+    int	      connect_timeout;	    /* socket connection timeout, in ms */
 };
 
 struct iperf_test;

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -110,6 +110,14 @@ use SCTP rather than TCP (FreeBSD and Linux)
 .BR -u ", " --udp
 use UDP rather than TCP
 .TP
+.BR --connect-timeout " \fIn\fR"
+set timeout for establishing the initial control connection to the
+server, in milliseconds.
+The default behavior is the operating system's timeout for TCP
+connection establishment.
+Providing a shorter value may speed up detection of a down iperf3
+server.
+.TP
 .BR -b ", " --bandwidth " \fIn\fR[KM]"
 set target bandwidth to \fIn\fR bits/sec (default 1 Mbit/sec for UDP, unlimited for TCP).
 If there are multiple streams (\-P flag), the bandwidth limit is applied 

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -682,6 +682,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 #endif /* HAVE_SSL */
 	{"fq-rate", required_argument, NULL, OPT_FQ_RATE},
 	{"pacing-timer", required_argument, NULL, OPT_PACING_TIMER},
+	{"connect-timeout", required_argument, NULL, OPT_CONNECT_TIMEOUT},
         {"debug", no_argument, NULL, 'd'},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
@@ -1033,6 +1034,10 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 #endif /* HAVE_SSL */
 	    case OPT_PACING_TIMER:
 		test->settings->pacing_timer = unit_atoi(optarg);
+		client_flag = 1;
+		break;
+	    case OPT_CONNECT_TIMEOUT:
+		test->settings->connect_timeout = unit_atoi(optarg);
 		client_flag = 1;
 		break;
 	    case 'h':
@@ -2070,6 +2075,7 @@ iperf_defaults(struct iperf_test *testp)
     testp->settings->mss = 0;
     testp->settings->bytes = 0;
     testp->settings->blocks = 0;
+    testp->settings->connect_timeout = -1;
     memset(testp->cookie, 0, COOKIE_SIZE);
 
     testp->multisend = 10;	/* arbitrary */

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -59,6 +59,7 @@ struct iperf_stream;
 #define OPT_SERVER_RSA_PRIVATE_KEY 14
 #define OPT_SERVER_AUTHORIZED_USERS 15
 #define OPT_PACING_TIMER 16
+#define OPT_CONNECT_TIMEOUT 17
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -321,7 +321,7 @@ iperf_connect(struct iperf_test *test)
     /* Create and connect the control channel */
     if (test->ctrl_sck < 0)
 	// Create the control channel using an ephemeral port
-	test->ctrl_sck = netdial(test->settings->domain, Ptcp, test->bind_address, 0, test->server_hostname, test->server_port);
+	test->ctrl_sck = netdial(test->settings->domain, Ptcp, test->bind_address, 0, test->server_hostname, test->server_port, test->settings->connect_timeout);
     if (test->ctrl_sck < 0) {
         i_errno = IECONNECT;
         return -1;

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -21,6 +21,9 @@
 /* Define to 1 if you have the <netinet/sctp.h> header file. */
 #undef HAVE_NETINET_SCTP_H
 
+/* Define to 1 if you have the <poll.h> header file. */
+#undef HAVE_POLL_H
+
 /* Define to 1 if you have the `sched_setaffinity' function. */
 #undef HAVE_SCHED_SETAFFINITY
 

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -131,6 +131,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  --nstreams      #         number of SCTP streams\n"
 #endif /* HAVE_SCTP */
                            "  -u, --udp                 use UDP rather than TCP\n"
+                           "  --connect-timeout #       timeout for control connection setup (ms)\n"
                            "  -b, --bandwidth #[KMG][/#] target bandwidth in bits/sec (0 for unlimited)\n"
                            "                            (default %d Mbit/sec for UDP, unlimited for TCP)\n"
                            "                            (optional slash and packet count for burst mode)\n"

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -427,7 +427,7 @@ iperf_udp_connect(struct iperf_test *test)
     int rc;
 
     /* Create and bind our local socket. */
-    if ((s = netdial(test->settings->domain, Pudp, test->bind_address, test->bind_port, test->server_hostname, test->server_port)) < 0) {
+    if ((s = netdial(test->settings->domain, Pudp, test->bind_address, test->bind_port, test->server_hostname, test->server_port, -1)) < 0) {
         i_errno = IESTREAMCONNECT;
         return -1;
     }

--- a/src/net.c
+++ b/src/net.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014, 2015, The Regents of the University of
+ * iperf, Copyright (c) 2014, 2015, 2017, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -56,9 +56,55 @@
 #endif
 #endif /* HAVE_SENDFILE */
 
+#ifdef HAVE_POLL_H
+#include <poll.h>
+#endif /* HAVE_POLL_H */
+
 #include "iperf_util.h"
 #include "net.h"
 #include "timer.h"
+
+/*
+ * timeout_connect adapted from netcat, via OpenBSD and FreeBSD
+ * Copyright (c) 2001 Eric Jackson <ericj@monkey.org>
+ */
+int
+timeout_connect(int s, const struct sockaddr *name, socklen_t namelen,
+    int timeout)
+{
+	struct pollfd pfd;
+	socklen_t optlen;
+	int flags, optval;
+	int ret;
+
+	if (timeout != -1) {
+		flags = fcntl(s, F_GETFL, 0);
+		if (fcntl(s, F_SETFL, flags | O_NONBLOCK) == -1)
+			err(1, "set non-blocking mode");
+	}
+
+	if ((ret = connect(s, name, namelen)) != 0 && errno == EINPROGRESS) {
+		pfd.fd = s;
+		pfd.events = POLLOUT;
+		if ((ret = poll(&pfd, 1, timeout)) == 1) {
+			optlen = sizeof(optval);
+			if ((ret = getsockopt(s, SOL_SOCKET, SO_ERROR,
+			    &optval, &optlen)) == 0) {
+				errno = optval;
+				ret = optval == 0 ? 0 : -1;
+			}
+		} else if (ret == 0) {
+			errno = ETIMEDOUT;
+			ret = -1;
+		} else
+			err(1, "poll failed");
+	}
+
+	if (timeout != -1 && fcntl(s, F_SETFL, flags) == -1)
+		err(1, "restoring flags");
+
+	return (ret);
+}
 
 /* netdial and netannouce code comes from libtask: http://swtch.com/libtask/
  * Copyright: http://swtch.com/libtask/COPYRIGHT
@@ -66,7 +112,7 @@
 
 /* make connection to server */
 int
-netdial(int domain, int proto, char *local, int local_port, char *server, int port)
+netdial(int domain, int proto, char *local, int local_port, char *server, int port, int timeout)
 {
     struct addrinfo hints, *local_res, *server_res;
     int s;
@@ -111,7 +157,7 @@ netdial(int domain, int proto, char *local, int local_port, char *server, int po
     }
 
     ((struct sockaddr_in *) server_res->ai_addr)->sin_port = htons(port);
-    if (connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen) < 0 && errno != EINPROGRESS) {
+    if (timeout_connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen, timeout) < 0 && errno != EINPROGRESS) {
 	close(s);
 	freeaddrinfo(server_res);
         return -1;

--- a/src/net.c
+++ b/src/net.c
@@ -80,7 +80,7 @@ timeout_connect(int s, const struct sockaddr *name, socklen_t namelen,
 	if (timeout != -1) {
 		flags = fcntl(s, F_GETFL, 0);
 		if (fcntl(s, F_SETFL, flags | O_NONBLOCK) == -1)
-			err(1, "set non-blocking mode");
+			return -1;
 	}
 
 	if ((ret = connect(s, name, namelen)) != 0 && errno == EINPROGRESS) {
@@ -97,11 +97,11 @@ timeout_connect(int s, const struct sockaddr *name, socklen_t namelen,
 			errno = ETIMEDOUT;
 			ret = -1;
 		} else
-			err(1, "poll failed");
+			ret = -1;
 	}
 
 	if (timeout != -1 && fcntl(s, F_SETFL, flags) == -1)
-		err(1, "restoring flags");
+		ret = -1;
 
 	return (ret);
 }

--- a/src/net.h
+++ b/src/net.h
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014, The Regents of the University of
+ * iperf, Copyright (c) 2014, 2017, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -27,7 +27,8 @@
 #ifndef __NET_H
 #define __NET_H
 
-int netdial(int domain, int proto, char *local, int local_port, char *server, int port);
+int timeout_connect(int s, const struct sockaddr *name, socklen_t namelen, int timeout);
+int netdial(int domain, int proto, char *local, int local_port, char *server, int port, int timeout);
 int netannounce(int domain, int proto, char *local, int port);
 int Nread(int fd, char *buf, size_t count, int prot);
 int Nwrite(int fd, const char *buf, size_t count, int prot) /* __attribute__((hot)) */;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:  master / all

* Issues fixed (if any): #216 

* Brief description of code changes (suitable for use as a commit message):

Add a wrapper around connect(2) that fails if there's no response by a user-configured timeout.  Hook up a new `--connect-timeout` command-line option to this.

