### PR TITLE
Return random ascii-string in make_cookie.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3169,9 +3169,6 @@ iperf_new_stream(struct iperf_test *test, int s)
         free(sp);
         return NULL;
     }
-    srandom(time(NULL));
-    for (i = 0; i < test->settings->blksize; ++i)
-        sp->buffer[i] = random();
 
     /* Set socket */
     sp->socket = s;
@@ -3196,7 +3193,8 @@ iperf_new_stream(struct iperf_test *test, int s)
         sp->diskfile_fd = -1;
 
     /* Initialize stream */
-    if (iperf_init_stream(sp, test) < 0) {
+    if ((readentropy(sp->buffer, test->settings->blksize) < 0) ||
+        (iperf_init_stream(sp, test) < 0)) {
         close(sp->buffer_fd);
         munmap(sp->buffer, sp->test->settings->blksize);
         free(sp->result);

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -45,6 +45,37 @@
 #include <errno.h>
 
 #include "cjson.h"
+#include "iperf.h"
+#include "iperf_api.h"
+
+/*
+ * Read entropy from /dev/urandom
+ * Errors are fatal.
+ * Returns 0 on success.
+ */
+int readentropy(void *out, size_t outsize)
+{
+    static FILE *frandom;
+    static const char rndfile[] = "/dev/urandom";
+
+    if (!outsize) return 0;
+
+    if (frandom == NULL) {
+        frandom = fopen(rndfile, "rb");
+        if (frandom == NULL) {
+            iperf_errexit(NULL, "error - failed to open %s: %s\n",
+                          rndfile, strerror(errno));
+        }
+        setbuf(frandom, NULL);
+    }
+    if (fread(out, 1, outsize, frandom) != outsize) {
+        iperf_errexit(NULL, "error - failed to read %s: %s\n",
+                      rndfile,
+                      feof(frandom) ? "EOF" : strerror(errno));
+    }
+    return 0;
+}
+
 
 /* make_cookie
  *
@@ -53,27 +84,21 @@
  * Iperf uses this function to create test "cookies" which
  * server as unique test identifiers. These cookies are also
  * used for the authentication of stream connections.
+ * Assumes cookie has size (COOKIE_SIZE + 1) char's.
  */
 
 void
 make_cookie(char *cookie)
 {
-    static int randomized = 0;
-    char hostname[500];
-    struct timeval tv;
-    char temp[1000];
+    unsigned char *out = (unsigned char*)cookie;
+    size_t pos;
+    static const unsigned char rndchars[] = "abcdefghijklmnopqrstuvwxyz234567";
 
-    if ( ! randomized )
-        srandom((int) time(0) ^ getpid());
-
-    /* Generate a string based on hostname, time, randomness, and filler. */
-    (void) gethostname(hostname, sizeof(hostname));
-    (void) gettimeofday(&tv, 0);
-    (void) snprintf(temp, sizeof(temp), "%s.%ld.%06ld.%08lx%08lx.%s", hostname, (unsigned long int) tv.tv_sec, (unsigned long int) tv.tv_usec, (unsigned long int) random(), (unsigned long int) random(), "1234567890123456789012345678901234567890");
-
-    /* Now truncate it to 36 bytes and terminate. */
-    memcpy(cookie, temp, 36);
-    cookie[36] = '\0';
+    readentropy(out, COOKIE_SIZE);
+    for (pos = 0; pos < (COOKIE_SIZE - 1); pos++) {
+        out[pos] = rndchars[out[pos] % (sizeof(rndchars) - 1)];
+    }
+    out[pos] = '\0';
 }
 
 

--- a/src/iperf_util.h
+++ b/src/iperf_util.h
@@ -29,6 +29,9 @@
 
 #include "cjson.h"
 #include <sys/select.h>
+#include <stddef.h>
+
+int readentropy(void *out, size_t outsize);
 
 void make_cookie(char *);
 


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):
#576 

* Brief description of code changes (suitable for use as a commit message):

Having hostname and microsecond timestamp in the cookie is not
necessary.  Also fill test buffer with data from /dev/urandom
instead of using random().
