### PR TITLE
C++ compatiblity

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -29,6 +29,14 @@
 
 #include <sys/time.h>
 #include <setjmp.h>
+#include <stdio.h>
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#ifdef __cplusplus
+extern "C" { /* open extern "C" */
+#endif
+
 
 struct iperf_test;
 struct iperf_stream_result;
@@ -359,5 +367,11 @@ enum {
     IENEWTIMER = 300,       // Unable to create new timer (check perror)
     IEUPDATETIMER = 301,    // Unable to update timer (check perror)
 };
+
+
+#ifdef __cplusplus
+} /* close extern "C" */
+#endif
+
 
 #endif /* !__IPERF_API_H */


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

I would like to be able to use libiperf as an external library to my C++ application. 
During compilation, there are problems with iperf_api.h not being able to find FILE*
and uint64 because they aren't included in the header. 

* Brief description of code changes (suitable for use as a commit message):
Making the functions extern because it's not accessible as an API, as well as including 
stdio/stdint in iperf_api.h 

