### PR TITLE
fix server-side memory leaks

### DIFF
--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -48,6 +48,7 @@
 #include "iperf.h"
 #include "iperf_api.h"
 
+static FILE *frandom = NULL;
 /*
  * Read entropy from /dev/urandom
  * Errors are fatal.
@@ -55,7 +56,6 @@
  */
 int readentropy(void *out, size_t outsize)
 {
-    static FILE *frandom;
     static const char rndfile[] = "/dev/urandom";
 
     if (!outsize) return 0;
@@ -74,6 +74,13 @@ int readentropy(void *out, size_t outsize)
                       feof(frandom) ? "EOF" : strerror(errno));
     }
     return 0;
+}
+void entropycleanup()
+{
+    if (frandom != NULL) {
+        fclose(frandom);
+        frandom = NULL;
+    }
 }
 
 

--- a/src/iperf_util.h
+++ b/src/iperf_util.h
@@ -31,7 +31,10 @@
 #include <sys/select.h>
 #include <stddef.h>
 
+extern FILE *frandom;
+
 int readentropy(void *out, size_t outsize);
+void entropycleanup();
 
 void make_cookie(char *);
 

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,7 @@
 
 #include "iperf.h"
 #include "iperf_api.h"
+#include "iperf_util.h"
 #include "units.h"
 #include "iperf_locale.h"
 #include "net.h"
@@ -159,6 +160,8 @@ run(struct iperf_test *test)
                 if (iperf_get_test_one_off(test))
                     break;
             }
+	    entropycleanup();
+	    tmr_destroy();
 	    iperf_delete_pidfile(test);
             break;
 	case 'c':


### PR DESCRIPTION
this should fix leaks: 
* timer free list was not cleansed
* frandom file was not closed

Adding a function to close the frandom file might not be the best way to go. I did it to try and stay within the iperf_util context: it opens, so it should be the one to close.
Do tell me if you wish this to be handled another way.

test command:
```bash
valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes \
         --read-var-info=yes -- ./src/.libs/iperf3 -s --json -1
```

Valgrind memcheck's trace:
```
72 bytes in 1 blocks are indirectly lost in loss record 1 of 3
   at 0x4C27AD1: malloc (vg_replace_malloc.c:299)
   by 0x4E552E5: tmr_create (timer.c:151)
   by 0x4E4FC58: create_server_timers (iperf_server_api.c:357)
   by 0x4E50BB9: iperf_run_server (iperf_server_api.c:631)
   by 0x401031: run (main.c:151)
   by 0x400EDD: main (main.c:107)
144 (72 direct, 72 indirect) bytes in 1 blocks are definitely lost in loss record 2 of 3
   at 0x4C27AD1: malloc (vg_replace_malloc.c:299)
   by 0x4E552E5: tmr_create (timer.c:151)
   by 0x4E4FCE7: create_server_timers (iperf_server_api.c:364)
   by 0x4E50BB9: iperf_run_server (iperf_server_api.c:631)
   by 0x401031: run (main.c:151)
   by 0x400EDD: main (main.c:107)
568 bytes in 1 blocks are still reachable in loss record 1 of 1
   at 0x4C27AD1: malloc (vg_replace_malloc.c:299)
   by 0x5A2654C: __fopen_internal (in /usr/lib64/libc-2.17.so)
   by 0x4E53351: readentropy (iperf_util.c:64)
   by 0x4E4ABCB: iperf_new_stream (iperf_api.c:3203)
   by 0x4E50701: iperf_run_server (iperf_server_api.c:573)
   by 0x401031: run (main.c:151)
   by 0x400EDD: main (main.c:107)
```

Signed-off-by: Gabriel Ganne <gabriel.ganne@enea.com>