### PR TITLE
ctrl_sck not closed in iperf_client_end()

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -407,6 +407,10 @@ iperf_client_end(struct iperf_test *test)
     /* show final summary */
     test->reporter_callback(test);
 
+    /* Close control socket */
+    if (test->ctrl_sck)
+        close(test->ctrl_sck);
+
     if (iperf_set_send_state(test, IPERF_DONE) != 0)
         return -1;
 


### PR DESCRIPTION
This should fix leaks on test->ctrl_sck

I think iperf_client_end() is the right position for closing ctrl_sck.
This fixed the socket fd leaks I'm getting while running repeated client tests using this library.