### PR TITLE
Add getline() fallback for OSX <= 10.6

### DIFF
--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -34,6 +34,8 @@
 #include <stdio.h>
 #include <termios.h>
 
+#include "iperf_util.h"
+
 #if defined(HAVE_SSL)
 
 #include <openssl/bio.h>

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -432,3 +432,87 @@ iperf_dump_fdset(FILE *fp, char *str, int nfds, fd_set *fds)
     }
     fprintf(fp, "]\n");
 }
+
+/* Fallback getline() for OSX <= 10.6 */
+#ifdef __APPLE__
+#include <Availability.h>
+#if __MAC_OS_X_VERSION_MIN_REQUIRED <= 1060
+
+/* GNU mailutils - a suite of utilities for electronic mail
+** Copyright (C) 1999, 2000, 2001 Free Software Foundation, Inc.
+**
+** This program is free software; you can redistribute it and/or modify
+** it under the terms of the GNU General Library Public License as published by
+** the Free Software Foundation; either version 2, or (at your option)
+** any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Library General Public License for more details.
+**
+** You should have received a copy of the GNU Library General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.  */
+
+/* First implementation by Alain Magloire */
+
+/* Default value for line length.  */
+static const int line_size = 128;
+
+static ssize_t
+getdelim (char **lineptr, size_t *n, int delim, FILE *stream)
+{
+    int indx = 0;
+    int c;
+
+    /* Sanity checks.  */
+    if (lineptr == NULL || n == NULL || stream == NULL)
+        return -1;
+
+    /* Allocate the line the first time.  */
+    if (*lineptr == NULL)
+    {
+        *lineptr = malloc (line_size);
+        if (*lineptr == NULL)
+            return -1;
+        *n = line_size;
+    }
+
+    /* Clear the line.  */
+    memset (*lineptr, '\0', *n);
+
+    while ((c = getc (stream)) != EOF)
+    {
+        /* Check if more memory is needed.  */
+        if (indx >= *n)
+        {
+            *lineptr = realloc (*lineptr, *n + line_size);
+            if (*lineptr == NULL)
+            {
+                return -1;
+            }
+            /* Clear the rest of the line.  */
+            memset(*lineptr + *n, '\0', line_size);
+            *n += line_size;
+        }
+
+        /* Push the result in the line.  */
+        (*lineptr)[indx++] = c;
+
+        /* Bail out.  */
+        if (c == delim)
+        {
+            break;
+        }
+    }
+    return (c == EOF) ? -1 : indx;
+}
+
+ssize_t
+getline (char **lineptr, size_t *n, FILE *stream)
+{
+    return getdelim (lineptr, n, '\n', stream);
+}
+#endif
+#endif

--- a/src/iperf_util.h
+++ b/src/iperf_util.h
@@ -56,3 +56,13 @@ cJSON* iperf_json_printf(const char *format, ...);
 void iperf_dump_fdset(FILE *fp, char *str, int nfds, fd_set *fds);
 
 #endif
+
+/* Fallback getline() for OSX <= 10.6 */
+#ifdef __APPLE__
+#include <Availability.h>
+#if __MAC_OS_X_VERSION_MIN_REQUIRED <= 1060
+
+ssize_t
+getline (char **lineptr, size_t *n, FILE *stream);
+#endif
+#endif


### PR DESCRIPTION
Fixes #607. Verified on 10.6.8 x64 running llvm-gcc-4.2.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): #607 

* Brief description of code changes (suitable for use as a commit message):
Implements a fallback to the `getline()` function on OSX <= 10.6. Adapted from the mailutils forum (https://lists.gnu.org/archive/html/bug-mailutils/2002-10/msg00038.html).