### PR TITLE
Add required RSA header for OpenSSL

### DIFF
--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -36,6 +36,7 @@
 
 #if defined(HAVE_SSL)
 
+#include <openssl/rsa.h>
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/sha.h>


### PR DESCRIPTION
Fixes cross-compilation issues under certain buildroot configurations (like LEDE).