### PR TITLE
fix for issue #624 - force build without openssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,13 +101,16 @@ AC_CHECK_HEADERS([netinet/sctp.h],
 #endif
 ])
 
-# Check for OPENSSL support
-AX_CHECK_OPENSSL(
-	AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available])
-)
-LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
-LIBS="$OPENSSL_LIBS $LIBS"
-CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+if test "x$with_openssl" != "xno"; then
+    # Check for OPENSSL support
+    AX_CHECK_OPENSSL(
+        [ AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available]) ],
+	[ AC_MSG_FAILURE([--with-openssl was given, but test for openssl failed]) ]
+    )
+    LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+    LIBS="$OPENSSL_LIBS $LIBS"
+    CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+fi
 
 # Check for TCP_CONGESTION sockopt (believed to be Linux and FreeBSD only)
 AC_CACHE_CHECK([TCP_CONGESTION socket option],

--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,9 @@ AC_CHECK_HEADERS([netinet/sctp.h],
 #endif
 ])
 
-if test "x$with_openssl" != "xno"; then
+if test "x$with_openssl" = "xno"; then
+    AC_MSG_WARN( [Building without OpenSSL; disabling iperf_auth functionality.] )
+else
     # Check for OPENSSL support
     AX_CHECK_OPENSSL(
         [ AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available]) ],


### PR DESCRIPTION
As requested by issue #624 , with this fix we are able to force the build of iperf skipping openssl library check. 

At the same time, I think it's better to raise an exception if openssl is enabled but not found into the system.

please run autoconf after pull changes!