### PR TITLE
Fix out-of-the-box builds with no OpenSSL

### DIFF
--- a/configure
+++ b/configure
@@ -12947,10 +12947,12 @@ else
 
             { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-             { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+             if test "x$with_openssl" != "x"; then
+	  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "--with-openssl was given, but test for openssl failed
+as_fn_error $? "--with-openssl was given, but test for OpenSSL failed
 See \`config.log' for more details" "$LINENO" 5; }
+	  fi
 
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,9 @@ else
     # Check for OPENSSL support
     AX_CHECK_OPENSSL(
         [ AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available]) ],
-	[ AC_MSG_FAILURE([--with-openssl was given, but test for openssl failed]) ]
+	[ if test "x$with_openssl" != "x"; then
+	  AC_MSG_FAILURE([--with-openssl was given, but test for OpenSSL failed])
+	  fi ]
     )
     LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
     LIBS="$OPENSSL_LIBS $LIBS"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:  master, 3.2-STABLE

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

Don't make OpenSSL detection error out unless --with-openssl explicitly given.
This fixes the out-of-the-box build on macOS, which doesn't include
headers, etc. for OpenSSL by default.  The configure script still
errors out if the user specifies a --with-openssl flag but for some
reason the build host's OpenSSL is broken or can't be used.  Related to #631.

While here, fix capitalization of "OpenSSL" in a message.
