### PR TITLE
Two fixes for a warning for possibly-too-large UDP packets.

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -382,10 +382,11 @@ iperf_connect(struct iperf_test *test)
 	 * Regardless of whether explicitly or implicitly set, if the
 	 * block size is larger than the MSS, print a warning.
 	 */
-	if (test->settings->blksize > test->ctrl_sck_mss) {
+	if (test->settings->blksize > test->ctrl_sck_mss &&
+	    test->ctrl_sck_mss > 0) {
 	    char str[128];
 	    snprintf(str, sizeof(str),
-		     "Warning:  UDP block size %d exceeds TCP MSS %d, may result in fragmentation / drops", test->settings->blksize, test->ctrl_sck_mss);
+		     "UDP block size %d exceeds TCP MSS %d, may result in fragmentation / drops", test->settings->blksize, test->ctrl_sck_mss);
 	    warning(str);
 	}
     }

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -382,8 +382,8 @@ iperf_connect(struct iperf_test *test)
 	 * Regardless of whether explicitly or implicitly set, if the
 	 * block size is larger than the MSS, print a warning.
 	 */
-	if (test->settings->blksize > test->ctrl_sck_mss &&
-	    test->ctrl_sck_mss > 0) {
+	if (test->ctrl_sck_mss > 0 &&
+	    test->settings->blksize > test->ctrl_sck_mss) {
 	    char str[128];
 	    snprintf(str, sizeof(str),
 		     "UDP block size %d exceeds TCP MSS %d, may result in fragmentation / drops", test->settings->blksize, test->ctrl_sck_mss);


### PR DESCRIPTION
1.  Make sure we have a valid TCP MSS on the path when comparing
the UDP block size.

2.  Fix a redundant "warning".

This should fix a bug observed on Windows but not (so far) on any
UNIX-like platforms.  Fixes #604.

