### PR TITLE
Clear TOS value when resetting test parameters.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2305,6 +2305,7 @@ iperf_reset_test(struct iperf_test *test)
     test->settings->rate = 0;
     test->settings->burst = 0;
     test->settings->mss = 0;
+    test->settings->tos = 0;
     memset(test->cookie, 0, COOKIE_SIZE);
     test->multisend = 10;	/* arbitrary */
     test->udp_counters_64bit = 0;


### PR DESCRIPTION
This addresses a problem where the --tos parameter would incorrectly
"stick" on the server, causing wrong TOS values to be inserted into
packets during --reverse tests.  Fixes #639.

