### PR TITLE
Fix memory leak introduced in 1460aa3433769db1f5660e7819b669e5414e9b42.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2305,7 +2305,10 @@ iperf_reset_test(struct iperf_test *test)
     test->settings->burst = 0;
     test->settings->mss = 0;
     test->settings->tos = 0;
-    test->settings->authtoken = NULL;
+    if (test->settings->authtoken) {
+	free(test->settings->authtoken);
+	test->settings->authtoken = NULL;
+    }
     memset(test->cookie, 0, COOKIE_SIZE);
     test->multisend = 10;	/* arbitrary */
     test->udp_counters_64bit = 0;


### PR DESCRIPTION
Pointed out by:  @pprindeville
Should have been found by:  @bmah888

