### PR TITLE
Don't overwrite a PID file corresponding to a valid process.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3438,6 +3438,36 @@ iperf_create_pidfile(struct iperf_test *test)
     if (test->pidfile) {
 	int fd;
 	char buf[8];
+
+	/* See if the file already exists and we can read it. */
+	fd = open(test->pidfile, O_RDONLY, 0);
+	if (fd >= 0) {
+	    if (read(fd, buf, sizeof(buf) - 1) >= 0) {
+
+		/* We read some bytes, see if they correspond to a valid PID */
+		pid_t pid;
+		pid = atoi(buf);
+		if (pid > 0) {
+
+		    /* See if the process exists. */
+		    if (kill(pid, 0) == 0) {
+			/*
+			 * Make sure not to try to delete existing PID file by
+			 * scribbling over the pathname we'd use to refer to it.
+			 * Then exit with an error.
+			 */
+			free(test->pidfile);
+			test->pidfile = NULL;
+			iperf_errexit(test, "Another instance of iperf3 appears to be running");
+		    }
+		}
+	    }
+	}
+	
+	/*
+	 * File didn't exist, we couldn't read it, or it didn't correspond to 
+	 * a running process.  Try to create it. 
+	 */
 	fd = open(test->pidfile, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR|S_IWUSR);
 	if (fd < 0) {
 	    return -1;


### PR DESCRIPTION
This fixes a problem described in issue #623 where the PID file
opened by a running instance of iperf3 could be overwritten /
deleted by a subsequent invocation of iperf3.
