### PR TITLE
Fix 3.3 build warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,14 @@ AC_CHECK_HEADERS([netinet/sctp.h],
 #endif
 ])
 
+AC_CHECK_HEADER([endian.h],
+		AC_DEFINE([HAVE_ENDIAN_H], [1], [Define to 1 if you have the <endian.h> header file.]),
+		AC_CHECK_HEADER([sys/endian.h],
+				AC_DEFINE([HAVE_SYS_ENDIAN_H], [1], [Define to 1 if you have the <sys/endian.h> header file.]),
+				AC_MSG_WARN([Couldn't find endian.h or sys/endian.h files: doing compile-time tests.])
+				)
+		)
+
 if test "x$with_openssl" = "xno"; then
     AC_MSG_WARN( [Building without OpenSSL; disabling iperf_auth functionality.] )
 else

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -36,7 +36,9 @@
 #endif
 #include <sys/select.h>
 #include <sys/socket.h>
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #include <netinet/tcp.h>
 
 #if defined(HAVE_CPUSET_SETAFFINITY)

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -24,7 +24,9 @@
  * This code is distributed under a BSD style license, see the LICENSE file
  * for complete information.
  */
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
 #define __USE_GNU
 
 #include "iperf_config.h"

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -9,6 +9,9 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
+/* Define to 1 if you have the <endian.h> header file. */
+#undef HAVE_ENDIAN_H
+
 /* Have IPv6 flowlabel support. */
 #undef HAVE_FLOWLABEL
 
@@ -53,6 +56,9 @@
 
 /* Define to 1 if the system has the type `struct sctp_assoc_value'. */
 #undef HAVE_STRUCT_SCTP_ASSOC_VALUE
+
+/* Define to 1 if you have the <sys/endian.h> header file. */
+#undef HAVE_SYS_ENDIAN_H
 
 /* Define to 1 if you have the <sys/socket.h> header file. */
 #undef HAVE_SYS_SOCKET_H

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -24,8 +24,6 @@
  * This code is distributed under a BSD style license, see the LICENSE
  * file for complete information.
  */
-#include "iperf_config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -43,6 +41,12 @@
 #include "iperf_tcp.h"
 #include "net.h"
 #include "cjson.h"
+
+#if defined(HAVE_INTTYPES_H)
+# include <inttypes.h>
+#else
+# define PRIu64		"llu"
+#endif
 
 #if defined(HAVE_FLOWLABEL)
 #include "flowlabel.h"
@@ -90,7 +94,7 @@ iperf_tcp_send(struct iperf_stream *sp)
     sp->result->bytes_sent_this_interval += r;
 
     if (sp->test->debug)
-	printf("sent %d bytes of %d, total %llu\n", r, sp->settings->blksize, sp->result->bytes_sent);
+	printf("sent %d bytes of %d, total %" PRIu64 "\n", r, sp->settings->blksize, sp->result->bytes_sent);
 
     return r;
 }

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -48,6 +48,12 @@
 #include "cjson.h"
 #include "portable_endian.h"
 
+#if defined(HAVE_INTTYPES_H)
+# include <inttypes.h>
+#else
+# define PRIu64		"llu"
+#endif
+
 /* iperf_udp_recv
  *
  * receives the data for UDP
@@ -98,7 +104,7 @@ iperf_udp_recv(struct iperf_stream *sp)
     }
 
     if (sp->test->debug)
-	fprintf(stderr, "pcount %llu packet_count %d\n", pcount, sp->packet_count);
+	fprintf(stderr, "pcount %" PRIu64 " packet_count %d\n", pcount, sp->packet_count);
 
     /*
      * Try to handle out of order packets.  The way we do this
@@ -141,7 +147,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 	
 	/* Log the out-of-order packet */
 	if (sp->test->debug) 
-	    fprintf(stderr, "OUT OF ORDER - incoming packet sequence %llu but expected sequence %d on stream %d", pcount, sp->packet_count, sp->socket);
+	    fprintf(stderr, "OUT OF ORDER - incoming packet sequence %" PRIu64 " but expected sequence %d on stream %d", pcount, sp->packet_count, sp->socket);
     }
 
     /*
@@ -220,7 +226,7 @@ iperf_udp_send(struct iperf_stream *sp)
     sp->result->bytes_sent_this_interval += r;
 
     if (sp->test->debug)
-	printf("sent %d bytes of %d, total %llu\n", r, sp->settings->blksize, sp->result->bytes_sent);
+	printf("sent %d bytes of %d, total %" PRIu64 "\n", r, sp->settings->blksize, sp->result->bytes_sent);
 
     return r;
 }

--- a/src/net.c
+++ b/src/net.c
@@ -31,13 +31,12 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <sys/types.h>
-#include <sys/errno.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <assert.h>
 #include <netdb.h>
 #include <string.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 
 #ifdef HAVE_SENDFILE
 #ifdef linux

--- a/src/portable_endian.h
+++ b/src/portable_endian.h
@@ -10,17 +10,36 @@
 
 #endif
 
-// GLIBC / Linux with endian(3) support, which was added in glibc 2.9.
-// Intended to support CentOS 6 and newer.
-#if defined(__linux__) && \
-    ((__GLIBC__ > 3) || \
-     (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 9))
+#if defined(__CYGWIN__)
 
 #	include <endian.h>
 
-#elif defined(__CYGWIN__)
-
+#elif defined(HAVE_ENDIAN_H)
 #	include <endian.h>
+
+#elif defined(HAVE_SYS_ENDIAN_H)
+#	include <sys/endian.h>
+
+#	if defined(__OpenBSD__)
+
+#		define be16toh(x) betoh16(x)
+#		define le16toh(x) letoh16(x)
+
+#		define be32toh(x) betoh32(x)
+#		define le32toh(x) letoh32(x)
+
+#		define be64toh(x) betoh64(x)
+#		define le64toh(x) letoh64(x)
+
+#	elif defined(__sgi)
+
+#		include <netinet/in.h>
+#		include <inttypes.h>
+
+#		define be64toh(x) (x)
+#		define htobe64(x) (x)
+
+#	endif
 
 #elif defined(__APPLE__)
 
@@ -45,32 +64,6 @@
 #	define __BIG_ENDIAN    BIG_ENDIAN
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
-
-#elif defined(__OpenBSD__)
-
-#	include <sys/endian.h>
-
-#	define be16toh(x) betoh16(x)
-#	define le16toh(x) letoh16(x)
-
-#	define be32toh(x) betoh32(x)
-#	define le32toh(x) letoh32(x)
-
-#	define be64toh(x) betoh64(x)
-#	define le64toh(x) letoh64(x)
-
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
-
-#	include <sys/endian.h>
-
-#elif defined(__sgi)
-
-#  include <sys/endian.h>
-#  include <netinet/in.h>
-#  include <inttypes.h>
-
-#  define be64toh(x) (x)
-#  define htobe64(x) (x)
 
 #elif defined(__sun) && defined(__SVR4)
 


### PR DESCRIPTION
To be applied to `master`.

Fixes compilation warnings against the MUSL library, and simplifies the detection of the correct endianness (via header file when present) without explicitly dependencies on detecting the type of C run-time being built against.

Fixes type mismatches on 64-bit machines where `size_t` or `uint64_t` values are being formatted as `%llu`.

Fixes warnings when `_GNU_SOURCE` is redefined.
