### PR TITLE
Add missing saved_errno dance around some close(2) calls.

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -53,7 +53,7 @@
 int
 iperf_create_streams(struct iperf_test *test)
 {
-    int i, s;
+    int i, s, saved_errno;
     struct iperf_stream *sp;
 
     int orig_bind_port = test->bind_port;
@@ -69,7 +69,9 @@ iperf_create_streams(struct iperf_test *test)
 	if (test->protocol->id == Ptcp) {
 	    if (test->congestion) {
 		if (setsockopt(s, IPPROTO_TCP, TCP_CONGESTION, test->congestion, strlen(test->congestion)) < 0) {
+		    saved_errno = errno;
 		    close(s);
+		    errno = saved_errno;
 		    i_errno = IESETCONGESTION;
 		    return -1;
 		} 
@@ -78,7 +80,9 @@ iperf_create_streams(struct iperf_test *test)
 		socklen_t len = TCP_CA_NAME_MAX;
 		char ca[TCP_CA_NAME_MAX + 1];
 		if (getsockopt(s, IPPROTO_TCP, TCP_CONGESTION, ca, &len) < 0) {
+		    saved_errno = errno;
 		    close(s);
+		    errno = saved_errno;
 		    i_errno = IESETCONGESTION;
 		    return -1;
 		}

--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -437,6 +437,7 @@ iperf_sctp_bindx(struct iperf_test *test, int s, int is_server)
     int nxaddrs;
     int retval;
     int domain;
+    int saved_errno;
 
     domain = test->settings->domain;
     xbe0 = NULL;

--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -152,7 +152,7 @@ iperf_sctp_listen(struct iperf_test *test)
 #if defined(HAVE_SCTP)
     struct addrinfo hints, *res;
     char portstr[6];
-    int s, opt;
+    int s, opt, saved_errno;
 
     close(test->listener);
    
@@ -180,8 +180,10 @@ iperf_sctp_listen(struct iperf_test *test)
             opt = 1;
         if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, 
 		       (char *) &opt, sizeof(opt)) < 0) {
+	    saved_errno = errno;
 	    close(s);
 	    freeaddrinfo(res);
+	    errno = saved_errno;
 	    i_errno = IEPROTOCOL;
 	    return -1;
 	}
@@ -190,8 +192,10 @@ iperf_sctp_listen(struct iperf_test *test)
 
     opt = 1;
     if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+        saved_errno = errno;
         close(s);
         freeaddrinfo(res);
+        errno = saved_errno;
         i_errno = IEREUSEADDR;
         return -1;
     }
@@ -203,8 +207,10 @@ iperf_sctp_listen(struct iperf_test *test)
             return -1;
     } else
     if (bind(s, (struct sockaddr *) res->ai_addr, res->ai_addrlen) < 0) {
+        saved_errno = errno;
         close(s);
         freeaddrinfo(res);
+        errno = saved_errno;
         i_errno = IESTREAMLISTEN;
         return -1;
     }
@@ -234,7 +240,7 @@ int
 iperf_sctp_connect(struct iperf_test *test)
 {
 #if defined(HAVE_SCTP)
-    int s, opt;
+    int s, opt, saved_errno;
     char portstr[6];
     struct addrinfo hints, *local_res, *server_res;
 
@@ -271,8 +277,10 @@ iperf_sctp_connect(struct iperf_test *test)
     if (test->no_delay != 0) {
          opt = 1;
          if (setsockopt(s, IPPROTO_SCTP, SCTP_NODELAY, &opt, sizeof(opt)) < 0) {
+             saved_errno = errno;
              close(s);
              freeaddrinfo(server_res);
+             errno = saved_errno;
              i_errno = IESETNODELAY;
              return -1;
          }
@@ -302,8 +310,10 @@ iperf_sctp_connect(struct iperf_test *test)
         av.assoc_value = test->settings->mss;
 
         if (setsockopt(s, IPPROTO_SCTP, SCTP_MAXSEG, &av, sizeof(av)) < 0) {
+            saved_errno = errno;
             close(s);
             freeaddrinfo(server_res);
+            errno = saved_errno;
             i_errno = IESETMSS;
             return -1;
         }
@@ -316,8 +326,10 @@ iperf_sctp_connect(struct iperf_test *test)
 	 */
         if (setsockopt(s, IPPROTO_SCTP, SCTP_MAXSEG, &opt, sizeof(opt)) < 0 &&
 	    errno != ENOPROTOOPT) {
+            saved_errno = errno;
             close(s);
             freeaddrinfo(server_res);
+            errno = saved_errno;
             i_errno = IESETMSS;
             return -1;
         }
@@ -331,8 +343,10 @@ iperf_sctp_connect(struct iperf_test *test)
         initmsg.sinit_num_ostreams = test->settings->num_ostreams;
 
         if (setsockopt(s, IPPROTO_SCTP, SCTP_INITMSG, &initmsg, sizeof(struct sctp_initmsg)) < 0) {
+                saved_errno = errno;
                 close(s);
                 freeaddrinfo(server_res);
+                errno = saved_errno;
                 i_errno = IESETSCTPNSTREAM;
                 return -1;
         }
@@ -346,8 +360,10 @@ iperf_sctp_connect(struct iperf_test *test)
 
     /* TODO support sctp_connectx() to avoid heartbeating. */
     if (connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen) < 0 && errno != EINPROGRESS) {
+	saved_errno = errno;
 	close(s);
 	freeaddrinfo(server_res);
+	errno = saved_errno;
         i_errno = IESTREAMCONNECT;
         return -1;
     }
@@ -355,7 +371,9 @@ iperf_sctp_connect(struct iperf_test *test)
 
     /* Send cookie for verification */
     if (Nwrite(s, test->cookie, COOKIE_SIZE, Psctp) < 0) {
+	saved_errno = errno;
 	close(s);
+	errno = saved_errno;
         i_errno = IESENDCOOKIE;
         return -1;
     }
@@ -370,8 +388,10 @@ iperf_sctp_connect(struct iperf_test *test)
     opt = 0;
     if (setsockopt(s, IPPROTO_SCTP, SCTP_DISABLE_FRAGMENTS, &opt, sizeof(opt)) < 0 &&
 	errno != ENOPROTOOPT) {
+        saved_errno = errno;
         close(s);
         freeaddrinfo(server_res);
+        errno = saved_errno;
         i_errno = IESETSCTPDISABLEFRAG;
         return -1;
     }
@@ -525,8 +545,10 @@ iperf_sctp_bindx(struct iperf_test *test, int s, int is_server)
     }
 
     if (sctp_bindx(s, xaddrs, nxaddrs, SCTP_BINDX_ADD_ADDR) == -1) {
+        saved_errno = errno;
         close(s);
         free(xaddrs);
+        errno = saved_errno;
         i_errno = IESETSCTPBINDX;
         retval = -1;
         goto out;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -450,7 +450,7 @@ cleanup_server(struct iperf_test *test)
 int
 iperf_run_server(struct iperf_test *test)
 {
-    int result, s, streams_accepted;
+    int result, s, streams_accepted, saved_errno;
     fd_set read_set, write_set;
     struct iperf_stream *sp;
     struct timeval now;
@@ -541,8 +541,10 @@ iperf_run_server(struct iperf_test *test)
 				    warning("TCP congestion control algorithm not supported");
 				}
 				else {
+				    saved_errno = errno;
 				    close(s);
 				    cleanup_server(test);
+				    errno = saved_errno;
 				    i_errno = IESETCONGESTION;
 				    return -1;
 				}
@@ -552,8 +554,10 @@ iperf_run_server(struct iperf_test *test)
 			    socklen_t len = TCP_CA_NAME_MAX;
 			    char ca[TCP_CA_NAME_MAX + 1];
 			    if (getsockopt(s, IPPROTO_TCP, TCP_CONGESTION, ca, &len) < 0) {
+				saved_errno = errno;
 				close(s);
 				cleanup_server(test);
+				errno = saved_errno;
 				i_errno = IESETCONGESTION;
 				return -1;
 			    }


### PR DESCRIPTION
Many of the close() calls in the error path preserve the original errno of the failed system call but not all.  This commit preserves the original errno around calls to close() and freeaddrinfo() so that things like iperf_strerror() will report the correct error string.