### PR TITLE
Make help and manpage a bit clearer about TOS values

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -298,7 +298,8 @@ set the IP type of service. The usual prefixes for octal and hex can be used,
 i.e. 52, 064 and 0x34 all specify the same value.
 .TP
 .BR "--dscp " \fIdscp\fR
-set the IP DSCP bits.  Both numeric and symbolic values are accepted.
+set the IP DSCP bits.  Both numeric and symbolic values are accepted. Numeric
+values can be specified in decimal, octal and hex (see --tos above).
 .TP
 .BR -L ", " --flowlabel " \fIn\fR"
 set the IPv6 flow label (currently only supported on Linux)

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -294,7 +294,8 @@ only use IPv4
 only use IPv6
 .TP
 .BR -S ", " --tos " \fIn\fR"
-set the IP type of service
+set the IP type of service. The usual prefixes for octal and hex can be used,
+i.e. 52, 064 and 0x34 all specify the same value.
 .TP
 .BR "--dscp " \fIdscp\fR
 set the IP DSCP bits.  Both numeric and symbolic values are accepted.

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -156,7 +156,10 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -N, --no-delay            set TCP/SCTP no delay, disabling Nagle's Algorithm\n"
                            "  -4, --version4            only use IPv4\n"
                            "  -6, --version6            only use IPv6\n"
-                           "  -S, --tos N               set the IP type of service, 0-255\n"
+                           "  -S, --tos N               set the IP type of service, 0-255.\n"
+                           "                            The usual prefixes for octal and hex can be used,\n"
+                           "                            i.e. 52, 064 and 0x34 all specify the same value.\n"
+
                            "  --dscp N or --dscp val    set the IP dscp value, either 0-63 or symbolic\n"
 #if defined(HAVE_FLOWLABEL)
                            "  -L, --flowlabel N         set the IPv6 flow label (only supported on Linux)\n"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -160,7 +160,9 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "                            The usual prefixes for octal and hex can be used,\n"
                            "                            i.e. 52, 064 and 0x34 all specify the same value.\n"
 
-                           "  --dscp N or --dscp val    set the IP dscp value, either 0-63 or symbolic\n"
+                           "  --dscp N or --dscp val    set the IP dscp value, either 0-63 or symbolic.\n"
+                           "                            Numeric values can be specified in decimal,\n"
+                           "                            octal and hex (see --tos above).\n"
 #if defined(HAVE_FLOWLABEL)
                            "  -L, --flowlabel N         set the IPv6 flow label (only supported on Linux)\n"
 #endif /* HAVE_FLOWLABEL */


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

master

* Brief description of code changes (suitable for use as a commit message):

Make help and manpage a bit clearler about TOS values on the cmdline

Since iperf3 uses strtol() to parse these values, the user can specify
them with 0 prefix for octals and 0x for hex values.

