### PR TITLE
Fix some compile-time warnings on macOS

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -46,6 +46,18 @@
 #include <sys/cpuset.h>
 #endif /* HAVE_CPUSET_SETAFFINITY */
 
+#if defined(HAVE_INTTYPES_H)
+# include <inttypes.h>
+#else
+# ifndef PRIu64
+#  if sizeof(long) == 8
+#   define PRIu64		"lu"
+#  else
+#   define PRIu64		"llu"
+#  endif
+# endif
+#endif
+
 #include "timer.h"
 #include "queue.h"
 #include "cjson.h"

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -85,6 +85,12 @@
 #include "iperf_auth.h"
 #endif /* HAVE_SSL */
 
+#if defined(HAVE_INTTYPES_H)
+# include <inttypes.h>
+#else
+# define PRIu64		"llu"
+#endif
+
 /* Forwards. */
 static int send_parameters(struct iperf_test *test);
 static int get_parameters(struct iperf_test *test);
@@ -2486,7 +2492,7 @@ iperf_print_intermediate(struct iperf_test *test)
 	    double interval_len = timeval_diff(&irp->interval_start_time,
 					       &irp->interval_end_time);
 	    if (test->debug) {
-		printf("interval_len %f bytes_transferred %lu\n", interval_len, irp->bytes_transferred);
+		printf("interval_len %f bytes_transferred %" PRIu64 "\n", interval_len, irp->bytes_transferred);
 	    }
 
 	    /*

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -85,12 +85,6 @@
 #include "iperf_auth.h"
 #endif /* HAVE_SSL */
 
-#if defined(HAVE_INTTYPES_H)
-# include <inttypes.h>
-#else
-# define PRIu64		"llu"
-#endif
-
 /* Forwards. */
 static int send_parameters(struct iperf_test *test);
 static int get_parameters(struct iperf_test *test);

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -53,7 +53,10 @@
 int
 iperf_create_streams(struct iperf_test *test)
 {
-    int i, s, saved_errno;
+    int i, s;
+#if defined(HAVE_TCP_CONGESTION)
+    int saved_errno;
+#endif /* HAVE_TCP_CONGESTION */
     struct iperf_stream *sp;
 
     int orig_bind_port = test->bind_port;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -385,7 +385,10 @@ cleanup_server(struct iperf_test *test)
 int
 iperf_run_server(struct iperf_test *test)
 {
-    int result, s, streams_accepted, saved_errno;
+    int result, s, streams_accepted;
+#if defined(HAVE_TCP_CONGESTION)
+    int saved_errno;
+#endif /* HAVE_TCP_CONGESTION */
     fd_set read_set, write_set;
     struct iperf_stream *sp;
     struct timeval now;

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -42,12 +42,6 @@
 #include "net.h"
 #include "cjson.h"
 
-#if defined(HAVE_INTTYPES_H)
-# include <inttypes.h>
-#else
-# define PRIu64		"llu"
-#endif
-
 #if defined(HAVE_FLOWLABEL)
 #include "flowlabel.h"
 #endif /* HAVE_FLOWLABEL */


### PR DESCRIPTION
* Attempt to quiet a warning with print(3) formatting.  As a part of this, factor out PRIu64 support / compatibility (added in #664) into a header file and make it more portable by taking into account the size of a long integer.  Based on email conversation with:  @pprindeville.

* Follow-up to pull request #669, fixing compiler warnings on platforms that don't have HAVE_TCP_CONGESTION defined.

 