### PR TITLE
Fix regression that caused client to close control connection prematurely

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2017, The Regents of the University of
+ * iperf, Copyright (c) 2014-2018, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -425,12 +425,12 @@ iperf_client_end(struct iperf_test *test)
     /* show final summary */
     test->reporter_callback(test);
 
+    if (iperf_set_send_state(test, IPERF_DONE) != 0)
+        return -1;
+
     /* Close control socket */
     if (test->ctrl_sck)
         close(test->ctrl_sck);
-
-    if (iperf_set_send_state(test, IPERF_DONE) != 0)
-        return -1;
 
     return 0;
 }


### PR DESCRIPTION
The user-visible symptom was messages of the following form on the
server:

iperf3: the client has unexpectedly closed the connection

This bug was introduced in #597 and was present in iperf 3.2 and 3.3.

Fixes #677.

