### PR TITLE
Fix large values of -p on FreeBSD by setting a large listen(2) backlog.

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014, 2015, 2017, The Regents of the University of
+ * iperf, Copyright (c) 2014-2018, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -37,6 +37,7 @@
 #include <netdb.h>
 #include <string.h>
 #include <fcntl.h>
+#include <limits.h>
 
 #ifdef HAVE_SENDFILE
 #ifdef linux
@@ -256,7 +257,7 @@ netannounce(int domain, int proto, char *local, int port)
     freeaddrinfo(res);
     
     if (proto == SOCK_STREAM) {
-        if (listen(s, 5) < 0) {
+        if (listen(s, INT_MAX) < 0) {
 	    saved_errno = errno;
 	    close(s);
 	    errno = saved_errno;


### PR DESCRIPTION
Might be useful for other platforms as well (no effects on Linux
because the semantics of listen(2) are subtly different there).
Submitted by Matt Macy.  Fixes #691.
