### PR TITLE
Fix a server-side crash with --verbose and a client with multiple con…

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2017, The Regents of the University of
+ * iperf, Copyright (c) 2014-2018, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -2879,7 +2879,7 @@ iperf_print_results(struct iperf_test *test)
 		else
 		    if (test->role == 's' && !test->sender) {
 		        if (test->verbose)
-			    iperf_printf(test, report_sender_not_available_format, sp->socket);
+			    iperf_printf(test, report_sender_not_available_summary_format, "SUM");
 		    }
 		    else {
 		      iperf_printf(test, report_sum_bw_retrans_format, start_time, sender_time, ubuf, nbuf, total_retransmits, report_sender);
@@ -2891,7 +2891,7 @@ iperf_print_results(struct iperf_test *test)
 		else
 		    if (test->role == 's' && !test->sender) {
 		        if (test->verbose) 
-			    iperf_printf(test, report_sender_not_available_format, sp->socket);
+			    iperf_printf(test, report_sender_not_available_summary_format, "SUM");
 		    }
 		    else {
 		        iperf_printf(test, report_sum_bw_format, start_time, sender_time, ubuf, nbuf, report_sender);

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -1,5 +1,5 @@
 /*--------------------------------------------------------------- 
- * iperf, Copyright (c) 2014, 2016, 2017, The Regents of the University of
+ * iperf, Copyright (c) 2014-2018, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -391,6 +391,7 @@ const char report_remote[] = "remote";
 const char report_sender[] = "sender";
 const char report_receiver[] = "receiver";
 const char report_sender_not_available_format[] = "[%3d] (sender statistics not available)\n";
+const char report_sender_not_available_summary_format[] = "[%3s] (sender statistics not available)\n";
 const char report_receiver_not_available_format[] = "[%3d] (receiver statistics not available)\n";
 
 #if defined(linux)

--- a/src/iperf_locale.h
+++ b/src/iperf_locale.h
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014, 2017, The Regents of the University of
+ * iperf, Copyright (c) 2014-2018, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -96,6 +96,7 @@ extern const char report_remote[] ;
 extern const char report_sender[] ;
 extern const char report_receiver[] ;
 extern const char report_sender_not_available_format[];
+extern const char report_sender_not_available_summary_format[];
 extern const char report_receiver_not_available_format[];
 
 extern const char report_tcpInfo[] ;


### PR DESCRIPTION
…nections.

This was caused by a stale / invalid pointer reference that didn't even
make any sense in context anyway.  Fixes #686.

