### PR TITLE
Change the wording on bind parameter documentation for clarity

### DIFF
--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -156,8 +156,9 @@ the executable.
                  potentialy multiple CPUs).
    
           -B, --bind host
-                 bind to a specific interface. If the host  has  multiple  inter-
-                 faces, it will use the first interface by default.
+                 bind  to the specific interface  associated with address <host>.
+                 If the host  has  multiple  interfaces, it  will use  the  first
+                 interface by default.
    
           -V, --verbose
                  give more detailed output

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -138,7 +138,9 @@ to a single CPU (as opposed to a set containing potentialy multiple
 CPUs).
 .TP
 .BR -B ", " --bind " \fIhost\fR"
-bind to a specific interface. If the host has multiple interfaces, it will use the first interface by default.
+bind to the specific interface associated with address \fIhost\fR.
+If the host has multiple interfaces, it will use the first interface
+by default.
 .TP
 .BR -V ", " --verbose " "
 give more detailed output 

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -104,7 +104,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #if defined(HAVE_CPU_AFFINITY)
                            "  -A, --affinity n/n,m      set CPU affinity\n"
 #endif /* HAVE_CPU_AFFINITY */
-                           "  -B, --bind      <host>    bind to a specific interface\n"
+                           "  -B, --bind      <host>    bind to the interface associated with the address <host>\n"
                            "  -V, --verbose             more detailed output\n"
                            "  -J, --json                output in JSON format\n"
                            "  --logfile f               send output to a log file\n"


### PR DESCRIPTION
Changed wording for the bind `--bind/-B ` command to improve clarity/readability to make it obvious that host is an address