### PR TITLE
Issue #712 - Auth support on libiperf

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -62,6 +62,10 @@
 #include "queue.h"
 #include "cjson.h"
 
+#if defined(HAVE_SSL)
+#include <openssl/bio.h>
+#endif // HAVE_SSL
+
 typedef uint64_t iperf_size_t;
 
 struct iperf_interval_results
@@ -141,7 +145,12 @@ struct iperf_settings
     iperf_size_t blocks;            /* number of blocks (packets) to send */
     char      unit_format;          /* -f */
     int       num_ostreams;         /* SCTP initmsg settings */
+#if defined(HAVE_SSL)
     char      *authtoken;           /* Authentication token */
+    char      *client_username;
+    char      *client_password;
+    EVP_PKEY  *client_rsa_pubkey;
+#endif // HAVE_SSL
     int	      connect_timeout;	    /* socket connection timeout, in ms */
 };
 
@@ -257,8 +266,11 @@ struct iperf_test
     int       prot_listener;
 
     int	      ctrl_sck_mss;			/* MSS for the control channel */
-    char     *server_rsa_private_key;
-    char     *server_authorized_users;
+
+#if defined(HAVE_SSL)
+    char      *server_authorized_users;
+    EVP_PKEY  *server_rsa_private_key;
+#endif // HAVE_SSL
 
     /* boolean variables for Options */
     int       daemon;                           /* -D option */

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -64,6 +64,7 @@
 
 #if defined(HAVE_SSL)
 #include <openssl/bio.h>
+#include <openssl/evp.h>
 #endif // HAVE_SSL
 
 typedef uint64_t iperf_size_t;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -142,6 +142,12 @@ void	iperf_set_test_bind_address( struct iperf_test* ipt, char *bind_address );
 void	iperf_set_test_udp_counters_64bit( struct iperf_test* ipt, int udp_counters_64bit );
 void	iperf_set_test_one_off( struct iperf_test* ipt, int one_off );
 
+#if defined(HAVE_SSL)
+void    iperf_set_test_client_username(struct iperf_test *ipt, char *client_username);
+void    iperf_set_test_client_password(struct iperf_test *ipt, char *client_password);
+void    iperf_set_test_client_rsa_pubkey(struct iperf_test *ipt, char *client_rsa_pubkey_base64);
+#endif // HAVE_SSL
+
 /**
  * exchange_parameters - handles the param_Exchange part for client
  *

--- a/src/iperf_auth.h
+++ b/src/iperf_auth.h
@@ -27,10 +27,14 @@
 
 #include <time.h>
 #include <sys/types.h>
+#include <openssl/bio.h>
 
-int test_load_pubkey(const char *public_keyfile);
-int test_load_private_key(const char *private_keyfile);
-int encode_auth_setting(const char *username, const char *password, const char *public_keyfile, char **authtoken);
-int decode_auth_setting(int enable_debug, const char *authtoken, const char *private_keyfile, char **username, char **password, time_t *ts);
+int test_load_pubkey_from_file(const char *public_keyfile);
+int test_load_private_key_from_file(const char *private_keyfile);
+EVP_PKEY *load_pubkey_from_file(const char *file);
+EVP_PKEY *load_pubkey_from_base64(const char *buffer);
+EVP_PKEY *load_privkey_from_file(const char *file);
+int encode_auth_setting(const char *username, const char *password, EVP_PKEY *public_key, char **authtoken);
+int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *private_key, char **username, char **password, time_t *ts);
 int check_authentication(const char *username, const char *password, const time_t ts, const char *filename);
 ssize_t iperf_getpass (char **lineptr, size_t *n, FILE *stream);


### PR DESCRIPTION
Added the following methods on libiperf as requested on #712 
```
iperf_set_test_client_username(struct iperf_test *ipt, char *client_username)
iperf_set_test_client_password(struct iperf_test *ipt, char *client_password)
iperf_set_test_client_rsa_pubkey(struct iperf_test *ipt, char *client_rsa_pubkey_base64)
```

* A small refactor was needed
* A direct feedback is requested on the iperf_reset_test behaviour. In the previous implementation is obvious that authtoken must be reset: but what about username, password and publickey setup? I supposed to reset them accordingly.

