### PR TITLE
Add warning if JSON output is used with explicit report format

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1177,6 +1177,11 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         return -1;
     }
 
+    /* Show warning if JSON output is used with explicit report format */
+    if ((test->json_output) && (test->settings->unit_format != 'a')) {
+        warning("Report format'-f' is ignored within JSON output '-J'\n");
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): 709

* Brief description of code changes (suitable for use as a commit message): Add warning if JSON output option '-J' is used with explicit report format '-f'
