### PR TITLE
Add --repeating-pattern-payload option to the client side

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -273,6 +273,7 @@ struct iperf_test
     int	      udp_counters_64bit;		/* --use-64-bit-udp-counters */
     int       forceflush; /* --forceflush - flushing output at every interval */
     int	      multisend;
+    int	      repeating_payload;                /* --repeating-payload */
 
     char     *json_output_string; /* rendered JSON output if json_output is set */
     /* Select related parameters */

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -350,6 +350,13 @@ If the client is run with \fB--json\fR, the server output is included
 in a JSON object; otherwise it is appended at the bottom of the
 human-readable output.
 .TP
+.BR --repeating-payload
+Use repeating pattern in payload, instead of random bytes.
+The same payload is used in iperf2 (ASCII '0..9' repeating).
+It might help to test and reveal problems in networking gear with hardware
+compression (including some WiFi access points), where iperf2 and iperf3
+perform differently, just based on payload entropy.
+.TP
 .BR --username " \fIusername\fR" 
 username to use for authentication to the iperf server (if built with
 OpenSSL support).

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -68,6 +68,7 @@ struct iperf_stream;
 #define OPT_SERVER_AUTHORIZED_USERS 15
 #define OPT_PACING_TIMER 16
 #define OPT_CONNECT_TIMEOUT 17
+#define OPT_REPEATING_PAYLOAD 18
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -171,6 +171,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -T, --title str           prefix every output line with this string\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
+                           "  --repeating-payload       use repeating pattern in payload, instead of\n"
+                           "                            randomized payload (like in iperf2)\n"
 #if defined(HAVE_SSL)
                            "  --username                username for authentication\n"
                            "  --rsa-public-key-path     path to the RSA public key used to encrypt\n"

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -79,6 +79,27 @@ int readentropy(void *out, size_t outsize)
 }
 
 
+/*
+ * Fills buffer with repeating pattern (similar to pattern that used in iperf2)
+ */
+void fill_with_repeating_pattern(void *out, size_t outsize)
+{
+    size_t i;
+    int counter = 0;
+    char *buf = (char *)out;
+
+    if (!outsize) return;
+
+    for (i = 0; i < outsize; i++) {
+        buf[i] = (char)('0' + counter);
+        if (counter >= 9)
+            counter = 0;
+        else
+            counter++;
+    }
+}
+
+
 /* make_cookie
  *
  * Generate and return a cookie string

--- a/src/iperf_util.h
+++ b/src/iperf_util.h
@@ -34,6 +34,8 @@
 
 int readentropy(void *out, size_t outsize);
 
+void fill_with_repeating_pattern(void *out, size_t outsize);
+
 void make_cookie(char *);
 
 int is_closed(int);


### PR DESCRIPTION
This option simulates payload in iperf2, which is just repetitive pattern, as
opposed to iperf3 where payload is random.
It might help in testing and reveal problems in networking gear with hardware
compression (including WiFi access points), where iperf2 and iperf3 perform
differently, just based on payload entropy.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

