### PR TITLE
Now the it can output a valid JSON string.

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -363,8 +363,9 @@ iperf_connect(struct iperf_test *test)
 		}
 	}
 
-    if (test->verbose) {
-	printf("Control connection MSS %d\n", test->ctrl_sck_mss);
+    // Now it will not print control connection message when using JSON output
+    if (test->verbose && !test->json_output) {
+	    printf("Control connection MSS %d\n", test->ctrl_sck_mss);
     }
 
     /*

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -105,7 +105,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -A, --affinity n/n,m      set CPU affinity\n"
 #endif /* HAVE_CPU_AFFINITY */
                            "  -B, --bind      <host>    bind to the interface associated with the address <host>\n"
-                           "  -V, --verbose             more detailed output\n"
+                           "  -V, --verbose             more detailed output, turned off when using JSON output(-J)\n"
                            "  -J, --json                output in JSON format\n"
                            "  --logfile f               send output to a log file\n"
                            "  --forceflush              force flushing output at every interval\n"


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

Merge to branch master.

* Issues fixed (if any):

NO.

* Brief description of code changes (suitable for use as a commit message):

No it can output an valid JSON string when using '-J' and '-V' at the same time.

Current version of iperf3 will ouput the string: 'Control connection MSS ...'  when using JSON output at client side. When users redirect the output to a JSON file, by using command such as 'iperf3 -c 127.0.0.1 -J -V 1> sample.json', and parse the sample.json later, it failed because that string is unparseable. Therefore, I added an condiction at the 'if' to judge whether it is using JSON output before printing verbose output. Moreover, I also modified the help information to clearify it.
