### PR TITLE
configure flag (--disable-profiling) to disable creation of iperf3_profile binary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,13 @@ if test "x$GCC" = "xyes"; then
   CFLAGS="$CFLAGS -Wall"
 fi
 
+# Check if profiling must be disabled
+AC_ARG_ENABLE([profiling],
+    AS_HELP_STRING([--disable-profiling], [Disable iperf profiling binary]),
+    [:],
+    [enable_profiling=yes])
+AM_CONDITIONAL([ENABLE_PROFILING], [test x$enable_profiling = xyes])
+
 # Checks for header files.
 AC_HEADER_STDC
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,11 @@
 lib_LTLIBRARIES         = libiperf.la                                   # Build and install an iperf library
 bin_PROGRAMS            = iperf3                                        # Build and install an iperf binary
+if ENABLE_PROFILING
 noinst_PROGRAMS         = t_timer t_units t_uuid iperf3_profile         # Build, but don't install the test programs and a profiled version of iperf3
-include_HEADERS         = iperf_api.h # Defines the headers that get installed with the program
+else
+noinst_PROGRAMS         = t_timer t_units t_uuid                        # Build, but don't install the test programs 
+endif
+include_HEADERS         = iperf_api.h                                   # Defines the headers that get installed with the program
 
 
 # Specify the source files and flags for the iperf library
@@ -15,7 +19,7 @@ libiperf_la_SOURCES     = \
                         iperf_error.c \
                         iperf_auth.h \
                         iperf_auth.c \
-			iperf_client_api.c \
+                        iperf_client_api.c \
                         iperf_locale.c \
                         iperf_locale.h \
                         iperf_server_api.c \
@@ -23,14 +27,14 @@ libiperf_la_SOURCES     = \
                         iperf_tcp.h \
                         iperf_udp.c \
                         iperf_udp.h \
-			iperf_sctp.c \
-	                iperf_sctp.h \
+                        iperf_sctp.c \
+                        iperf_sctp.h \
                         iperf_util.c \
                         iperf_util.h \
-			dscp.c \
+                        dscp.c \
                         net.c \
                         net.h \
-			portable_endian.h \
+                        portable_endian.h \
                         queue.h \
                         tcp_info.c \
                         timer.c \
@@ -45,14 +49,17 @@ iperf3_CFLAGS           = -g
 iperf3_LDADD            = libiperf.la
 iperf3_LDFLAGS          = -g
 
+if ENABLE_PROFILING
+# If the iperf-profiled-binary is enabled (and this condition is true by default)
 # Specify the sources and various flags for the profiled iperf binary. This
 # binary recompiles all the source files to make sure they are all profiled.
 iperf3_profile_SOURCES  = main.c \
-						  $(libiperf_la_SOURCES)
+                          $(libiperf_la_SOURCES)
 
 iperf3_profile_CFLAGS   = -pg -g
 iperf3_profile_LDADD    = libiperf.la
 iperf3_profile_LDFLAGS  = -pg -g
+endif
 
 # Specify the sources and various flags for the test cases
 t_timer_SOURCES         = t_timer.c


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #749 

* Brief description of code changes (suitable for use as a commit message):
Provide a command line option with the configure script to disable creation of the iperf3_profile binary. (--disable-profiling)
This holds only the changes in configure.ac and Makefile.am. From what @bmah888 said on #760, after merging bootstrap.sh will be rerun to regenerate the Makefile.in, etc. files.

This is the reworked version of PR https://github.com/esnet/iperf/pull/760 
