### PR TITLE
Autotools: Move the automake "foreign" directive from bootstrap.sh to configure.ac

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -49,6 +49,6 @@ set -x
 $libtoolize --copy --force --automake
 aclocal -I config
 autoheader
-automake --foreign --add-missing --copy
+automake --add-missing --copy
 autoconf
 rm -rf config.cache

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_CONFIG_AUX_DIR(config)
 
 
 # Initialize the automake system
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([foreign])
 AM_MAINTAINER_MODE
 AM_CONFIG_HEADER(src/iperf_config.h)
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #764

* Brief description of code changes (suitable for use as a commit message):
Moved the "foreign" Automake flavor directive from bootstrap.sh to configure.ac.
