### PR TITLE
Issue 595

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ src/iperf3_profile
 src/t_timer
 src/t_units
 src/t_uuid
+src/t_api
 examples/.libs
 examples/Makefile
 examples/mic

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,9 @@
 lib_LTLIBRARIES         = libiperf.la                                   # Build and install an iperf library
 bin_PROGRAMS            = iperf3                                        # Build and install an iperf binary
 if ENABLE_PROFILING
-noinst_PROGRAMS         = t_timer t_units t_uuid iperf3_profile         # Build, but don't install the test programs and a profiled version of iperf3
+noinst_PROGRAMS         = t_timer t_units t_uuid t_api iperf3_profile   # Build, but don't install the test programs and a profiled version of iperf3
 else
-noinst_PROGRAMS         = t_timer t_units t_uuid                        # Build, but don't install the test programs 
+noinst_PROGRAMS         = t_timer t_units t_uuid t_api                  # Build, but don't install the test programs
 endif
 include_HEADERS         = iperf_api.h                                   # Defines the headers that get installed with the program
 
@@ -77,6 +77,10 @@ t_uuid_CFLAGS           = -g
 t_uuid_LDFLAGS          =
 t_uuid_LDADD            = libiperf.la
 
+t_api_SOURCES           = t_api.c
+t_api_CFLAGS            = -g
+t_api_LDFLAGS           =
+t_api_LDADD             = libiperf.la
 
 
 
@@ -84,6 +88,7 @@ t_uuid_LDADD            = libiperf.la
 TESTS                   = \
                         t_timer \
                         t_units \
-                        t_uuid
+                        t_uuid  \
+                        t_api
 
 dist_man_MANS          = iperf3.1 libiperf.3

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -321,6 +321,13 @@ iperf_get_test_extra_data(struct iperf_test *ipt)
     return ipt->extra_data;
 }
 
+static const char iperf_version[] = IPERF_VERSION;
+char *
+iperf_get_iperf_version(void)
+{
+    return (char*)iperf_version;
+}
+
 /************** Setter routines for some fields inside iperf_test *************/
 
 void

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -122,6 +122,7 @@ int	iperf_get_test_udp_counters_64bit( struct iperf_test* ipt );
 int	iperf_get_test_one_off( struct iperf_test* ipt );
 int iperf_get_test_tos( struct iperf_test* ipt );
 char*	iperf_get_extra_data( struct iperf_test* ipt );
+char*	iperf_get_iperf_version(void);
 
 /* Setter routines for some fields inside iperf_test. */
 void	iperf_set_verbose( struct iperf_test* ipt, int verbose );

--- a/src/t_api.c
+++ b/src/t_api.c
@@ -1,0 +1,53 @@
+/*
+ * iperf, Copyright (c) 2017, The Regents of the University of
+ * California, through Lawrence Berkeley National Laboratory (subject
+ * to receipt of any required approvals from the U.S. Dept. of
+ * Energy).  All rights reserved.
+ *
+ * If you have questions about your rights to use or distribute this
+ * software, please contact Berkeley Lab's Technology Transfer
+ * Department at TTD@lbl.gov.
+ *
+ * NOTICE.  This software is owned by the U.S. Department of Energy.
+ * As such, the U.S. Government has been granted for itself and others
+ * acting on its behalf a paid-up, nonexclusive, irrevocable,
+ * worldwide license in the Software to reproduce, prepare derivative
+ * works, and perform publicly and display publicly.  Beginning five
+ * (5) years after the date permission to assert copyright is obtained
+ * from the U.S. Department of Energy, and subject to any subsequent
+ * five (5) year renewals, the U.S. Government is granted for itself
+ * and others acting on its behalf a paid-up, nonexclusive,
+ * irrevocable, worldwide license in the Software to reproduce,
+ * prepare derivative works, distribute copies to the public, perform
+ * publicly and display publicly, and to permit others to do so.
+ *
+ * This code is distributed under a BSD style license, see the LICENSE
+ * file for complete information.
+ */
+
+
+#include <assert.h>
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#include <stdio.h>
+#include <string.h>
+
+#include "iperf.h"
+#include "iperf_api.h"
+
+#include "version.h"
+
+#include "units.h"
+
+
+int
+main(int argc, char **argv)
+{
+    const char *ver;
+
+    ver = iperf_get_iperf_version();
+    assert(strcmp(ver, IPERF_VERSION) == 0);
+
+    return 0;
+}


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): partially addresses #595 

* Brief description of code changes (suitable for use as a commit message): Add libiperf api for getting iperf version 

### Notes
* The extended version info (CJSON, system info, et al) is not present with this API.
* Makefile.am has changes to account for a new api test file. I've not added the changes to Makefile.in - per https://github.com/esnet/iperf/pull/760#issuecomment-400046932. So, this will require running the bootstrap.sh and regenerating the Makefile.in and merging before it can go into master.
If I need to 
* I've introduced a new placeholder for API tests as t_api.c - this also runs on make check. This is not really required for this simple API change, but is probably useful for housing/adding on other API check tests later.