### PR TITLE
Fixed function implementation

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -428,8 +428,10 @@ iperf_set_test_num_streams(struct iperf_test *ipt, int num_streams)
 static void
 check_sender_has_retransmits(struct iperf_test *ipt)
 {
-    if (ipt->sender && ipt->protocol->id == Ptcp)
-	ipt->sender_has_retransmits = has_tcpinfo_retransmits();
+    if (ipt->sender && ipt->protocol->id == Ptcp && has_tcpinfo_retransmits())
+	ipt->sender_has_retransmits = 1;
+    else
+	ipt->sender_has_retransmits = 0;
 }
 
 void

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2492,7 +2492,7 @@ iperf_reset_stats(struct iperf_test *test)
         rp->bytes_sent_omit = rp->bytes_sent;
         rp->bytes_received = 0;
         rp->bytes_sent_this_interval = rp->bytes_received_this_interval = 0;
-	if (test->sender && test->sender_has_retransmits) {
+	if (test->sender_has_retransmits == 1) {
 	    struct iperf_interval_results ir; /* temporary results structure */
 	    save_tcpinfo(sp, &ir);
 	    rp->stream_prev_total_retrans = get_total_retransmits(&ir);
@@ -2536,7 +2536,7 @@ iperf_stats_callback(struct iperf_test *test)
 	if (test->protocol->id == Ptcp) {
 	    if ( has_tcpinfo()) {
 		save_tcpinfo(sp, &temp);
-		if (test->sender && test->sender_has_retransmits) {
+		if (test->sender_has_retransmits == 1) {
 		    long total_retrans = get_total_retransmits(&temp);
 		    temp.interval_retrans = total_retrans - rp->stream_prev_total_retrans;
 		    rp->stream_retrans += temp.interval_retrans;
@@ -2672,7 +2672,7 @@ iperf_print_intermediate(struct iperf_test *test)
 	}
         bytes += irp->bytes_transferred;
 	if (test->protocol->id == Ptcp) {
-	    if (test->sender && test->sender_has_retransmits) {
+	    if (test->sender_has_retransmits == 1) {
 		retransmits += irp->interval_retrans;
 	    }
 	} else {
@@ -2696,7 +2696,7 @@ iperf_print_intermediate(struct iperf_test *test)
         start_time = timeval_diff(&sp->result->start_time,&irp->interval_start_time);
         end_time = timeval_diff(&sp->result->start_time,&irp->interval_end_time);
 	if (test->protocol->id == Ptcp || test->protocol->id == Psctp) {
-	    if (test->sender && test->sender_has_retransmits) {
+	    if (test->sender_has_retransmits == 1) {
 		/* Interval sum, TCP with retransmits. */
 		if (test->json_output)
 		    cJSON_AddItemToObject(json_interval, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  omitted: %b", (double) start_time, (double) end_time, (double) irp->interval_duration, (int64_t) bytes, bandwidth * 8, (int64_t) retransmits, irp->omitted)); /* XXX irp->omitted or test->omitting? */
@@ -3205,7 +3205,7 @@ print_interval_results(struct iperf_test *test, struct iperf_stream *sp, cJSON *
 	    */
 	    if (timeval_equals(&sp->result->start_time, &irp->interval_start_time)) {
 		if (test->protocol->id == Ptcp || test->protocol->id == Psctp) {
-		    if (test->sender && test->sender_has_retransmits)
+		    if (test->sender_has_retransmits == 1)
 			iperf_printf(test, "%s", report_bw_retrans_cwnd_header);
 		    else
 			iperf_printf(test, "%s", report_bw_header);
@@ -3233,7 +3233,7 @@ print_interval_results(struct iperf_test *test, struct iperf_stream *sp, cJSON *
     et = timeval_diff(&sp->result->start_time, &irp->interval_end_time);
     
     if (test->protocol->id == Ptcp || test->protocol->id == Psctp) {
-	if (test->sender && test->sender_has_retransmits) {
+	if (test->sender_has_retransmits == 1) {
 	    /* Interval, TCP with retransmits. */
 	    if (test->json_output)
 		cJSON_AddItemToArray(json_interval_streams, iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  snd_cwnd:  %d  rtt:  %d  rttvar: %d  pmtu: %d  omitted: %b", (int64_t) sp->socket, (double) st, (double) et, (double) irp->interval_duration, (int64_t) irp->bytes_transferred, bandwidth * 8, (int64_t) irp->interval_retrans, (int64_t) irp->snd_cwnd, (int64_t) irp->rtt, (int64_t) irp->rttvar, (int64_t) irp->pmtu, irp->omitted));

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -428,10 +428,8 @@ iperf_set_test_num_streams(struct iperf_test *ipt, int num_streams)
 static void
 check_sender_has_retransmits(struct iperf_test *ipt)
 {
-    if (ipt->sender && ipt->protocol->id == Ptcp && has_tcpinfo_retransmits())
-	ipt->sender_has_retransmits = 1;
-    else
-	ipt->sender_has_retransmits = 0;
+    if (ipt->sender && ipt->protocol->id == Ptcp)
+	ipt->sender_has_retransmits = has_tcpinfo_retransmits();
 }
 
 void
@@ -463,6 +461,10 @@ void
 iperf_set_test_reverse(struct iperf_test *ipt, int reverse)
 {
     ipt->reverse = reverse;
+    if (ipt->role == 'c')
+        ipt->sender = 1;
+    else
+        ipt->sender = 0;
     if (ipt->reverse)
         ipt->sender = ! ipt->sender;
     check_sender_has_retransmits(ipt);


### PR DESCRIPTION
Fixed implementation iperf_set_test_reverse.
Example of wrong behavior:
```
test->role = 'c';
iperf_set_test_reverse(test, 1);
*****
iperf_set_test_reverse(test, 1);
```
Expected value:
```
test->sender == 0;
test-> reverse == 1;
```
Current value:
```
test->sender == 1;
test-> reverse == 1;
```
------------------------------------
Also corrected unnecessary checks:
`test->sender && test->sender_has_retransmits => test->sender_has_retransmits == 1`

If !sender => ` test->sender_has_retransmits == -1`


