### PR TITLE
Fix iperf_add_stream

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3468,8 +3468,8 @@ iperf_add_stream(struct iperf_test *test, struct iperf_stream *sp)
         SLIST_INSERT_HEAD(&test->streams, sp, streams);
         sp->id = 1;
     } else {
-        // for (n = test->streams, i = 2; n->next; n = n->next, ++i);
-        i = 2;
+        // for (n = test->streams, i = 1; n->next; n = n->next, ++i);
+        i = 1;
         SLIST_FOREACH(n, &test->streams, streams) {
             prev = n;
             ++i;


### PR DESCRIPTION
The current version of function sets an incorrect id for the stream.
#### client side:
```
id: 1[  5] local 127.0.0.1 port 46520 connected to 127.0.0.1 port 5201
id: 3[  7] local 127.0.0.1 port 46522 connected to 127.0.0.1 port 5201
id: 4[  9] local 127.0.0.1 port 46524 connected to 127.0.0.1 port 5201
id: 5[ 11] local 127.0.0.1 port 46526 connected to 127.0.0.1 port 5201
id: 6[ 13] local 127.0.0.1 port 46528 connected to 127.0.0.1 port 5201
id: 7[ 15] local 127.0.0.1 port 46530 connected to 127.0.0.1 port 5201
```
#### server side:
```
id: 1[  5] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46520
id: 3[  8] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46522
id: 4[ 10] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46524
id: 5[ 12] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46526
id: 6[ 14] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46528
id: 7[ 16] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46530
```
### Fixed version
#### client side:
```
id: 1[  5] local 127.0.0.1 port 46580 connected to 127.0.0.1 port 5201
id: 2[  7] local 127.0.0.1 port 46582 connected to 127.0.0.1 port 5201
id: 3[  9] local 127.0.0.1 port 46584 connected to 127.0.0.1 port 5201
id: 4[ 11] local 127.0.0.1 port 46586 connected to 127.0.0.1 port 5201
id: 5[ 13] local 127.0.0.1 port 46588 connected to 127.0.0.1 port 5201
id: 6[ 15] local 127.0.0.1 port 46590 connected to 127.0.0.1 port 5201
```
#### server side:
```
id: 1[  5] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46580
id: 2[  8] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46582
id: 3[ 10] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46584
id: 4[ 12] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46586
id: 5[ 14] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46588
id: 6[ 16] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 46590
```

