### PR TITLE
Fix a segmentation fault in verbose mode.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3057,7 +3057,7 @@ iperf_print_results(struct iperf_test *test)
 	    else
 	        if (test->role == 's' && test->sender) {
 		    if (test->verbose) 
-		        iperf_printf(test, report_receiver_not_available_format, sp->socket);
+		        iperf_printf(test, report_receiver_not_available_summary_format, "SUM");
 		}
 		else {
 		    iperf_printf(test, report_sum_bw_format, start_time, receiver_time, ubuf, nbuf, report_receiver);

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -396,6 +396,7 @@ const char report_receiver[] = "receiver";
 const char report_sender_not_available_format[] = "[%3d] (sender statistics not available)\n";
 const char report_sender_not_available_summary_format[] = "[%3s] (sender statistics not available)\n";
 const char report_receiver_not_available_format[] = "[%3d] (receiver statistics not available)\n";
+const char report_receiver_not_available_summary_format[] = "[%3s] (receiver statistics not available)\n";
 
 #if defined(linux)
 const char report_tcpInfo[] =

--- a/src/iperf_locale.h
+++ b/src/iperf_locale.h
@@ -98,6 +98,7 @@ extern const char report_receiver[] ;
 extern const char report_sender_not_available_format[];
 extern const char report_sender_not_available_summary_format[];
 extern const char report_receiver_not_available_format[];
+extern const char report_receiver_not_available_summary_format[];
 
 extern const char report_tcpInfo[] ;
 extern const char report_tcpInfo[] ;


### PR DESCRIPTION
Porting the fix for #778 from Aquantia/iperf.
