### PR TITLE
UDP Sender and Reciever Values in Client JSON

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3246,8 +3246,18 @@ iperf_print_results(struct iperf_test *test)
                 else {
                     lost_percent = 0.0;
                 }
-                if (test->json_output)
+                if (test->json_output) {
                     cJSON_AddItemToObject(test->json_end, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f sender: %b", (double) start_time, (double) receiver_time, (double) receiver_time, (int64_t) total_sent, bandwidth * 8, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) total_packets, (double) lost_percent, stream_must_be_sender));
+                    if (test->role != 's') {
+                        cJSON_AddItemToObject(test->json_end, "sum_sender", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f", (double) start_time, (double) sender_time, (double) sender_time, (int64_t) total_sent, bandwidth * 8, (double) 0.0, (int64_t) 0, (int64_t) total_packets, (double) lost_percent));
+                        if (receiver_time > 0.0) {
+                            bandwidth = (double) total_received / (double) receiver_time;
+                        } else {
+                            bandwidth = 0.0;
+                        }
+                        cJSON_AddItemToObject(test->json_end, "sum_receiver", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f", (double) start_time, (double) receiver_time, (double) receiver_time, (int64_t) total_received, bandwidth * 8, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) receiver_total_packets, (double) lost_percent));
+                    }
+                }
                 else {
                     /*
                      * On the client we have both sender and receiver overall summary


### PR DESCRIPTION
Add udp sum_sender and sum_receiver output objects to the client JSON output.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Brief description of code changes (suitable for use as a commit message):
Write the separate UDP sender and receiver statistics to the client JSON output end object to get the detail in the JSON output that is present in the standard output.

We are aware that there are larger, more comprehensive solutions that have been discussed around the UDP JSON output, but we have found this patch to be useful for us for quite a while and thought it could be useful to others as well. 
