### PR TITLE
Increase maximum concurrent streams

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -312,6 +312,7 @@ struct iperf_test
     double remote_cpu_util[3];                     /* cpu utilization for the remote host/client - total, user, system */
 
     int       num_streams;                      /* total streams in the test (-P) */
+    int       max_streams;			/* maximum number of streams */
 
     iperf_size_t bytes_sent;
     iperf_size_t blocks_sent;
@@ -370,6 +371,5 @@ struct iperf_test
 #define MAX_TIME 86400
 #define MAX_BURST 1000
 #define MAX_MSS (9 * 1024)
-#define MAX_STREAMS 128
 
 #endif /* !__IPERF_H */

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -936,7 +936,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 break;
             case 'P':
                 test->num_streams = atoi(optarg);
-                if (test->num_streams > MAX_STREAMS) {
+                if (test->num_streams > test->max_streams) {
                     i_errno = IENUMSTREAMS;
                     return -1;
                 }
@@ -2201,6 +2201,15 @@ iperf_defaults(struct iperf_test *testp)
 
     testp->stats_interval = testp->reporter_interval = 1;
     testp->num_streams = 1;
+
+#ifdef	_SC_OPEN_MAX
+    if ((testp->max_streams = sysconf(_SC_OPEN_MAX)) >= 20) {
+	    /* Reserve for stdio, log, control sockets etc. */
+	    testp->max_streams -= 8;
+    } else
+#endif	/*_SC_OPEN_MAX*/
+
+    testp->max_streams = 128;	/* default per older version */
 
     testp->settings->domain = AF_UNSPEC;
     testp->settings->unit_format = 'a';

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3318,7 +3318,8 @@ iperf_free_stream(struct iperf_stream *sp)
 
     /* XXX: need to free interval list too! */
     munmap(sp->buffer, sp->test->settings->blksize);
-    close(sp->buffer_fd);
+    if (sp->buffer_fd >= 0)
+	close(sp->buffer_fd);
     if (sp->diskfile_fd >= 0)
 	close(sp->diskfile_fd);
     for (irp = TAILQ_FIRST(&sp->result->interval_results); irp != NULL; irp = nirp) {
@@ -3432,8 +3433,10 @@ iperf_new_stream(struct iperf_test *test, int s)
     else
         ret = readentropy(sp->buffer, test->settings->blksize);
 
+    close(sp->buffer_fd);
+    sp->buffer_fd = -1;
+
     if ((ret < 0) || (iperf_init_stream(sp, test) < 0)) {
-        close(sp->buffer_fd);
         munmap(sp->buffer, sp->test->settings->blksize);
         free(sp->result);
         free(sp);

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -313,7 +313,7 @@ enum {
     IESERVERONLY = 3,       // This option is server only
     IECLIENTONLY = 4,       // This option is client only
     IEDURATION = 5,         // test duration too long. Maximum value = %dMAX_TIME
-    IENUMSTREAMS = 6,       // Number of parallel streams too large. Maximum value = %dMAX_STREAMS
+    IENUMSTREAMS = 6,       // Number of parallel streams too large.
     IEBLOCKSIZE = 7,        // Block size too large. Maximum value = %dMAX_BLOCKSIZE
     IEBUFSIZE = 8,          // Socket buffer size too large. Maximum value = %dMAX_TCP_BUFFER
     IEINTERVAL = 9,         // Invalid report interval (min = %gMIN_INTERVAL, max = %gMAX_INTERVAL seconds)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -111,7 +111,7 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "test duration too long (maximum = %d seconds)", MAX_TIME);
             break;
         case IENUMSTREAMS:
-            snprintf(errstr, len, "number of parallel streams too large (maximum = %d)", MAX_STREAMS);
+            snprintf(errstr, len, "number of parallel streams too large");
             break;
         case IEBLOCKSIZE:
             snprintf(errstr, len, "block size too large (maximum = %d bytes)", MAX_BLOCKSIZE);


### PR DESCRIPTION
Instead of the hard-coded MAX_STREAMS macro, discover the maximum file
descriptor count available to the process, and leave some descriptors in
reserve;

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

