### PR TITLE
implement providing password via environment variable

### DIFF
--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -377,8 +377,11 @@ the executable.
           --username username
                  username to use for authentication to the iperf server (if built
                  with OpenSSL support).  The password will be prompted for inter-
-                 actively when the test is run.
-   
+                 actively when the test is run.  Note, the password to use can
+                 also be specified via the IPERF3_PASSWORD environment variable.
+                 If this variable is present, the password prompt will be
+                 skipped.
+
           --rsa-public-key-path file
                  path to the RSA public key used to encrypt  authentication  cre-
                  dentials (if built with OpenSSL support)

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -370,7 +370,9 @@ perform differently, just based on payload entropy.
 .BR --username " \fIusername\fR" 
 username to use for authentication to the iperf server (if built with
 OpenSSL support).
-The password will be prompted for interactively when the test is run.
+The password will be prompted for interactively when the test is run.  Note,
+the password to use can also be specified via the IPERF3_PASSWORD environment
+variable. If this variable is present, the password prompt will be skipped.
 .TP
 .BR --rsa-public-key-path " \fIfile\fR" 
 path to the RSA public key used to encrypt authentication credentials

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1192,7 +1192,8 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 
         char *client_password = NULL;
         size_t s;
-        if (iperf_getpass(&client_password, &s, stdin) < 0){
+        if ((client_password = getenv("IPERF3_PASSWORD")) == NULL &&
+            iperf_getpass(&client_password, &s, stdin) < 0){
             return -1;
         } 
 


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

`master`

* Issues fixed (if any):

None.

* Brief description of code changes (suitable for use as a commit message):

This change introduces the ability to provide a password via environment variable. This functionality is practically required for any type of automation that interacts with authenticated iperf3 servers.

