### PR TITLE
Add delay parameter.

### DIFF
--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -215,6 +215,11 @@ the executable.
                  run  in  client  mode,  connecting  to the specified server.  By
                  default, a test consists of sending data from the client to  the
                  server, unless the -R flag is specified.
+          -z, --delay n
+                 time in seconds to delay between establishing client/server
+                 connection and running test proper. Useful if running
+                 simultaneous tests and new iperf instances have problems
+                 establishing new connections.
    
           --sctp use SCTP rather than TCP (FreeBSD and Linux)
    

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -236,6 +236,7 @@ struct xbind_entry {
 
 struct iperf_test
 {
+    int delay;
     char      role;                             /* 'c' lient or 's' erver */
     int       sender;                           /* client & !reverse or server & reverse */
     int       sender_has_retransmits;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -722,6 +722,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 {
     static struct option longopts[] =
     {
+        {"delay", required_argument, NULL, 'z'},
         {"port", required_argument, NULL, 'p'},
         {"format", required_argument, NULL, 'f'},
         {"interval", required_argument, NULL, 'i'},
@@ -807,10 +808,13 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     char *client_username = NULL, *client_rsa_public_key = NULL, *server_rsa_private_key = NULL;
 #endif /* HAVE_SSL */
 
-    while ((flag = getopt_long(argc, argv, "p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:A:T:C:dI:hX:", longopts, NULL)) != -1) {
+    while ((flag = getopt_long(argc, argv, "z:p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:A:T:C:dI:hX:", longopts, NULL)) != -1) {
         switch (flag) {
             case 'p':
                 test->server_port = atoi(optarg);
+                break;
+            case 'z':
+                test->delay = atoi(optarg);
                 break;
             case 'f':
 		if (!optarg) {

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -254,6 +254,12 @@ iperf_handle_message_client(struct iperf_test *test)
         case CREATE_STREAMS:
             if (iperf_create_streams(test) < 0)
                 return -1;
+
+            if(test->delay) {
+            	printf("Will now delay %d sec...\n",test->delay);
+            	sleep(test->delay);
+            }
+
             break;
         case TEST_START:
             if (iperf_init_test(test) < 0)
@@ -338,6 +344,13 @@ iperf_connect(struct iperf_test *test)
     if (Nwrite(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
         i_errno = IESENDCOOKIE;
         return -1;
+    }
+
+    char delay_buffer[COOKIE_SIZE];
+    snprintf(delay_buffer, sizeof(delay_buffer), "%d",test->delay);
+    if (Nwrite(test->ctrl_sck, delay_buffer, COOKIE_SIZE, Ptcp) < 0) {
+            i_errno = IESENDCOOKIE;
+            return -1;
     }
 
     FD_SET(test->ctrl_sck, &test->read_set);

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -117,6 +117,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -D, --daemon              run the server as a daemon\n"
                            "  -I, --pidfile file        write PID file\n"
                            "  -1, --one-off             handle one client connection then exit\n"
+                           "  -z, --delay #             time in seconds to delay between connecting\n"
+                           "                            and running test proper.\n"
 #if defined(HAVE_SSL)
                            "  --rsa-private-key-path    path to the RSA private key used to decrypt\n"
 			   "                            authentication credentials\n"

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -116,6 +116,9 @@ iperf_accept(struct iperf_test *test)
         return -1;
     }
 
+    char delay_buffer[COOKIE_SIZE];
+    int delay;
+
     if (test->ctrl_sck == -1) {
         /* Server free, accept new client */
         test->ctrl_sck = s;
@@ -123,6 +126,14 @@ iperf_accept(struct iperf_test *test)
             i_errno = IERECVCOOKIE;
             return -1;
         }
+
+        if (Nread(test->ctrl_sck, delay_buffer, COOKIE_SIZE, Ptcp) < 0) {
+                    i_errno = IERECVCOOKIE;
+                    return -1;
+        }
+        delay = atoi(delay_buffer);
+        test->delay = delay;
+
 	FD_SET(test->ctrl_sck, &test->read_set);
 	if (test->ctrl_sck > test->max_fd) test->max_fd = test->ctrl_sck;
 
@@ -540,6 +551,10 @@ iperf_run_server(struct iperf_test *test)
                 }
 
                 if (streams_accepted == test->num_streams) {
+                    if(test->delay) {
+                        printf("Will now delay %d sec...\n",test->delay);
+                        sleep(test->delay);
+                    }
                     if (test->protocol->id != Ptcp) {
                         FD_CLR(test->prot_listener, &test->read_set);
                         close(test->prot_listener);


### PR DESCRIPTION
This change adds a -z/delay parameter which specifies how many seconds to sleep after connecting to server. This is useful if running many simultaneous tests, as problems establishing new connections if a test is already running have been found.

Signed-off-by: Jan Sokolowski <jan.sokolowski@intel.com>

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

