### PR TITLE
Fix cpu usage calculation regression in cpu_util()

### DIFF
--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -211,7 +211,7 @@ cpu_util(double pcpu[3])
     getrusage(RUSAGE_SELF, &rtemp);
 
     iperf_time_diff(&now, &last, &temp_time);
-    timediff = iperf_time_in_secs(&temp_time);
+    timediff = iperf_time_in_usecs(&temp_time);
 
     userdiff = ((rtemp.ru_utime.tv_sec * 1000000.0 + rtemp.ru_utime.tv_usec) -
                 (rlast.ru_utime.tv_sec * 1000000.0 + rlast.ru_utime.tv_usec));


### PR DESCRIPTION
iperf reported "impossible" CPU usage percentages in JSON output:

    "cpu_utilization_percent":      {
        "host_total":   70907445.679701567,
        "host_user":    1303335.9336584355,
        "host_system":  69604109.746043131,
        "remote_total": 13580675.258652203,
        "remote_user":  540984.0827233647,
        "remote_system":        13039620.331720918
    },

Regression introduced in commit cde81d7 ("Add initial portable time abstraction"), where "timediff" was accidentally changed from microseconds to seconds:

```
  -    timediff = ((temp.tv_sec * 1000000.0 + temp.tv_usec) -
  -                (last.tv_sec * 1000000.0 + last.tv_usec));
  +    iperf_time_diff(&now, &last, &temp_time);
  +    timediff = iperf_time_in_secs(&temp_time);
```