### PR TITLE
tcp sctp: Let the system pick the largest possible backlog value for `listen()`

### DIFF
--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -37,6 +37,7 @@
 #include <netdb.h>
 #include <sys/time.h>
 #include <sys/select.h>
+#include <limits.h>
 
 #ifdef HAVE_NETINET_SCTP_H
 #include <netinet/sctp.h>
@@ -234,7 +235,7 @@ iperf_sctp_listen(struct iperf_test *test)
 
     freeaddrinfo(res);
 
-    if (listen(s, 5) < 0) {
+    if (listen(s, INT_MAX) < 0) {
         i_errno = IESTREAMLISTEN;
         return -1;
     }

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -35,6 +35,7 @@
 #include <netdb.h>
 #include <sys/time.h>
 #include <sys/select.h>
+#include <limits.h>
 
 #include "iperf.h"
 #include "iperf_api.h"
@@ -301,7 +302,7 @@ iperf_tcp_listen(struct iperf_test *test)
 
         freeaddrinfo(res);
 
-        if (listen(s, 5) < 0) {
+        if (listen(s, INT_MAX) < 0) {
             i_errno = IESTREAMLISTEN;
             return -1;
         }


### PR DESCRIPTION
Hi,

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): Passing 5 as a value for the backlog parameter of the `listen()` call is insufficient when testing large amounts of sessions, so we let the system truncate `INT_MAX` down to whatever the maximum value is supported.

* Brief description of code changes (suitable for use as a commit message): This commit applies the same changes made by b481169 (#693), to the TCP and SCTP server sockets.
