### PR TITLE
print current listening port when specified port is 0

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -88,7 +88,7 @@ iperf_server_listen(struct iperf_test *test)
 
     if (!test->json_output) {
 	iperf_printf(test, "-----------------------------------------------------------\n");
-	iperf_printf(test, "Server listening on %d\n", test->server_port);
+	iperf_printf(test, "Server listening on %d\n", getsockport(test->listener));
 	iperf_printf(test, "-----------------------------------------------------------\n");
 	if (test->forceflush)
 	    iflush(test);

--- a/src/net.c
+++ b/src/net.c
@@ -481,3 +481,18 @@ getsockdomain(int sock)
     }
     return ((struct sockaddr *) &sa)->sa_family;
 }
+
+/****************************************************************************/
+
+int
+getsockport(int sock)
+{
+    struct sockaddr_in sin;
+    socklen_t len = sizeof(sin);
+    if (getsockname(sock, (struct sockaddr *)&sin, &len) == -1) {
+        perror("getsockname");
+        return -1;
+    }
+
+    return ntohs(sin.sin_port);
+}

--- a/src/net.h
+++ b/src/net.h
@@ -36,6 +36,7 @@ int has_sendfile(void);
 int Nsendfile(int fromfd, int tofd, const char *buf, size_t count) /* __attribute__((hot)) */;
 int setnonblocking(int fd, int nonblocking);
 int getsockdomain(int sock);
+int getsockport(int sock);
 int parse_qos(const char *tos);
 
 #define NET_SOFTERROR -1


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #831

* Brief description of code changes (suitable for use as a commit message):

print current listening port when specified port is 0 