### PR TITLE
Fix duplicate sum JSON objects in bidirectional mode reports

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -347,6 +347,7 @@ struct iperf_test
     cJSON *json_connected;
     cJSON *json_intervals;
     cJSON *json_end;
+    cJSON *json_end_sums;
 
     /* Server output (use on client side only) */
     char *server_output_text;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
In bidirectional mode, "sum" / "sum_received" / "sum_sent" objects are duplicated, and most JSON parsers don't allow duplicate keys. Hence it is impossible to parse report fully.

* Brief description of code changes (suitable for use as a commit message):
Introduce "sums" array for bidirectional mode which acts as a container for "sum" / "sum_received" / "sum_sent" objects. Add it to both intervals and end objects.
For each interval in 'intervals', new JSON structure is:
"sums": [ <sum1>, <sum2> ]
For 'end', new structure is:
"sums': [ { "sum_sent", "sum_received" }, { "sum_sent", "sum_received" } ]
