### PR TITLE
add support for Linux VSOCK address family

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -2881,6 +2881,9 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # before this can be enabled.
   hardcode_into_libs=yes
 
+  # Add ABI-specific directories to the system library path.
+  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
+
   # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
@@ -2889,7 +2892,7 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   # appending ld.so.conf contents (and includes) to the search path.
   if test -f /etc/ld.so.conf; then
     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \[$]2)); skip = 1; } { if (!skip) print \[$]0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
-    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
   fi
 
   # We used to test for /lib/ld.so.1 and disable shared libraries on

--- a/config/ltmain.sh
+++ b/config/ltmain.sh
@@ -2124,7 +2124,7 @@ fi
 # a configuration failure hint, and exit.
 func_fatal_configuration ()
 {
-    func__fatal_error ${1+"$@"} \
+    func_fatal_error ${1+"$@"} \
       "See the $PACKAGE documentation for more information." \
       "Fatal configuration error."
 }
@@ -7272,10 +7272,12 @@ func_mode_link ()
       # -tp=*                Portland pgcc target processor selection
       # --sysroot=*          for sysroot support
       # -O*, -g*, -flto*, -fwhopr*, -fuse-linker-plugin GCC link-time optimization
+      # -specs=*             GCC specs files
       # -stdlib=*            select c++ std lib with clang
       -64|-mips[0-9]|-r[0-9][0-9]*|-xarch=*|-xtarget=*|+DA*|+DD*|-q*|-m*| \
       -t[45]*|-txscale*|-p|-pg|--coverage|-fprofile-*|-F*|@*|-tp=*|--sysroot=*| \
-      -O*|-g*|-flto*|-fwhopr*|-fuse-linker-plugin|-fstack-protector*|-stdlib=*)
+      -O*|-g*|-flto*|-fwhopr*|-fuse-linker-plugin|-fstack-protector*|-stdlib=*| \
+      -specs=*)
         func_quote_for_eval "$arg"
 	arg=$func_quote_for_eval_result
         func_append compile_command " $arg"

--- a/configure
+++ b/configure
@@ -11102,6 +11102,9 @@ fi
   # before this can be enabled.
   hardcode_into_libs=yes
 
+  # Add ABI-specific directories to the system library path.
+  sys_lib_dlsearch_path_spec="/lib64 /usr/lib64 /lib /usr/lib"
+
   # Ideally, we could use ldconfig to report *all* directores which are
   # searched for libraries, however this is still not possible.  Aside from not
   # being certain /sbin/ldconfig is available, command
@@ -11110,7 +11113,7 @@ fi
   # appending ld.so.conf contents (and includes) to the search path.
   if test -f /etc/ld.so.conf; then
     lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
-    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+    sys_lib_dlsearch_path_spec="$sys_lib_dlsearch_path_spec $lt_ld_extra"
   fi
 
   # We used to test for /lib/ld.so.1 and disable shared libraries on
@@ -12702,6 +12705,26 @@ _ACEOF
 
 
 fi
+
+fi
+
+done
+
+
+# Check for VSOCK support
+for ac_header in linux/vm_sockets.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "linux/vm_sockets.h" "ac_cv_header_linux_vm_sockets_h" "#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+
+"
+if test "x$ac_cv_header_linux_vm_sockets_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LINUX_VM_SOCKETS_H 1
+_ACEOF
+
+$as_echo "#define HAVE_VSOCK 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,15 @@ AC_CHECK_HEADERS([netinet/sctp.h],
 #endif
 ])
 
+# Check for VSOCK support
+AC_CHECK_HEADERS([linux/vm_sockets.h],
+		 AC_DEFINE([HAVE_VSOCK], [1], [Have VSOCK support.]),
+		 [],
+		 [#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+])
+
 AC_CHECK_HEADER([endian.h],
 		AC_DEFINE([HAVE_ENDIAN_H], [1], [Define to 1 if you have the <endian.h> header file.]),
 		AC_CHECK_HEADER([sys/endian.h],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,8 @@ libiperf_la_SOURCES     = \
                         iperf_udp.h \
                         iperf_sctp.c \
                         iperf_sctp.h \
+                        iperf_vsock.c \
+                        iperf_vsock.h \
                         iperf_util.c \
                         iperf_util.h \
                         iperf_time.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -147,8 +147,8 @@ libiperf_la_LIBADD =
 am_libiperf_la_OBJECTS = cjson.lo iperf_api.lo iperf_error.lo \
 	iperf_auth.lo iperf_client_api.lo iperf_locale.lo \
 	iperf_server_api.lo iperf_tcp.lo iperf_udp.lo iperf_sctp.lo \
-	iperf_util.lo iperf_time.lo dscp.lo net.lo tcp_info.lo \
-	timer.lo units.lo
+	iperf_vsock.lo iperf_util.lo iperf_time.lo dscp.lo net.lo \
+	tcp_info.lo timer.lo units.lo
 libiperf_la_OBJECTS = $(am_libiperf_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -164,10 +164,10 @@ am__iperf3_profile_SOURCES_DIST = main.c cjson.c cjson.h flowlabel.h \
 	iperf.h iperf_api.c iperf_api.h iperf_error.c iperf_auth.h \
 	iperf_auth.c iperf_client_api.c iperf_locale.c iperf_locale.h \
 	iperf_server_api.c iperf_tcp.c iperf_tcp.h iperf_udp.c \
-	iperf_udp.h iperf_sctp.c iperf_sctp.h iperf_util.c \
-	iperf_util.h iperf_time.c iperf_time.h dscp.c net.c net.h \
-	portable_endian.h queue.h tcp_info.c timer.c timer.h units.c \
-	units.h version.h
+	iperf_udp.h iperf_sctp.c iperf_sctp.h iperf_vsock.c \
+	iperf_vsock.h iperf_util.c iperf_util.h iperf_time.c \
+	iperf_time.h dscp.c net.c net.h portable_endian.h queue.h \
+	tcp_info.c timer.c timer.h units.c units.h version.h
 am__objects_1 = iperf3_profile-cjson.$(OBJEXT) \
 	iperf3_profile-iperf_api.$(OBJEXT) \
 	iperf3_profile-iperf_error.$(OBJEXT) \
@@ -178,6 +178,7 @@ am__objects_1 = iperf3_profile-cjson.$(OBJEXT) \
 	iperf3_profile-iperf_tcp.$(OBJEXT) \
 	iperf3_profile-iperf_udp.$(OBJEXT) \
 	iperf3_profile-iperf_sctp.$(OBJEXT) \
+	iperf3_profile-iperf_vsock.$(OBJEXT) \
 	iperf3_profile-iperf_util.$(OBJEXT) \
 	iperf3_profile-iperf_time.$(OBJEXT) \
 	iperf3_profile-dscp.$(OBJEXT) iperf3_profile-net.$(OBJEXT) \
@@ -245,6 +246,7 @@ am__depfiles_remade = ./$(DEPDIR)/cjson.Plo ./$(DEPDIR)/dscp.Plo \
 	./$(DEPDIR)/iperf3_profile-iperf_time.Po \
 	./$(DEPDIR)/iperf3_profile-iperf_udp.Po \
 	./$(DEPDIR)/iperf3_profile-iperf_util.Po \
+	./$(DEPDIR)/iperf3_profile-iperf_vsock.Po \
 	./$(DEPDIR)/iperf3_profile-main.Po \
 	./$(DEPDIR)/iperf3_profile-net.Po \
 	./$(DEPDIR)/iperf3_profile-tcp_info.Po \
@@ -255,10 +257,11 @@ am__depfiles_remade = ./$(DEPDIR)/cjson.Plo ./$(DEPDIR)/dscp.Plo \
 	./$(DEPDIR)/iperf_sctp.Plo ./$(DEPDIR)/iperf_server_api.Plo \
 	./$(DEPDIR)/iperf_tcp.Plo ./$(DEPDIR)/iperf_time.Plo \
 	./$(DEPDIR)/iperf_udp.Plo ./$(DEPDIR)/iperf_util.Plo \
-	./$(DEPDIR)/net.Plo ./$(DEPDIR)/t_api-t_api.Po \
-	./$(DEPDIR)/t_timer-t_timer.Po ./$(DEPDIR)/t_units-t_units.Po \
-	./$(DEPDIR)/t_uuid-t_uuid.Po ./$(DEPDIR)/tcp_info.Plo \
-	./$(DEPDIR)/timer.Plo ./$(DEPDIR)/units.Plo
+	./$(DEPDIR)/iperf_vsock.Plo ./$(DEPDIR)/net.Plo \
+	./$(DEPDIR)/t_api-t_api.Po ./$(DEPDIR)/t_timer-t_timer.Po \
+	./$(DEPDIR)/t_units-t_units.Po ./$(DEPDIR)/t_uuid-t_uuid.Po \
+	./$(DEPDIR)/tcp_info.Plo ./$(DEPDIR)/timer.Plo \
+	./$(DEPDIR)/units.Plo
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -641,6 +644,8 @@ libiperf_la_SOURCES = \
                         iperf_udp.h \
                         iperf_sctp.c \
                         iperf_sctp.h \
+                        iperf_vsock.c \
+                        iperf_vsock.h \
                         iperf_util.c \
                         iperf_util.h \
                         iperf_time.c \
@@ -886,6 +891,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-iperf_time.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-iperf_udp.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-iperf_util.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-iperf_vsock.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-main.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-net.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-tcp_info.Po@am__quote@ # am--include-marker
@@ -902,6 +908,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf_time.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf_udp.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf_util.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf_vsock.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/net.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/t_api-t_api.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/t_timer-t_timer.Po@am__quote@ # am--include-marker
@@ -1105,6 +1112,20 @@ iperf3_profile-iperf_sctp.obj: iperf_sctp.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='iperf_sctp.c' object='iperf3_profile-iperf_sctp.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -c -o iperf3_profile-iperf_sctp.obj `if test -f 'iperf_sctp.c'; then $(CYGPATH_W) 'iperf_sctp.c'; else $(CYGPATH_W) '$(srcdir)/iperf_sctp.c'; fi`
+
+iperf3_profile-iperf_vsock.o: iperf_vsock.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -MT iperf3_profile-iperf_vsock.o -MD -MP -MF $(DEPDIR)/iperf3_profile-iperf_vsock.Tpo -c -o iperf3_profile-iperf_vsock.o `test -f 'iperf_vsock.c' || echo '$(srcdir)/'`iperf_vsock.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/iperf3_profile-iperf_vsock.Tpo $(DEPDIR)/iperf3_profile-iperf_vsock.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='iperf_vsock.c' object='iperf3_profile-iperf_vsock.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -c -o iperf3_profile-iperf_vsock.o `test -f 'iperf_vsock.c' || echo '$(srcdir)/'`iperf_vsock.c
+
+iperf3_profile-iperf_vsock.obj: iperf_vsock.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -MT iperf3_profile-iperf_vsock.obj -MD -MP -MF $(DEPDIR)/iperf3_profile-iperf_vsock.Tpo -c -o iperf3_profile-iperf_vsock.obj `if test -f 'iperf_vsock.c'; then $(CYGPATH_W) 'iperf_vsock.c'; else $(CYGPATH_W) '$(srcdir)/iperf_vsock.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/iperf3_profile-iperf_vsock.Tpo $(DEPDIR)/iperf3_profile-iperf_vsock.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='iperf_vsock.c' object='iperf3_profile-iperf_vsock.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -c -o iperf3_profile-iperf_vsock.obj `if test -f 'iperf_vsock.c'; then $(CYGPATH_W) 'iperf_vsock.c'; else $(CYGPATH_W) '$(srcdir)/iperf_vsock.c'; fi`
 
 iperf3_profile-iperf_util.o: iperf_util.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -MT iperf3_profile-iperf_util.o -MD -MP -MF $(DEPDIR)/iperf3_profile-iperf_util.Tpo -c -o iperf3_profile-iperf_util.o `test -f 'iperf_util.c' || echo '$(srcdir)/'`iperf_util.c
@@ -1708,6 +1729,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_time.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_udp.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_util.Po
+	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_vsock.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-main.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-net.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-tcp_info.Po
@@ -1724,6 +1746,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/iperf_time.Plo
 	-rm -f ./$(DEPDIR)/iperf_udp.Plo
 	-rm -f ./$(DEPDIR)/iperf_util.Plo
+	-rm -f ./$(DEPDIR)/iperf_vsock.Plo
 	-rm -f ./$(DEPDIR)/net.Plo
 	-rm -f ./$(DEPDIR)/t_api-t_api.Po
 	-rm -f ./$(DEPDIR)/t_timer-t_timer.Po
@@ -1793,6 +1816,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_time.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_udp.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_util.Po
+	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_vsock.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-main.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-net.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-tcp_info.Po
@@ -1809,6 +1833,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/iperf_time.Plo
 	-rm -f ./$(DEPDIR)/iperf_udp.Plo
 	-rm -f ./$(DEPDIR)/iperf_util.Plo
+	-rm -f ./$(DEPDIR)/iperf_vsock.Plo
 	-rm -f ./$(DEPDIR)/net.Plo
 	-rm -f ./$(DEPDIR)/t_api-t_api.Po
 	-rm -f ./$(DEPDIR)/t_timer-t_timer.Po

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -14,7 +14,7 @@ iperf3 \- perform network throughput tests
 
 .SH DESCRIPTION
 iperf3 is a tool for performing network throughput measurements.
-It can test TCP, UDP, or SCTP throughput.
+It can test TCP, UDP, SCTP or VSOCK throughput.
 To perform an iperf3 test the user must establish both a server and a
 client.
 .PP
@@ -43,13 +43,15 @@ iperf3 clients (in other words, the iperf3 program run in client
 mode).
 The client mode can be started using the -c command-line option,
 which also requires a host to which iperf3 should connect.
-The host can by specified by hostname, IPv4 literal, or IPv6 literal:
+The host can by specified by hostname, IPv4 literal, IPv6 literal or VSOCK CID:
 .IP
 \fCiperf3 -c iperf3.example.com\fR
 .IP
 \fCiperf3 -c 192.0.2.1\fR
 .IP
 \fCiperf3 -c 2001:db8::1\fR
+.IP
+\fCiperf3 --vsock -c 3\fR
 .PP
 If the iperf3 server is running on a non-default TCP port, that port
 number needs to be specified on the client as well:
@@ -105,6 +107,21 @@ used to set the parameters of a test.
 They are given in the "GENERAL OPTIONS" section of the manual page
 below, as well as summarized in iperf3's help output, which can be
 viewed by running iperf3 with the -h flag.
+.SS VSOCK
+.PP
+The  VSOCK  address family facilitates communication between virtual
+machines and the host they are running on.
+To use VSOCK (only Linux), you must use the option --vsock on both server
+and client.
+.PP
+Usually the server side runs in the VM:
+.IP
+\fCiperf3 --vsock -s\fR
+.PP
+And the client runs in the host, in this case you must specify the Context
+Identifier (CID) of the guest where the server is running (eg. guest-cid = 3):
+.IP
+\fCiperf3 --vsock -c 3\fR
 .SH "GENERAL OPTIONS"
 .TP
 .BR -p ", " --port " \fIn\fR"
@@ -139,6 +156,9 @@ CPUs).
 .TP
 .BR -B ", " --bind " \fIhost\fR"
 bind to the specific interface associated with address \fIhost\fR.
+.TP
+.BR --vsock
+use VSOCK address family rather than INET (Linux)
 .TP
 .BR -V ", " --verbose " "
 give more detailed output 
@@ -211,7 +231,7 @@ server.
 .TP
 .BR -b ", " --bitrate " \fIn\fR[KM]"
 set target bitrate to \fIn\fR bits/sec (default 1 Mbit/sec for UDP,
-unlimited for TCP/SCTP).
+unlimited for TCP/SCTP/VSOCK).
 If there are multiple streams (\-P flag), the throughput limit is applied
 separately to each stream.
 You can also add a '/' and a number to the bitrate specifier.
@@ -265,7 +285,7 @@ is 128KB.
 In the case of UDP, iperf3 tries to dynamically determine a reasonable
 sending size based on the path MTU; if that cannot be determined it
 uses 1460 bytes as a sending size.
-For SCTP tests, the default size is 64KB.
+For SCTP and VSOCK tests, the default size is 64KB.
 .TP
 .BR --cport " \fIport\fR"
 bind data streams to a specific client port (for TCP and UDP only,

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -49,9 +49,15 @@ struct iperf_time;
 #define Ptcp SOCK_STREAM
 #define Pudp SOCK_DGRAM
 #define Psctp 12
+#ifdef HAVE_VSOCK
+#define Pvsock AF_VSOCK
+#else /* !HAVE_VSOCK */
+#define Pvsock 40
+#endif
 #define DEFAULT_UDP_BLKSIZE 1460 /* default is dynamically set, else this */
 #define DEFAULT_TCP_BLKSIZE (128 * 1024)  /* default read/write block size */
 #define DEFAULT_SCTP_BLKSIZE (64 * 1024)
+#define DEFAULT_VSOCK_BLKSIZE (64 * 1024)
 
 /* short option equivalents, used to support options that only have long form */
 #define OPT_SCTP 1
@@ -73,6 +79,7 @@ struct iperf_time;
 #define OPT_REPEATING_PAYLOAD 18
 #define OPT_EXTRA_DATA 19
 #define OPT_BIDIRECTIONAL 20
+#define OPT_VSOCK 21
 
 /* states */
 #define TEST_START 1
@@ -343,6 +350,7 @@ enum {
     IEBADFORMAT = 24,	    // Bad format argument to -f
     IEREVERSEBIDIR = 25,    // Iperf cannot be both reverse and bidirectional
     IEBADPORT = 26,	    // Bad port number
+    IENOVSOCK = 27,	    // No VSOCK support available
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -27,6 +27,9 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
+/* Define to 1 if you have the <linux/vm_sockets.h> header file. */
+#undef HAVE_LINUX_VM_SOCKETS_H
+
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 
@@ -86,6 +89,9 @@
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
+
+/* Have VSOCK support. */
+#undef HAVE_VSOCK
 
 /* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -105,6 +105,9 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -A, --affinity n/n,m      set CPU affinity\n"
 #endif /* HAVE_CPU_AFFINITY */
                            "  -B, --bind      <host>    bind to the interface associated with the address <host>\n"
+#if defined(HAVE_VSOCK)
+                           "  --vsock                   use VSOCK rather than TCP\n"
+#endif /* HAVE_VSOCK */
                            "  -V, --verbose             more detailed output\n"
                            "  -J, --json                output in JSON format\n"
                            "  --logfile f               send output to a log file\n"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -285,13 +285,13 @@ const char report_reverse[] =
 "Reverse mode, remote host %s is sending\n";
 
 const char report_accepted[] =
-"Accepted connection from %s, port %d\n";
+"Accepted connection from %s, port %u\n";
 
 const char report_cookie[] =
 "      Cookie: %s\n";
 
 const char report_connected[] =
-"[%3d] local %s port %d connected to %s port %d\n";
+"[%3d] local %s port %u connected to %s port %u\n";
 
 const char report_window[] =
 "TCP window size: %s\n";

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -581,7 +581,7 @@ iperf_run_server(struct iperf_test *test)
 
 
                 if (rec_streams_accepted == streams_to_rec && send_streams_accepted == streams_to_send) {
-                    if (test->protocol->id != Ptcp) {
+                    if (test->protocol->id != Ptcp && test->protocol->id != Pvsock) {
                         FD_CLR(test->prot_listener, &test->read_set);
                         close(test->prot_listener);
                     } else { 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -49,6 +49,10 @@
 #include <setjmp.h>
 
 #include "iperf.h"
+#if defined(HAVE_VSOCK)
+#include <linux/vm_sockets.h>
+#endif /* HAVE_VSOCK */
+
 #include "iperf_api.h"
 #include "iperf_udp.h"
 #include "iperf_tcp.h"

--- a/src/iperf_vsock.c
+++ b/src/iperf_vsock.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * (1) Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * (2) Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/ or other materials provided with the distribution.
+ *
+ * (3) Neither the name of Red Hat, Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "iperf_config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include "iperf.h"
+#include "iperf_api.h"
+#include "iperf_vsock.h"
+
+
+#if !defined(HAVE_VSOCK)
+
+static int
+iperf_vsock_notsupported(void)
+{
+	fprintf(stderr, "VSOCK not supported\n");
+	i_errno = IENOVSOCK;
+	return -1;
+}
+
+int
+iperf_vsock_accept(struct iperf_test *test)
+{
+	return iperf_vsock_notsupported();
+}
+
+int
+iperf_vsock_recv(struct iperf_stream *sp)
+{
+	return iperf_vsock_notsupported();
+}
+
+int
+iperf_vsock_send(struct iperf_stream *sp)
+{
+	return iperf_vsock_notsupported();
+}
+
+int
+iperf_vsock_listen(struct iperf_test *test)
+{
+	return iperf_vsock_notsupported();
+}
+
+int
+iperf_vsock_connect(struct iperf_test *test)
+{
+	return iperf_vsock_notsupported();
+}
+
+int
+iperf_vsock_init(struct iperf_test *test)
+{
+	return iperf_vsock_notsupported();
+}
+
+#else /* HAVE_VSOCK */
+
+#include <sys/socket.h>
+#include <linux/vm_sockets.h>
+
+#include "net.h"
+
+static int
+parse_cid(const char *cid_str)
+{
+	char *end = NULL;
+	long cid = strtol(cid_str, &end, 10);
+	if (cid_str != end && *end == '\0') {
+		return cid;
+	} else {
+		fprintf(stderr, "VSOCK - invalid cid: %s\n", cid_str);
+		return -1;
+	}
+}
+
+int
+iperf_vsock_accept(struct iperf_test *test)
+{
+	int fd;
+	signed char rbuf = ACCESS_DENIED;
+	char cookie[COOKIE_SIZE];
+	struct sockaddr_vm sa_client;
+	socklen_t socklen_client = sizeof(sa_client);
+
+	fd = accept(test->listener, (struct sockaddr *) &sa_client,
+		    &socklen_client);
+	if (fd < 0) {
+		i_errno = IESTREAMCONNECT;
+		return -1;
+	}
+
+	if (Nread(fd, cookie, COOKIE_SIZE, Pvsock) < 0) {
+		i_errno = IERECVCOOKIE;
+		return -1;
+	}
+
+	if (strcmp(test->cookie, cookie) != 0) {
+		if (Nwrite(fd, (char*) &rbuf, sizeof(rbuf), Pvsock) < 0) {
+			i_errno = IESENDMESSAGE;
+			return -1;
+		}
+		close(fd);
+	}
+
+	return fd;
+}
+
+int
+iperf_vsock_recv(struct iperf_stream *sp)
+{
+	int r;
+
+	r = Nread(sp->socket, sp->buffer, sp->settings->blksize, Pvsock);
+	if (r < 0)
+		return r;
+
+	/* Only count bytes received while we're in the correct state. */
+	if (sp->test->state == TEST_RUNNING) {
+		sp->result->bytes_received += r;
+		sp->result->bytes_received_this_interval += r;
+	}
+	else if (sp->test->debug) {
+			printf("Late receive, state = %d\n", sp->test->state);
+	}
+
+	return r;
+}
+
+int
+iperf_vsock_send(struct iperf_stream *sp)
+{
+	int r;
+
+	r = Nwrite(sp->socket, sp->buffer, sp->settings->blksize, Pvsock);
+	if (r < 0)
+		return r;
+
+	sp->result->bytes_sent += r;
+	sp->result->bytes_sent_this_interval += r;
+
+	return r;
+}
+
+int
+iperf_vsock_listen(struct iperf_test *test)
+{
+	/* We use the same socket used for control path (test->listener) */
+	return test->listener;
+}
+
+int
+iperf_vsock_connect(struct iperf_test *test)
+{
+	int fd, cid;
+	struct sockaddr_vm sa = {
+		.svm_family = AF_VSOCK,
+	};
+
+	cid = parse_cid(test->server_hostname);
+	if (cid < 0) {
+		return -1;
+	}
+
+	sa.svm_cid = cid;
+	sa.svm_port = test->server_port;
+
+	fd = socket(AF_VSOCK, SOCK_STREAM, 0);
+	if (fd < 0) {
+		goto err;
+	}
+
+	if (connect(fd, (struct sockaddr*)&sa, sizeof(sa)) != 0) {
+		goto err_close;
+	}
+
+	/* Send cookie for verification */
+	if (Nwrite(fd, test->cookie, COOKIE_SIZE, Pvsock) < 0) {
+		goto err_close;
+	}
+
+	return fd;
+
+err_close:
+	close(fd);
+err:
+	i_errno = IESTREAMCONNECT;
+	return -1;
+}
+
+int
+iperf_vsock_init(struct iperf_test *test)
+{
+	return 0;
+}
+
+#endif /* HAVE_VSOCK */

--- a/src/iperf_vsock.c
+++ b/src/iperf_vsock.c
@@ -142,8 +142,17 @@ iperf_vsock_recv(struct iperf_stream *sp)
 	int r;
 
 	r = Nread(sp->socket, sp->buffer, sp->settings->blksize, Pvsock);
-	if (r < 0)
-		return r;
+	if (r < 0) {
+		/*
+		 * VSOCK can return -1 with errno = ENOTCONN if the remote host
+		 * closes the connection, but in the iperf3 code we expect
+		 * return 0 in this case.
+		 */
+		if (errno == ENOTCONN)
+			return 0;
+		else
+			return r;
+	}
 
 	/* Only count bytes received while we're in the correct state. */
 	if (sp->test->state == TEST_RUNNING) {
@@ -163,8 +172,17 @@ iperf_vsock_send(struct iperf_stream *sp)
 	int r;
 
 	r = Nwrite(sp->socket, sp->buffer, sp->settings->blksize, Pvsock);
-	if (r < 0)
-		return r;
+	if (r < 0) {
+		/*
+		 * VSOCK can return -1 with errno = ENOTCONN if the remote host
+		 * closes the connection, but in the iperf3 code we expect
+		 * return 0 in this case.
+		 */
+		if (errno == ENOTCONN)
+			return 0;
+		else
+			return r;
+	}
 
 	sp->result->bytes_sent += r;
 	sp->result->bytes_sent_this_interval += r;

--- a/src/iperf_vsock.h
+++ b/src/iperf_vsock.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * (1) Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * (2) Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/ or other materials provided with the distribution.
+ *
+ * (3) Neither the name of Red Hat, Inc. nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef        IPERF_VSOCK_H
+#define        IPERF_VSOCK_H
+
+/**
+ * iperf_vsock_accept -- accepts a new VSOCK connection
+ * on the listener socket for VSOCK tests
+ *
+ *returns file descriptor on success, -1 on error
+ *
+ */
+int iperf_vsock_accept(struct iperf_test *);
+
+/**
+ * iperf_vsock_recv -- receives the data for VSOCK tests
+ *
+ *returns bytes received on success, < 0 on error
+ *
+ */
+int iperf_vsock_recv(struct iperf_stream *);
+
+/**
+ * iperf_vsock_send -- sends the data for VSOCK tests
+ *
+ *returns bytes sent on success, < 0 on error
+ *
+ */
+int iperf_vsock_send(struct iperf_stream *);
+
+/**
+ * iperf_vsock_listen -- get listener socket for VSOCK tests
+ * We use the same socket used for control path (test->listener)
+ *
+ *returns file descriptor of listener_socket
+ *
+ */
+int iperf_vsock_listen(struct iperf_test *);
+
+/**
+ * iperf_vsock_connect -- create a new VSOCK connection to the server
+ * for VSOCK tests
+ *
+ *returns file descriptor on success, -1 on error
+ *
+ */
+int iperf_vsock_connect(struct iperf_test *);
+
+/**
+ * iperf_vsock_init -- nop
+ *
+ *returns 0
+ */
+int iperf_vsock_init(struct iperf_test *test);
+
+#endif /* IPERF_VSOCK_H */


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: **master**

* Issues fixed (if any): **none**

* Brief description of code changes (suitable for use as a commit message):

This PR adds the support of VSOCK address family. In this way iperf3
can be used to measure the performance between guest and host
using VSOCK sockets.

The  VSOCK  address family facilitates communication between virtual
machines and the host they are running on.

To make use of VSOCK with QEMU and virtio-vsock, you must have:
    - a Linux hypervisor with kernel 4.8+
    - a Linux virtual machine on that hypervisor with kernel 4.8+
    - QEMU 2.8+ on the hypervisor, running the virtual machine

Examples with Fedora 29 (host and guest):
```
## Host: start the VM
GUEST_CID=3
sudo modprobe vhost_vsock
sudo qemu-system-x86_64 -m 1G -smp 2 -cpu host -M accel=kvm	\
     -drive if=virtio,file=/path/to/fedora.img,format=qcow2     \
     -device vhost-vsock-pci,guest-cid=${GUEST_CID}

## Guest: start iperf server
# SELinux can block you, so you can write a policy o temporally disable it
sudo setenforce 0
iperf3 --vsock -s

## Guest: start iperf client
iperf3 --vsock -c ${GUEST_CID}
```

Notes:
I saw that you are committed also a file generated by autotools, so I added a separated commit whit these changes, feel free to merge it or not.

Thanks,
Stefano
