### PR TITLE
Fix configure when openssl is absent.

### DIFF
--- a/configure
+++ b/configure
@@ -737,6 +737,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -822,6 +823,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1074,6 +1076,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1211,7 +1222,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1364,6 +1375,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -12736,6 +12748,7 @@ if test "x$with_openssl" = "xno"; then
 $as_echo "$as_me: WARNING: Building without OpenSSL; disabling iperf_auth functionality. " >&2;}
 else
     # Check for OPENSSL support
+    havs_ssl=false
 
     found=false
 
@@ -12923,6 +12936,7 @@ $as_echo "yes" >&6; }
 
 $as_echo "#define HAVE_SSL 1" >>confdefs.h
 
+          have_ssl=true
 
 else
 
@@ -12947,9 +12961,11 @@ rm -f core conftest.err conftest.$ac_objext \
 
 
 
-    LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
-    LIBS="$OPENSSL_LIBS $LIBS"
-    CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+    if $have_ssl; then
+        LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+        LIBS="$OPENSSL_LIBS $LIBS"
+        CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+    fi
 fi
 
 # Check for TCP_CONGESTION sockopt (believed to be Linux and FreeBSD only)

--- a/configure.ac
+++ b/configure.ac
@@ -114,15 +114,19 @@ if test "x$with_openssl" = "xno"; then
     AC_MSG_WARN( [Building without OpenSSL; disabling iperf_auth functionality.] )
 else
     # Check for OPENSSL support
+    havs_ssl=false
     AX_CHECK_OPENSSL(
-        [ AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available]) ],
+        [ AC_DEFINE([HAVE_SSL], [1], [OpenSSL Is Available])
+          have_ssl=true ],
 	[ if test "x$with_openssl" != "x"; then
 	  AC_MSG_FAILURE([--with-openssl was given, but test for OpenSSL failed])
 	  fi ]
     )
-    LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
-    LIBS="$OPENSSL_LIBS $LIBS"
-    CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+    if $have_ssl; then
+        LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+        LIBS="$OPENSSL_LIBS $LIBS"
+        CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+    fi
 fi
 
 # Check for TCP_CONGESTION sockopt (believed to be Linux and FreeBSD only)


### PR DESCRIPTION
openssl flags was appended to normal cpp/ld flags even if it is absent. They should really be appended if openssl is detected. This change fixes configure.ac and regenerates configure.