### PR TITLE
Issue 751

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -270,6 +270,9 @@ create_server_timers(struct iperf_test * test)
 {
     struct iperf_time now;
     TimerClientData cd;
+    int max_rtt = 4; /* seconds */
+    int state_transitions = 10; /* number of state transitions in iperf3 */
+    int grace_period = max_rtt * state_transitions;
 
     if (iperf_time_now(&now) < 0) {
 	i_errno = IEINITTEST;
@@ -279,7 +282,7 @@ create_server_timers(struct iperf_test * test)
     test->timer = test->stats_timer = test->reporter_timer = NULL;
     if (test->duration != 0 ) {
         test->done = 0;
-        test->timer = tmr_create(&now, server_timer_proc, cd, (test->duration + test->omit + 5) * SEC_TO_US, 0);
+        test->timer = tmr_create(&now, server_timer_proc, cd, (test->duration + test->omit + grace_period) * SEC_TO_US, 0);
         if (test->timer == NULL) {
             i_errno = IEINITTEST;
             return -1;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -194,6 +194,7 @@ iperf_handle_message_server(struct iperf_test *test)
                 test->on_test_finish(test);
             break;
         case IPERF_DONE:
+            test->state = IPERF_DONE;
             break;
         case CLIENT_TERMINATE:
             i_errno = IECLIENTTERM;


### PR DESCRIPTION
* Fixes issue #751

* Reduce likelihood of triggering server cleanup timeout before results can be exchanged, which happens when the round trip time is hundreds to thousands of milliseconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/esnet/iperf/859)
<!-- Reviewable:end -->
