### PR TITLE
Fix getting json server output in bidir mode

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3325,7 +3325,7 @@ iperf_print_results(struct iperf_test *test)
             }
 
             /* Print server output if we're on the client and it was requested/provided */
-            if (test->role == 'c' && iperf_get_test_get_server_output(test)) {
+            if (test->role == 'c' && iperf_get_test_get_server_output(test) && !test->json_output) {
                 if (test->json_server_output) {
                     iperf_printf(test, "\nServer JSON output:\n%s\n", cJSON_Print(test->json_server_output));
                     cJSON_Delete(test->json_server_output);


### PR DESCRIPTION
In bidirectional mode, if option --get-server-output is set and if
both client and server have --json set to true, client would still print
the json output of server to stdout as a separate piece instead of
including it into client's json output.

This patch fixes this problem, the server's json output would be
appended to client's json field 'server_output_json' as it should be.

There is probably better approach to fix this but that also works and the fix is pretty small.

To reproduce the issue, you can start the server as follows: 
`iperf3 -s --json`

and client:
`iperf3 -c <server> --json --get-server-output --bidir`

You will see that server's JSON output would be printed as below before the client's output. However it should be included into client's JSON output.
`
Server JSON output:
{
        "start":        {
                "connected":    [{
<...>
`


_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

