### PR TITLE
Introduce API functions for no_delay option

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -328,6 +328,12 @@ iperf_get_iperf_version(void)
     return (char*)iperf_version;
 }
 
+int
+iperf_get_test_no_delay(struct iperf_test *ipt)
+{
+    return ipt->no_delay;
+}
+
 /************** Setter routines for some fields inside iperf_test *************/
 
 void
@@ -577,6 +583,12 @@ iperf_set_test_bidirectional(struct iperf_test* ipt, int bidirectional)
         ipt->mode = BIDIRECTIONAL;
     else
         iperf_set_test_reverse(ipt, ipt->reverse);
+}
+
+void
+iperf_set_test_no_delay(struct iperf_test* ipt, int no_delay)
+{
+    ipt->no_delay = no_delay;
 }
 
 /********************** Get/set test protocol structure ***********************/

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -125,6 +125,7 @@ int	iperf_get_test_one_off( struct iperf_test* ipt );
 int iperf_get_test_tos( struct iperf_test* ipt );
 char*	iperf_get_extra_data( struct iperf_test* ipt );
 char*	iperf_get_iperf_version(void);
+int	iperf_get_test_no_delay( struct iperf_test* ipt );
 
 /* Setter routines for some fields inside iperf_test. */
 void	iperf_set_verbose( struct iperf_test* ipt, int verbose );
@@ -157,6 +158,7 @@ void	iperf_set_test_one_off( struct iperf_test* ipt, int one_off );
 void    iperf_set_test_tos( struct iperf_test* ipt, int tos );
 void	iperf_set_extra_data( struct iperf_test* ipt, char *dat);
 void    iperf_set_test_bidirectional( struct iperf_test* ipt, int bidirectional);
+void    iperf_set_test_no_delay( struct iperf_test* ipt, int no_delay);
 
 #if defined(HAVE_SSL)
 void    iperf_set_test_client_username(struct iperf_test *ipt, char *client_username);


### PR DESCRIPTION
Introduce setter and getter libiperf API functions for no_delay option.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

