### PR TITLE
Introduce iperf_set_test_logfile API function

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -379,6 +379,12 @@ iperf_set_test_blksize(struct iperf_test *ipt, int blksize)
 }
 
 void
+iperf_set_test_logfile(struct iperf_test *ipt, char *logfile)
+{
+    ipt->logfile = strdup(logfile);
+}
+
+void
 iperf_set_test_rate(struct iperf_test *ipt, uint64_t rate)
 {
     ipt->settings->rate = rate;
@@ -1193,15 +1199,6 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         }
     }
 
-    /* Set logging to a file if specified, otherwise use the default (stdout) */
-    if (test->logfile) {
-        test->outfile = fopen(test->logfile, "a+");
-        if (test->outfile == NULL) {
-            i_errno = IELOGFILE;
-            return -1;
-        }
-    }
-
     /* Check flag / role compatibility. */
     if (test->role == 'c' && server_flag) {
         i_errno = IESERVERONLY;
@@ -1321,6 +1318,20 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     }
     if (test->json_output && test->debug) {
         warning("Debug output (-d) may interfere with JSON output (-J)");
+    }
+
+    return 0;
+}
+
+/*
+ * Open the file specified by test->logfile and set test->outfile to its' FD.
+ */
+int iperf_open_logfile(struct iperf_test *test)
+{
+    test->outfile = fopen(test->logfile, "a+");
+    if (test->outfile == NULL) {
+        i_errno = IELOGFILE;
+        return -1;
     }
 
     return 0;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -135,6 +135,7 @@ void	iperf_set_test_reporter_interval( struct iperf_test* ipt, double reporter_i
 void	iperf_set_test_stats_interval( struct iperf_test* ipt, double stats_interval );
 void	iperf_set_test_state( struct iperf_test* ipt, signed char state );
 void	iperf_set_test_blksize( struct iperf_test* ipt, int blksize );
+void	iperf_set_test_logfile( struct iperf_test* ipt, char *logfile );
 void	iperf_set_test_rate( struct iperf_test* ipt, uint64_t rate );
 void    iperf_set_test_pacing_timer( struct iperf_test* ipt, int pacing_timer );
 void    iperf_set_test_bytes( struct iperf_test* ipt, uint64_t bytes );
@@ -262,6 +263,7 @@ int iperf_exchange_results(struct iperf_test *);
 int iperf_init_test(struct iperf_test *);
 int iperf_create_send_timers(struct iperf_test *);
 int iperf_parse_arguments(struct iperf_test *, int, char **);
+int iperf_open_logfile(struct iperf_test *);
 void iperf_reset_test(struct iperf_test *);
 void iperf_reset_stats(struct iperf_test * test);
 

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -454,6 +454,10 @@ iperf_run_client(struct iperf_test * test)
     struct timeval* timeout = NULL;
     struct iperf_stream *sp;
 
+    if (test->logfile)
+        if (iperf_open_logfile(test) < 0)
+            return -1;
+
     if (test->affinity != -1)
 	if (iperf_setaffinity(test, test->affinity) != 0)
 	    return -1;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -398,6 +398,10 @@ iperf_run_server(struct iperf_test *test)
     struct timeval* timeout;
     int flag;
 
+    if (test->logfile)
+        if (iperf_open_logfile(test) < 0)
+            return -1;
+
     if (test->affinity != -1) 
 	if (iperf_setaffinity(test, test->affinity) != 0)
 	    return -2;


### PR DESCRIPTION
To be able to set the test->outfile to a different file other than default
if using libiperf API.

Since logfile is now opened in iperf_parse_arguments() and this function
may not be used if running iperf using API, define a dedicated function
iperf_open_logfile() and move the opening of logfile into
iperf_run_client() and iperf_run_server() to make sure logfile will be
opened if iperf_parse_arguments() was not called.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

