### PR TITLE
enh: Properly include <sys/socket.h> for improved portability.

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -27,6 +27,7 @@
 #ifndef        __IPERF_API_H
 #define        __IPERF_API_H
 
+#include <sys/socket.h>
 #include <sys/time.h>
 #include <setjmp.h>
 #include <stdio.h>


### PR DESCRIPTION
Fixes #821.
