### PR TITLE
Fix off by one overwrite crash and memory leaks.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1757,7 +1757,7 @@ get_parameters(struct iperf_test *test)
 	if (test->debug) {
             char *str;
             str = cJSON_Print(j);
-	    printf("get_parameters:\n%s\n", str );
+            printf("get_parameters:\n%s\n", str );
             free(str);
 	}
 
@@ -2400,8 +2400,6 @@ iperf_free_test(struct iperf_test *test)
         SLIST_REMOVE_HEAD(&test->streams, streams);
         iperf_free_stream(sp);
     }
-    free(test->remote_congestion_used);
-    test->remote_congestion_used = NULL;
     if (test->server_hostname)
 	free(test->server_hostname);
     if (test->tmp_template)
@@ -2538,7 +2536,8 @@ iperf_reset_test(struct iperf_test *test)
 
     SLIST_INIT(&test->streams);
 
-    free(test->remote_congestion_used);
+    if (test->remote_congestion_used)
+        free(test->remote_congestion_used);
     test->remote_congestion_used = NULL;
     test->role = 's';
     test->mode = RECEIVER;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1246,8 +1246,10 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 
         char *client_password = NULL;
         size_t s;
-        if ((client_password = getenv("IPERF3_PASSWORD")) == NULL &&
-            iperf_getpass(&client_password, &s, stdin) < 0){
+        /* Need to copy env var, so we can do a common free */
+        if ((client_password = getenv("IPERF3_PASSWORD")) != NULL)
+             client_password = strdup(client_password);
+        else if (iperf_getpass(&client_password, &s, stdin) < 0){
             return -1;
         } 
 
@@ -1265,6 +1267,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         test->settings->client_password = client_password;
         test->settings->client_rsa_pubkey = load_pubkey_from_file(client_rsa_public_key);
     }
+    free(client_rsa_public_key);
 
     if (test->role == 'c' && (server_rsa_private_key || test->server_authorized_users)){
         i_errno = IESERVERONLY;
@@ -1273,12 +1276,15 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         !(server_rsa_private_key && test->server_authorized_users)) {
          i_errno = IESETSERVERAUTH;
         return -1;
-    } else if (test->role == 's' && server_rsa_private_key && test_load_private_key_from_file(server_rsa_private_key) < 0){
-        i_errno = IESETSERVERAUTH;
-        return -1;
-    } else {
+    } else if (test->role == 's' && server_rsa_private_key == NULL) {
         test->server_rsa_private_key = load_privkey_from_file(server_rsa_private_key);
+        if (test->server_rsa_private_key == NULL){
+            i_errno = IESETSERVERAUTH;
+            return -1;
+        }
     }
+    free(server_rsa_private_key);
+    server_rsa_private_key = NULL;
 
 #endif //HAVE_SSL
     if (blksize == 0) {
@@ -1545,11 +1551,17 @@ int test_is_authorized(struct iperf_test *test){
         int ret = check_authentication(username, password, ts, test->server_authorized_users);
         if (ret == 0){
             iperf_printf(test, report_authetication_successed, username, ts);
+            free(username);
+            free(password);
             return 0;
         } else {
             iperf_printf(test, report_authetication_failed, username, ts);
+            free(username);
+            free(password);
             return -1;
         }
+        free(username);
+        free(password);
     }
     return -1;
 }
@@ -1743,7 +1755,10 @@ get_parameters(struct iperf_test *test)
         r = -1;
     } else {
 	if (test->debug) {
-	    printf("get_parameters:\n%s\n", cJSON_Print(j));
+            char *str;
+            str = cJSON_Print(j);
+	    printf("get_parameters:\n%s\n", str );
+            free(str);
 	}
 
 	if ((j_p = cJSON_GetObjectItem(j, "tcp")) != NULL)
@@ -1908,7 +1923,9 @@ send_results(struct iperf_test *test)
 		}
 	    }
 	    if (r == 0 && test->debug) {
-		printf("send_results\n%s\n", cJSON_Print(j));
+                char *str = cJSON_Print(j);
+		printf("send_results\n%s\n", str);
+                free(str);
 	    }
 	    if (r == 0 && JSON_write(test->ctrl_sck, j) < 0) {
 		i_errno = IESENDRESULTS;
@@ -1964,7 +1981,9 @@ get_results(struct iperf_test *test)
 	    r = -1;
 	} else {
 	    if (test->debug) {
-		printf("get_results\n%s\n", cJSON_Print(j));
+                char *str = cJSON_Print(j);
+                printf("get_results\n%s\n", str);
+                free(str);
 	    }
 
 	    test->remote_cpu_util[0] = j_cpu_util_total->valuedouble;
@@ -2381,7 +2400,8 @@ iperf_free_test(struct iperf_test *test)
         SLIST_REMOVE_HEAD(&test->streams, streams);
         iperf_free_stream(sp);
     }
-
+    free(test->remote_congestion_used);
+    test->remote_congestion_used = NULL;
     if (test->server_hostname)
 	free(test->server_hostname);
     if (test->tmp_template)
@@ -2400,6 +2420,26 @@ iperf_free_test(struct iperf_test *test)
             free(xbe);
         }
     }
+#if defined(HAVE_SSL)
+
+    if (test->server_rsa_private_key)
+      EVP_PKEY_free(test->server_rsa_private_key);
+    test->server_rsa_private_key = NULL;
+
+    free(test->settings->authtoken);
+    test->settings->authtoken = NULL;
+
+    free(test->settings->client_username);
+    test->settings->client_username = NULL;
+
+    free(test->settings->client_password);
+    test->settings->client_password = NULL;
+
+    if (test->settings->client_rsa_pubkey)
+      EVP_PKEY_free(test->settings->client_rsa_pubkey);
+    test->settings->client_rsa_pubkey = NULL;
+#endif /* HAVE_SSL */
+
     if (test->settings)
     free(test->settings);
     if (test->title)
@@ -2498,6 +2538,8 @@ iperf_reset_test(struct iperf_test *test)
 
     SLIST_INIT(&test->streams);
 
+    free(test->remote_congestion_used);
+    test->remote_congestion_used = NULL;
     test->role = 's';
     test->mode = RECEIVER;
     test->sender_has_retransmits = 0;

--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -95,6 +95,7 @@ int check_authentication(const char *username, const char *password, const time_
         s_username = strtok(buf, ",");
         s_password = strtok(NULL, ",");
         if (strcmp( username, s_username ) == 0 && strcmp( passwordHash, s_password ) == 0){
+            fclose(ptr_file);
             return 0;
         }
     }
@@ -115,11 +116,9 @@ int Base64Encode(const unsigned char* buffer, const size_t length, char** b64tex
     BIO_write(bio, buffer, length);
     BIO_flush(bio);
     BIO_get_mem_ptr(bio, &bufferPtr);
-    BIO_set_close(bio, BIO_NOCLOSE);
+    *b64text = strndup( (*bufferPtr).data, (*bufferPtr).length );
     BIO_free_all(bio);
 
-    *b64text=(*bufferPtr).data;
-    (*b64text)[(*bufferPtr).length] = '\0';
     return (0); //success
 }
 
@@ -179,10 +178,12 @@ EVP_PKEY *load_privkey_from_file(const char *file) {
     BIO *key = NULL;
     EVP_PKEY *pkey = NULL;
 
-    key = BIO_new_file(file, "r");
-    pkey = PEM_read_bio_PrivateKey(key, NULL, NULL, NULL);
+    if (file) {
+      key = BIO_new_file(file, "r");
+      pkey = PEM_read_bio_PrivateKey(key, NULL, NULL, NULL);
 
-    BIO_free(key);
+      BIO_free(key);
+    }
     return (pkey);
 }
 
@@ -222,7 +223,7 @@ int encrypt_rsa_message(const char *plaintext, EVP_PKEY *public_key, unsigned ch
 
     RSA_free(rsa);
     OPENSSL_free(rsa_buffer);
-    OPENSSL_free(bioBuff);  
+    BIO_free(bioBuff);
 
     return encryptedtext_len;  
 }
@@ -244,7 +245,7 @@ int decrypt_rsa_message(const unsigned char *encryptedtext, const int encryptedt
 
     RSA_free(rsa);
     OPENSSL_free(rsa_buffer);
-    OPENSSL_free(bioBuff);   
+    BIO_free(bioBuff);
 
     return plaintext_len;
 }
@@ -258,6 +259,8 @@ int encode_auth_setting(const char *username, const char *password, EVP_PKEY *pu
     int encrypted_len;
     encrypted_len = encrypt_rsa_message(text, public_key, &encrypted);
     Base64Encode(encrypted, encrypted_len, authtoken);
+    OPENSSL_free(encrypted);
+
     return (0); //success
 }
 
@@ -270,6 +273,7 @@ int decode_auth_setting(int enable_debug, char *authtoken, EVP_PKEY *private_key
     int plaintext_len;
     plaintext_len = decrypt_rsa_message(encrypted_b64, encrypted_len_b64, private_key, &plaintext);
     plaintext[plaintext_len] = '\0';
+    free(encrypted_b64);
 
     char s_username[20], s_password[20];
     sscanf ((char *)plaintext,"user: %s\npwd:  %s\nts:   %ld", s_username, s_password, ts);
@@ -281,6 +285,7 @@ int decode_auth_setting(int enable_debug, char *authtoken, EVP_PKEY *private_key
     *password = (char *) calloc(21, sizeof(char));
     strncpy(*username, s_username, 20);
     strncpy(*password, s_password, 20);
+    OPENSSL_free(plaintext);
     return (0);
 }
 


### PR DESCRIPTION
The base64 decode will crash on musl c-library builds for OpenWRT
due to the write of the '\0' past the end of the allocated buffer.
Fix other various memory leaks on the authentication code paths.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

