### PR TITLE
fix burst mode throttle checking

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1397,7 +1397,7 @@ iperf_check_throttle(struct iperf_stream *sp, struct iperf_time *nowP)
     double seconds;
     uint64_t bits_per_second;
 
-    if (sp->test->done)
+    if (sp->test->done || sp->test->settings->rate == 0 || sp->test->settings->burst != 0)
         return;
     iperf_time_diff(&sp->result->start_time_fixed, nowP, &temp_time);
     seconds = iperf_time_in_secs(&temp_time);
@@ -1442,8 +1442,7 @@ iperf_send(struct iperf_test *test, fd_set *write_setP)
 		streams_active = 1;
 		test->bytes_sent += r;
 		++test->blocks_sent;
-		if (test->settings->rate != 0 && test->settings->burst == 0)
-		    iperf_check_throttle(sp, &now);
+		iperf_check_throttle(sp, &now);
 		if (multisend > 1 && test->settings->bytes != 0 && test->bytes_sent >= test->settings->bytes)
 		    break;
 		if (multisend > 1 && test->settings->blocks != 0 && test->blocks_sent >= test->settings->blocks)


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: **master**

* Issues fixed (if any):

While investigating a different iperf issue with udp stream tests I noticed that using -b 0/1000 results in iperf sending 1000 packets and then just idle for the remainder of the test duration.
The full command I was using to reproduce the issue:
```iperf3 -c 192.168.101.2 -B 192.168.101.1 -b0/1000 -u -t 10 -l 1400```

* Brief description of code changes (suitable for use as a commit message):

When burst mode is configured for unlimited rate (-b0) but with a
specific packet burst value, iperf only sends packets once, after that
the iperf_check_throttle function gets called and sets green_light=0
due to the rate value being 0 and average calculated rate always being
higher than that.

This can be fixed by moving the "don't throttle" condition
directly inside the iperf_check_throttle function.

Signed-off-by: Ondrej Lichtner <olichtne@redhat.com>