### PR TITLE
fix: check if bidir option was already set

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -470,7 +470,9 @@ iperf_set_test_role(struct iperf_test *ipt, char role)
 {
     ipt->role = role;
     if (!ipt->reverse) {
-        if (role == 'c')
+        if (ipt->bidirectional)
+            ipt->mode = BIDIRECTIONAL;
+        else if (role == 'c')
             ipt->mode = SENDER;
         else if (role == 's')
             ipt->mode = RECEIVER;


### PR DESCRIPTION
If --bidir option was passed before --client option on command line,
the latter would override ipt->mode parameter of the test back to SENDER
or RECEIVER making the test hang during execution.

Fix this by checking if ipt->biderectional was set to true in
iperf_set_test_role() function.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: latest

* Issues fixed (if any):
Fixes the hang when starting iperf3 client with --bidir option preceding --client option, that is:
```
iperf3 --bidir --client <server_name>
```

