### PR TITLE
Force type check on JSON objects that are blindly used as string type

### DIFF
--- a/src/cjson.c
+++ b/src/cjson.c
@@ -1738,9 +1738,21 @@ CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char
     return get_object_item(object, string, false);
 }
 
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemOfType(const cJSON * const object, const char * const string, int type)
+{
+    cJSON * obj = get_object_item(object, string, false);
+    return obj == NULL || obj->type != type ? NULL : obj;
+}
+
 CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string)
 {
     return get_object_item(object, string, true);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitiveOfType(const cJSON * const object, const char * const string, int type)
+{
+    cJSON * obj = get_object_item(object, string, true);
+    return obj == NULL || obj->type != type ? NULL : obj;
 }
 
 CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string)

--- a/src/cjson.h
+++ b/src/cjson.h
@@ -161,7 +161,9 @@ CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array);
 CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index);
 /* Get item "string" from object. Case insensitive. */
 CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemOfType(const cJSON * const object, const char * const string, int type);
 CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitiveOfType(const cJSON * const object, const char * const string, int type);
 CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string);
 /* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
 CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1815,13 +1815,13 @@ get_parameters(struct iperf_test *test)
 	    test->settings->tos = j_p->valueint;
 	if ((j_p = cJSON_GetObjectItem(j, "flowlabel")) != NULL)
 	    test->settings->flowlabel = j_p->valueint;
-	if ((j_p = cJSON_GetObjectItem(j, "title")) != NULL)
+	if ((j_p = cJSON_GetObjectItemOfType(j, "title", cJSON_String)) != NULL)
 	    test->title = strdup(j_p->valuestring);
-	if ((j_p = cJSON_GetObjectItem(j, "extra_data")) != NULL)
+	if ((j_p = cJSON_GetObjectItemOfType(j, "extra_data", cJSON_String)) != NULL)
 	    test->extra_data = strdup(j_p->valuestring);
-	if ((j_p = cJSON_GetObjectItem(j, "congestion")) != NULL)
+	if ((j_p = cJSON_GetObjectItemOfType(j, "congestion", cJSON_String)) != NULL)
 	    test->congestion = strdup(j_p->valuestring);
-	if ((j_p = cJSON_GetObjectItem(j, "congestion_used")) != NULL)
+	if ((j_p = cJSON_GetObjectItemOfType(j, "congestion_used", cJSON_String)) != NULL)
 	    test->congestion_used = strdup(j_p->valuestring);
 	if ((j_p = cJSON_GetObjectItem(j, "get_server_output")) != NULL)
 	    iperf_set_test_get_server_output(test, 1);
@@ -1830,7 +1830,7 @@ get_parameters(struct iperf_test *test)
 	if ((j_p = cJSON_GetObjectItem(j, "repeating_payload")) != NULL)
 	    test->repeating_payload = 1;
 #if defined(HAVE_SSL)
-	if ((j_p = cJSON_GetObjectItem(j, "authtoken")) != NULL)
+	if ((j_p = cJSON_GetObjectItemOfType(j, "authtoken", cJSON_String)) != NULL)
         test->settings->authtoken = strdup(j_p->valuestring);
 #endif //HAVE_SSL
 	if (test->mode && test->protocol->id == Ptcp && has_tcpinfo_retransmits())
@@ -2092,7 +2092,7 @@ get_results(struct iperf_test *test)
 		    }
 		    else {
 			/* No JSON, look for textual output.  Make a copy of the text for later. */
-			j_server_output = cJSON_GetObjectItem(j, "server_output_text");
+			j_server_output = cJSON_GetObjectItemOfType(j, "server_output_text", cJSON_String);
 			if (j_server_output != NULL) {
 			    test->server_output_text = strdup(j_server_output->valuestring);
 			}
@@ -2101,7 +2101,7 @@ get_results(struct iperf_test *test)
 	    }
 	}
 
-	j_remote_congestion_used = cJSON_GetObjectItem(j, "congestion_used");
+	j_remote_congestion_used = cJSON_GetObjectItemOfType(j, "congestion_used", cJSON_String);
 	if (j_remote_congestion_used != NULL) {
 	    test->remote_congestion_used = strdup(j_remote_congestion_used->valuestring);
 	}


### PR DESCRIPTION
The commit tries to prevent a situation when iperf_server treats
a received JSON object as a 'valuestring' without additional check,
while client can send something else - a number, null, ...
Passing the 'object->valuestring' into 'strdup' then ends with fault.

Add 'cJSON_GetObjectItemOfType', 'cJSON_GetObjectItemCaseSensitiveOfType' wrappers.
