### PR TITLE
Make '--port 0' a valid argument

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -877,7 +877,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         switch (flag) {
             case 'p':
 		portno = atoi(optarg);
-		if (portno < 1 || portno > 65535) {
+		if (portno < 0 || portno > 65535) {
 		    i_errno = IEBADPORT;
 		    return -1;
 		}
@@ -1046,7 +1046,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 break;
             case OPT_CLIENT_PORT:
 		portno = atoi(optarg);
-		if (portno < 1 || portno > 65535) {
+		if (portno < 0 || portno > 65535) {
 		    i_errno = IEBADPORT;
 		    return -1;
 		}

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -143,7 +143,7 @@ iperf_strerror(int int_errno)
 	    snprintf(errstr, len, "bad format specifier (valid formats are in the set [kmgtKMGT])");
 	    break;
 	case IEBADPORT:
-	    snprintf(errstr, len, "port number must be between 1 and 65535 inclusive");
+	    snprintf(errstr, len, "port number must be between 0 and 65535 inclusive");
 	    break;
         case IEMSS:
             snprintf(errstr, len, "TCP MSS too large (maximum = %d bytes)", MAX_MSS);


### PR DESCRIPTION
Changes based on #885.
Enables usage of `--port 0`.

See #931 for explanation.