### PR TITLE
Fix runtime linking when installed outside default prefix (#153)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,7 +49,7 @@ libiperf_la_SOURCES     = \
 iperf3_SOURCES          = main.c
 iperf3_CFLAGS           = -g
 iperf3_LDADD            = libiperf.la
-iperf3_LDFLAGS          = -g
+iperf3_LDFLAGS          = -g -rpath $(libdir)
 
 if ENABLE_PROFILING
 # If the iperf-profiled-binary is enabled (and this condition is true by default)


### PR DESCRIPTION
When libiperf was installed in a directory not searched by default (e.g. /usr/local/lib on some systems), iperf3 would fail to find it at runtime. Pass -rpath when linking iperf3 to remedy this. The problem was originally discovered on Ubuntu Linux.
