### PR TITLE
Fix memory leaks for RSA key setters

### DIFF
--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -172,6 +172,7 @@ EVP_PKEY *load_pubkey_from_base64(const char *buffer) {
     BIO* bio = BIO_new(BIO_s_mem());
     BIO_write(bio, key, key_len);
     EVP_PKEY *pkey = PEM_read_bio_PUBKEY(bio, NULL, NULL, NULL);
+    BIO_free(bio);
     return (pkey);
 }
 
@@ -196,6 +197,7 @@ EVP_PKEY *load_privkey_from_base64(const char *buffer) {
     BIO* bio = BIO_new(BIO_s_mem());
     BIO_write(bio, key, key_len);
     EVP_PKEY *pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+    BIO_free(bio);
     return (pkey);
 }
 


### PR DESCRIPTION
* Version of iperf3: `master` branch

* Issues fixed (if any): #940(partially) memory leaks while using API calls to set RSA keys

