### PR TITLE
build: Unbreak builds on macOS by not building profiled binaries by default

### DIFF
--- a/configure
+++ b/configure
@@ -1416,7 +1416,7 @@ Optional Features:
   --enable-fast-install[=PKGS]
                           optimize for fast installation [default=yes]
   --disable-libtool-lock  avoid locking (might break parallel builds)
-  --disable-profiling     Disable iperf profiling binary
+  --enable-profiling      Enable iperf profiling binary
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -12135,12 +12135,12 @@ if test "x$GCC" = "xyes"; then
   CFLAGS="$CFLAGS -Wall"
 fi
 
-# Check if profiling must be disabled
+# Check if enable profiling
 # Check whether --enable-profiling was given.
 if test "${enable_profiling+set}" = set; then :
-  enableval=$enable_profiling; :
+  enableval=$enable_profiling; enable_profiling=yes
 else
-  enable_profiling=yes
+  :
 fi
 
  if test x$enable_profiling = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -52,11 +52,11 @@ if test "x$GCC" = "xyes"; then
   CFLAGS="$CFLAGS -Wall"
 fi
 
-# Check if profiling must be disabled
+# Check if enable profiling
 AC_ARG_ENABLE([profiling],
-    AS_HELP_STRING([--disable-profiling], [Disable iperf profiling binary]),
-    [:],
-    [enable_profiling=yes])
+    AS_HELP_STRING([--enable-profiling], [Enable iperf profiling binary]),
+    [enable_profiling=yes],
+    [:])
 AM_CONDITIONAL([ENABLE_PROFILING], [test x$enable_profiling = xyes])
 
 # Checks for header files.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,7 +52,7 @@ iperf3_LDADD            = libiperf.la
 iperf3_LDFLAGS          = -g
 
 if ENABLE_PROFILING
-# If the iperf-profiled-binary is enabled (and this condition is true by default)
+# If the iperf-profiled-binary is enabled
 # Specify the sources and various flags for the profiled iperf binary. This
 # binary recompiles all the source files to make sure they are all profiled.
 iperf3_profile_SOURCES  = main.c \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -664,7 +664,7 @@ iperf3_CFLAGS = -g
 iperf3_LDADD = libiperf.la
 iperf3_LDFLAGS = -g
 
-# If the iperf-profiled-binary is enabled (and this condition is true by default)
+# If the iperf-profiled-binary is enabled
 # Specify the sources and various flags for the profiled iperf binary. This
 # binary recompiles all the source files to make sure they are all profiled.
 @ENABLE_PROFILING_TRUE@iperf3_profile_SOURCES = main.c \


### PR DESCRIPTION
Fixes #933.
