### PR TITLE
include iperf_util.h in main.c

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -44,9 +44,10 @@
 
 #include "iperf.h"
 #include "iperf_api.h"
-#include "units.h"
+#include "iperf_util.h"
 #include "iperf_locale.h"
 #include "net.h"
+#include "units.h"
 
 
 static int run(struct iperf_test *test);


### PR DESCRIPTION
73b02f9 implemented `daemon(3)` for systems that don't have it, but the
function prototype was never included in `main.c` where it is
referenced.

@bmah888 