### PR TITLE
fix urandom being left open

### DIFF
--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -75,6 +75,8 @@ int readentropy(void *out, size_t outsize)
                       rndfile,
                       feof(frandom) ? "EOF" : strerror(errno));
     }
+    fclose(frandom);
+    frandom = NULL;
     return 0;
 }
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): This file gets left open throughout both the c-api and iperf command program lifespan. Neither seem to close the file properly leading to a memory leak. The fix is more important for the c-api because the leak won't go away at the end of each iperf iteration. I wasn't exactly sure how often this function is used or if there is a better place to stick the file closing code. However, this change does eliminate the memory leak related to urandom being left open. 

Side note: There is another leak related to json which i'm currently trying to find a fix for. This looks like a cJSON issue but I'll continue investigating. 

* Brief description of code changes (suitable for use as a commit message): Fixed urandom being left open

