### PR TITLE
Issue #914 - workaround  to protect from garbled packet counters

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -357,6 +357,10 @@ struct iperf_test
 
 };
 
+/* Guard text before Packet Counter in UDP packets */
+#define PCOUNT_GURAD_BEFORE "BFOR"
+#define PCOUNT_GUARD_AFTER "AFTR"
+
 /* default settings */
 #define PORT 5201  /* default port to listen on (don't use the same port as iperf2) */
 #define uS_TO_NS 1000
@@ -374,8 +378,8 @@ struct iperf_test
 #define MB (1024 * 1024)
 #define MAX_TCP_BUFFER (512 * MB)
 #define MAX_BLOCKSIZE MB
-/* Minimum size UDP send is the size of two 32-bit ints followed by a 64-bit int */
-#define MIN_UDP_BLOCKSIZE (4 + 4 + 8)
+/* Minimum size UDP send is the size of two 32-bit ints followed by 4 chars guard then a 64-bit int and another 4 chars guard */
+#define MIN_UDP_BLOCKSIZE (4 + 4 + 4 + 8 +4)
 /* Maximum size UDP send is (64K - 1) - IP and UDP header sizes */
 #define MAX_UDP_BLOCKSIZE (65535 - 8 - 20)
 #define MIN_INTERVAL 0.1


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #914

* Brief description of code changes (suitable for use as a commit message):
As described in issue #914 discussion, it seems that sometimes the first UDP packet is received truncated or garbled, so the packet counter is garbled.
The changes include:
1. Adding a guard well known text before and after pcount in the packet header and verifying in the receiving side that this text was received.  Only then pcount is regarded as valid.
2. Clear the header part of the receiving buffer before each receive, to make sure that guards will no be valid in case a truncated packet is received.
