### PR TITLE
Fix for possible leaks or double frees

### DIFF
--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -479,6 +479,7 @@ iperf_sctp_connect(struct iperf_test *test)
     if (!TAILQ_EMPTY(&test->xbind_addrs)) {
         if (iperf_sctp_bindx(test, s, IPERF_SCTP_CLIENT)) {
             freeaddrinfo(server_res);
+            close(s);
             return -1;
         }
     }
@@ -502,7 +503,6 @@ iperf_sctp_connect(struct iperf_test *test)
         i_errno = IESENDCOOKIE;
         return -1;
     }
-    freeaddrinfo(server_res);
 
     /*
      * We want to allow fragmentation.  But there's at least one
@@ -522,6 +522,7 @@ iperf_sctp_connect(struct iperf_test *test)
         return -1;
     }
 
+    freeaddrinfo(server_res);
     return s;
 #else
     i_errno = IENOSCTP;

--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -131,12 +131,14 @@ iperf_sctp_accept(struct iperf_test * test)
 
     if (Nread(s, cookie, COOKIE_SIZE, Psctp) < 0) {
         i_errno = IERECVCOOKIE;
+        close(s);
         return -1;
     }
 
-    if (strcmp(test->cookie, cookie) != 0) {
+    if (strncmp(test->cookie, cookie, COOKIE_SIZE) != 0) {
         if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Psctp) < 0) {
             i_errno = IESENDMESSAGE;
+            close(s);
             return -1;
         }
         close(s);
@@ -240,9 +242,11 @@ iperf_sctp_listen(struct iperf_test *test)
 
     /* servers must call sctp_bindx() _instead_ of bind() */
     if (!TAILQ_EMPTY(&test->xbind_addrs)) {
-        freeaddrinfo(res);
-        if (iperf_sctp_bindx(test, s, IPERF_SCTP_SERVER))
+        if (iperf_sctp_bindx(test, s, IPERF_SCTP_SERVER)) {
+            close(s);
+            freeaddrinfo(res);
             return -1;
+        }
     } else
     if (bind(s, (struct sockaddr *) res->ai_addr, res->ai_addrlen) < 0) {
         saved_errno = errno;
@@ -473,8 +477,10 @@ iperf_sctp_connect(struct iperf_test *test)
 
     /* clients must call bind() followed by sctp_bindx() before connect() */
     if (!TAILQ_EMPTY(&test->xbind_addrs)) {
-        if (iperf_sctp_bindx(test, s, IPERF_SCTP_CLIENT))
+        if (iperf_sctp_bindx(test, s, IPERF_SCTP_CLIENT)) {
+            freeaddrinfo(server_res);
             return -1;
+        }
     }
 
     /* TODO support sctp_connectx() to avoid heartbeating. */
@@ -486,16 +492,17 @@ iperf_sctp_connect(struct iperf_test *test)
         i_errno = IESTREAMCONNECT;
         return -1;
     }
-    freeaddrinfo(server_res);
 
     /* Send cookie for verification */
     if (Nwrite(s, test->cookie, COOKIE_SIZE, Psctp) < 0) {
 	saved_errno = errno;
 	close(s);
+	freeaddrinfo(server_res);
 	errno = saved_errno;
         i_errno = IESENDCOOKIE;
         return -1;
     }
+    freeaddrinfo(server_res);
 
     /*
      * We want to allow fragmentation.  But there's at least one


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):
   I ran a coverity scan on the iperf3 code and there are a couple of possible leaks or double frees in the iperf_sctp.c file. I tried to resolve these in this PR. These might very well be false positives but I think at least some of these make sense. Take a look and let me know what you think.

Thanks.
