### PR TITLE
iperf_api: fix compiler warning while printing an uint64_t

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -773,7 +773,7 @@ iperf_on_connect(struct iperf_test *test)
             }
         }
         if (test->settings->rate)
-            iperf_printf(test, "      Target Bitrate: %llu\n", test->settings->rate);
+            iperf_printf(test, "      Target Bitrate: %"PRIu64"\n", test->settings->rate);
     }
 }
 


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):
iperf_api: fix compiler warning while printing an uint64_t

Fix the followig warning:
../../src/iperf_api.c: In function ‘iperf_on_connect’:
../../src/iperf_api.c:791:58: warning: format ‘%llu’ expects argument
of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t’
{aka ‘long unsigned int’} [-Wformat=]