### PR TITLE
Resolved name clashes between windows.h and openssl (cygwin under win…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,11 @@ else
 	  fi ]
     )
     if $have_ssl; then
+        case $host in
+           *-*-cygwin)
+             CFLAGS="$CFFLAGS -DNOCRYPT"
+             ;;
+        esac
         LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
         LIBS="$OPENSSL_LIBS $LIBS"
         CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@ else
     if $have_ssl; then
         case $host in
            *-*-cygwin)
-             CFLAGS="$CFFLAGS -DNOCRYPT"
+             CFLAGS="$CFLAGS -DNOCRYPT"
              ;;
         esac
         LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"


### PR DESCRIPTION
windows.h declares some const defined on openssl when using cygwin.
It can be sufficient do before importing openssl headers

#undef X509_NAME
#undef X509_CERT_PAIR
#undef X509_EXTENSIONS
#undef OCSP_REQUEST
#undef OCSP_RESPONSE

but using the CFLAGS -DNOCRYPT it solve the problem