### PR TITLE
Add configure option to enable static linking of iperf binary.

### DIFF
--- a/config/iperf_config_static_bin.m4
+++ b/config/iperf_config_static_bin.m4
@@ -1,0 +1,11 @@
+# Also link binaries as static
+AC_ARG_ENABLE([static-bin],
+    AS_HELP_STRING([--enable-static-bin], [link iperf binary statically]),
+    [enable_static_bin=yes
+     AC_DISABLE_SHARED],
+    [:])
+AM_CONDITIONAL([ENABLE_STATIC_BIN], [test x$enable_static_bin = xno])
+
+AS_IF([test "x$enable_static_bin" == xyes],
+ [LDFLAGS="$LDFLAGS --static"]
+ [])

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,7 @@
 # Initialize the autoconf system for the specified tool, version and mailing list
 AC_INIT(iperf, 3.7+, https://github.com/esnet/iperf, iperf, https://software.es.net/iperf/)
 m4_include([config/ax_check_openssl.m4])
+m4_include([config/iperf_config_static_bin.m4])
 AC_LANG(C)
 
 # Specify where the auxiliary files created by configure should go. The config
@@ -35,6 +36,9 @@ AC_CONFIG_AUX_DIR(config)
 
 # Initialize the automake system
 AM_INIT_AUTOMAKE([foreign])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+LT_INIT
+
 AM_MAINTAINER_MODE
 AM_CONFIG_HEADER(src/iperf_config.h)
 


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

