### PR TITLE
Allow disabling auto-detect of SCTP

### DIFF
--- a/config/iperf_config_static_bin.m4
+++ b/config/iperf_config_static_bin.m4
@@ -1,6 +1,6 @@
 # Also link binaries as static
 AC_ARG_ENABLE([static-bin],
-    AS_HELP_STRING([--enable-static-bin], [link iperf binary statically]),
+    AS_HELP_STRING([--enable-static-bin], [link iperf3 binary statically]),
     [enable_static_bin=yes
      AC_DISABLE_SHARED],
     [:])

--- a/configure
+++ b/configure
@@ -775,6 +775,7 @@ with_sysroot
 enable_libtool_lock
 enable_maintainer_mode
 enable_profiling
+with_sctp
 with_openssl
 '
       ac_precious_vars='build_alias
@@ -1433,6 +1434,7 @@ Optional Packages:
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
   --with-sysroot[=DIR]    Search for dependent libraries within DIR (or the
                           compiler's sysroot if not specified).
+  --without-sctp          disable SCTP
   --with-openssl=DIR      root of the OpenSSL directory
 
 Some influential environment variables:
@@ -13361,7 +13363,35 @@ fi
 done
 
 
+# SCTP.  Allow user to disable SCTP support with --without-sctp.
+# Otherwise we try to find whatever support is required.
+try_sctp=true
+
+# Check whether --with-sctp was given.
+if test "${with_sctp+set}" = set; then :
+  withval=$with_sctp;
+        case "$withval" in
+	y | ye | yes)
+	  ;;
+	n | no)
+	try_sctp=false
+	  ;;
+	*)
+	as_fn_error $? "Invalid --with-sctp value" "$LINENO" 5
+	  ;;
+	esac
+
+else
+
+        try_sctp=true
+
+
+fi
+
+
 # Check for SCTP support
+echo "TRY_SCTP" $try_sctp
+if $try_sctp; then
 for ac_header in sys/socket.h
 do :
   ac_fn_c_check_header_mongrel "$LINENO" "sys/socket.h" "ac_cv_header_sys_socket_h" "$ac_includes_default"
@@ -13513,6 +13543,7 @@ fi
 
 done
 
+fi
 
 ac_fn_c_check_header_mongrel "$LINENO" "endian.h" "ac_cv_header_endian_h" "$ac_includes_default"
 if test "x$ac_cv_header_endian_h" = xyes; then :

--- a/configure
+++ b/configure
@@ -1406,7 +1406,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-  --enable-static-bin     link iperf binary statically
+  --enable-static-bin     link iperf3 binary statically
   --enable-shared[=PKGS]  build shared libraries [default=no]
   --enable-silent-rules   less verbose build output (undo: "make V=1")
   --disable-silent-rules  verbose build output (undo: "make V=0")
@@ -1421,7 +1421,7 @@ Optional Features:
   --enable-maintainer-mode
                           enable make rules and dependencies not useful (and
                           sometimes confusing) to the casual installer
-  --enable-profiling      Enable iperf profiling binary
+  --enable-profiling      Enable iperf3 profiling binary
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -13390,7 +13390,6 @@ fi
 
 
 # Check for SCTP support
-echo "TRY_SCTP" $try_sctp
 if $try_sctp; then
 for ac_header in sys/socket.h
 do :

--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,7 @@ fi
 
 # Check if enable profiling
 AC_ARG_ENABLE([profiling],
-    AS_HELP_STRING([--enable-profiling], [Enable iperf profiling binary]),
+    AS_HELP_STRING([--enable-profiling], [Enable iperf3 profiling binary]),
     [enable_profiling=yes],
     [:])
 AM_CONDITIONAL([ENABLE_PROFILING], [test x$enable_profiling = xyes])
@@ -116,7 +116,6 @@ AC_ARG_WITH([sctp],
 )
 
 # Check for SCTP support
-echo "TRY_SCTP" $try_sctp
 if $try_sctp; then
 AC_CHECK_HEADERS([sys/socket.h])
 AC_CHECK_HEADERS([netinet/sctp.h],

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# iperf, Copyright (c) 2014-2018, The Regents of the University of
+# iperf, Copyright (c) 2014-2020, The Regents of the University of
 # California, through Lawrence Berkeley National Laboratory (subject
 # to receipt of any required approvals from the U.S. Dept. of
 # Energy).  All rights reserved.
@@ -93,7 +93,31 @@ AC_C_CONST
 # Check for poll.h (it's in POSIX so everyone should have it?)
 AC_CHECK_HEADERS([poll.h])
 
+# SCTP.  Allow user to disable SCTP support with --without-sctp.
+# Otherwise we try to find whatever support is required.
+try_sctp=true
+AC_ARG_WITH([sctp],
+    [AS_HELP_STRING([--without-sctp],
+        [disable SCTP])],
+    [
+        case "$withval" in
+	y | ye | yes)
+	  ;;
+	n | no)
+	try_sctp=false
+	  ;;
+	*)
+	AC_MSG_ERROR([Invalid --with-sctp value])
+	  ;;
+	esac
+    ], [
+        try_sctp=true
+    ]
+)
+
 # Check for SCTP support
+echo "TRY_SCTP" $try_sctp
+if $try_sctp; then
 AC_CHECK_HEADERS([sys/socket.h])
 AC_CHECK_HEADERS([netinet/sctp.h],
 		 AC_DEFINE([HAVE_SCTP], [1], [Have SCTP support.])
@@ -105,6 +129,7 @@ AC_CHECK_HEADERS([netinet/sctp.h],
 #include <sys/socket.h>
 #endif
 ])
+fi
 
 AC_CHECK_HEADER([endian.h],
 		AC_DEFINE([HAVE_ENDIAN_H], [1], [Define to 1 if you have the <endian.h> header file.]),


### PR DESCRIPTION
Support a --without-sctp flag at configure to disable SCTP checks.
Useful for the specific case of creating a statically-linked
executable on CentOS, which lacks static SCTP libraries.
