### PR TITLE
Fix warning: "HAVE_SCTP" redefined

### DIFF
--- a/configure
+++ b/configure
@@ -13415,7 +13415,7 @@ if test "x$ac_cv_header_netinet_sctp_h" = xyes; then :
 #define HAVE_NETINET_SCTP_H 1
 _ACEOF
 
-$as_echo "#define HAVE_SCTP 1" >>confdefs.h
+$as_echo "#define HAVE_SCTP_H 1" >>confdefs.h
 
 		 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing sctp_bindx" >&5
 $as_echo_n "checking for library containing sctp_bindx... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -119,7 +119,7 @@ AC_ARG_WITH([sctp],
 if $try_sctp; then
 AC_CHECK_HEADERS([sys/socket.h])
 AC_CHECK_HEADERS([netinet/sctp.h],
-		 AC_DEFINE([HAVE_SCTP], [1], [Have SCTP support.])
+		 AC_DEFINE([HAVE_SCTP_H], [1], [Have SCTP support.])
 		 AC_SEARCH_LIBS(sctp_bindx, [sctp])
 		 AC_CHECK_TYPES([struct sctp_assoc_value], [], [],
 				[[#include <netinet/sctp.h>]]),

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -76,9 +76,9 @@
 #include "iperf_api.h"
 #include "iperf_udp.h"
 #include "iperf_tcp.h"
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
 #include "iperf_sctp.h"
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 #include "timer.h"
 
 #include "cjson.h"
@@ -848,7 +848,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         {"congestion", required_argument, NULL, 'C'},
         {"linux-congestion", required_argument, NULL, 'C'},
 #endif /* HAVE_TCP_CONGESTION */
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
         {"sctp", no_argument, NULL, OPT_SCTP},
         {"nstreams", required_argument, NULL, OPT_NUMSTREAMS},
         {"xbind", required_argument, NULL, 'X'},
@@ -968,14 +968,14 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 		client_flag = 1;
                 break;
             case OPT_SCTP:
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
                 set_protocol(test, Psctp);
                 client_flag = 1;
                 break;
-#else /* HAVE_SCTP */
+#else /* HAVE_SCTP_H */
                 i_errno = IEUNIMP;
                 return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 
             case OPT_NUMSTREAMS:
 #if defined(linux) || defined(__FreeBSD__)
@@ -2322,9 +2322,9 @@ int
 iperf_defaults(struct iperf_test *testp)
 {
     struct protocol *tcp, *udp;
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     struct protocol *sctp;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 
     testp->omit = OMIT;
     testp->duration = DURATION;
@@ -2403,7 +2403,7 @@ iperf_defaults(struct iperf_test *testp)
 
     set_protocol(testp, Ptcp);
 
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     sctp = protocol_new();
     if (!sctp) {
         protocol_free(tcp);
@@ -2421,7 +2421,7 @@ iperf_defaults(struct iperf_test *testp)
     sctp->init = iperf_sctp_init;
 
     SLIST_INSERT_AFTER(udp, sctp, protocols);
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 
     testp->on_new_stream = iperf_on_new_stream;
     testp->on_test_start = iperf_on_test_start;

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -40,7 +40,7 @@
 #undef HAVE_SCHED_SETAFFINITY
 
 /* Have SCTP support. */
-#undef HAVE_SCTP
+#undef HAVE_SCTP_H
 
 /* Define to 1 if you have the `sendfile' function. */
 #undef HAVE_SENDFILE

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -125,11 +125,11 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #endif //HAVE_SSL
                            "Client specific:\n"
                            "  -c, --client    <host>    run in client mode, connecting to <host>\n"
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
                            "  --sctp                    use SCTP rather than TCP\n"
                            "  -X, --xbind <name>        bind SCTP association to links\n"
                            "  --nstreams      #         number of SCTP streams\n"
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
                            "  -u, --udp                 use UDP rather than TCP\n"
                            "  --connect-timeout #       timeout for control connection setup (ms)\n"
                            "  -b, --bitrate #[KMG][/#]  target bitrate in bits/sec (0 for unlimited)\n"

--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -57,7 +57,7 @@
 int
 iperf_sctp_recv(struct iperf_stream *sp)
 {
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     int r;
 
     r = Nread(sp->socket, sp->buffer, sp->settings->blksize, Psctp);
@@ -78,7 +78,7 @@ iperf_sctp_recv(struct iperf_stream *sp)
 #else
     i_errno = IENOSCTP;
     return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 }
 
 
@@ -89,7 +89,7 @@ iperf_sctp_recv(struct iperf_stream *sp)
 int
 iperf_sctp_send(struct iperf_stream *sp)
 {
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     int r;
 
     r = Nwrite(sp->socket, sp->buffer, sp->settings->blksize, Psctp);
@@ -103,7 +103,7 @@ iperf_sctp_send(struct iperf_stream *sp)
 #else
     i_errno = IENOSCTP;
     return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 }
 
 
@@ -115,7 +115,7 @@ iperf_sctp_send(struct iperf_stream *sp)
 int
 iperf_sctp_accept(struct iperf_test * test)
 {
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     int     s;
     signed char rbuf = ACCESS_DENIED;
     char    cookie[COOKIE_SIZE];
@@ -148,7 +148,7 @@ iperf_sctp_accept(struct iperf_test * test)
 #else
     i_errno = IENOSCTP;
     return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 }
 
 
@@ -159,7 +159,7 @@ iperf_sctp_accept(struct iperf_test * test)
 int
 iperf_sctp_listen(struct iperf_test *test)
 {
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     struct addrinfo hints, *res;
     char portstr[6];
     int s, opt, saved_errno;
@@ -270,7 +270,7 @@ iperf_sctp_listen(struct iperf_test *test)
 #else
     i_errno = IENOSCTP;
     return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 }
 
 
@@ -281,7 +281,7 @@ iperf_sctp_listen(struct iperf_test *test)
 int
 iperf_sctp_connect(struct iperf_test *test)
 {
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     int s, opt, saved_errno;
     char portstr[6];
     struct addrinfo hints, *local_res, *server_res;
@@ -527,7 +527,7 @@ iperf_sctp_connect(struct iperf_test *test)
 #else
     i_errno = IENOSCTP;
     return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 }
 
 
@@ -535,12 +535,12 @@ iperf_sctp_connect(struct iperf_test *test)
 int
 iperf_sctp_init(struct iperf_test *test)
 {
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     return 0;
 #else
     i_errno = IENOSCTP;
     return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 }
 
 
@@ -552,7 +552,7 @@ iperf_sctp_init(struct iperf_test *test)
 int
 iperf_sctp_bindx(struct iperf_test *test, int s, int is_server)
 {
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     struct addrinfo hints;
     char portstr[6];
     char *servname;
@@ -701,5 +701,5 @@ out:
 #else
     i_errno = IENOSCTP;
     return -1;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
 }

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -267,7 +267,7 @@ get_optional_features(void)
     numfeatures++;
 #endif /* HAVE_FLOWLABEL */
     
-#if defined(HAVE_SCTP)
+#if defined(HAVE_SCTP_H)
     if (numfeatures > 0) {
 	strncat(features, ", ", 
 		sizeof(features) - strlen(features) - 1);
@@ -275,7 +275,7 @@ get_optional_features(void)
     strncat(features, "SCTP", 
 	sizeof(features) - strlen(features) - 1);
     numfeatures++;
-#endif /* HAVE_SCTP */
+#endif /* HAVE_SCTP_H */
     
 #if defined(HAVE_TCP_CONGESTION)
     if (numfeatures > 0) {


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

master

* Issues fixed (if any):

The netinet/sctp.h header file defines HAVE_SCTP, so we have this
warning while building:
```
    In file included from ../../src/iperf.h:30,
                     from ../../src/iperf_sctp.c:46:
    ./iperf_config.h:44: warning: "HAVE_SCTP" redefined
       44 | #define HAVE_SCTP 1
          |
    In file included from ../../src/iperf_sctp.c:43:
    /usr/include/netinet/sctp.h:56: note: this is the location of the previous definition
       56 | #define HAVE_SCTP
          |
```

* Brief description of code changes (suitable for use as a commit message):

This patch replaces our HAVE_SCTP definition with HAVE_SCTP_H to avoid
this warning.
