### PR TITLE
Fix enable/disable-profiling flag

### DIFF
--- a/configure
+++ b/configure
@@ -12947,9 +12947,7 @@ fi
 # Check if enable profiling
 # Check whether --enable-profiling was given.
 if test "${enable_profiling+set}" = set; then :
-  enableval=$enable_profiling; enable_profiling=yes
-else
-  :
+  enableval=$enable_profiling;
 fi
 
  if test x$enable_profiling = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -58,9 +58,7 @@ fi
 
 # Check if enable profiling
 AC_ARG_ENABLE([profiling],
-    AS_HELP_STRING([--enable-profiling], [Enable iperf3 profiling binary]),
-    [enable_profiling=yes],
-    [:])
+    AS_HELP_STRING([--enable-profiling], [Enable iperf3 profiling binary]))
 AM_CONDITIONAL([ENABLE_PROFILING], [test x$enable_profiling = xyes])
 
 # Checks for header files.


### PR DESCRIPTION
This caused an issue having --disable-profiling, but the profiling was actually enabled.

The variable enable_profiling exists just because AC_ARG_ENABLE([profiling] is defined.
If it is redefined in the exist condition, the both enable and disable flags will enable the profiling,
just if the flag is missing it will be disabled.
Reference in Warning here: https://autotools.io/autoconf/arguments.html

Improves on #763 

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

