### PR TITLE
Issue 999 follow up

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -1,4 +1,4 @@
-.TH IPERF3 1 "June 2019" ESnet "User Manuals"
+.TH IPERF3 1 "July 2020" ESnet "User Manuals"
 .SH NAME
 iperf3 \- perform network throughput tests
 .SH SYNOPSIS

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -177,6 +177,15 @@ write a file with the process ID, most useful when running as a daemon.
 .BR -1 ", " --one-off
 handle one client connection, then exit.
 .TP
+.BR --server-bitrate-limit " \fIn\fR[KMGT]"
+set a limit on the server side, which will cause a test to abort if
+the client specifies a test of more than \fIn\fR bits per second, or
+if the average data sent or received by the client (including all data
+streams) is greater than \fIn\fR bits per second.  The default limit
+is zero, which implies no limit.  The interval over which to average
+the data rate is 5 seconds by default, but can be specified by adding
+a '/' and a number to the bitrate specifier.
+.TP
 .BR --rsa-private-key-path " \fIfile\fR"
 path to the RSA private key (not password-protected) used to decrypt 
 authentication credentials from the client (if built with OpenSSL
@@ -209,7 +218,7 @@ connection establishment.
 Providing a shorter value may speed up detection of a down iperf3
 server.
 .TP
-.BR -b ", " --bitrate " \fIn\fR[KM]"
+.BR -b ", " --bitrate " \fIn\fR[KMGT]"
 set target bitrate to \fIn\fR bits/sec (default 1 Mbit/sec for UDP,
 unlimited for TCP/SCTP).
 If there are multiple streams (\-P flag), the throughput limit is applied
@@ -226,7 +235,7 @@ Compare with the \--fq-rate flag.
 This option replaces the \--bandwidth flag, which is now deprecated
 but (at least for now) still accepted.
 .TP
-.BR --pacing-timer " \fIn\fR[KMG]"
+.BR --pacing-timer " \fIn\fR[KMGT]"
 set pacing timer interval in microseconds (default 1000 microseconds,
 or 1 ms).
 This controls iperf3's internal pacing timer for the \-b/\--bitrate
@@ -236,7 +245,7 @@ Smaller values of the pacing timer parameter smooth out the traffic
 emitted by iperf3, but potentially at the cost of performance due to
 more frequent timer processing.
 .TP
-.BR --fq-rate " \fIn\fR[KM]"
+.BR --fq-rate " \fIn\fR[KMGT]"
 Set a rate to be used with fair-queueing based socket-level pacing,
 in bits per second.
 This pacing (if specified) will be in addition to any pacing due to
@@ -253,13 +262,13 @@ It is equivalent to specifying --fq-rate=0.
 .BR -t ", " --time " \fIn\fR"
 time in seconds to transmit for (default 10 secs)
 .TP
-.BR -n ", " --bytes " \fIn\fR[KM]"
+.BR -n ", " --bytes " \fIn\fR[KMGT]"
 number of bytes to transmit (instead of \-t)
 .TP
-.BR -k ", " --blockcount " \fIn\fR[KM]"
+.BR -k ", " --blockcount " \fIn\fR[KMGT]"
 number of blocks (packets) to transmit (instead of \-t or \-n)
 .TP
-.BR -l ", " --length " \fIn\fR[KM]"
+.BR -l ", " --length " \fIn\fR[KMGT]"
 length of buffer to read or write.  For TCP tests, the default value
 is 128KB.
 In the case of UDP, iperf3 tries to dynamically determine a reasonable
@@ -282,7 +291,7 @@ client
 test in both directions (normal and reverse), with both the client and
 server sending and receiving data simultaneously
 .TP
-.BR -w ", " --window " \fIn\fR[KM]"
+.BR -w ", " --window " \fIn\fR[KMGT]"
 window size / socket buffer size (this gets sent to the server and used on that side too)
 .TP
 .BR -M ", " --set-mss " \fIn\fR"

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1526,11 +1526,11 @@ iperf_check_total_rate(struct iperf_test *test, iperf_size_t last_interval_bytes
     seconds = test->stats_interval * test->settings->bitrate_limit_stats_per_interval;
     bits_per_second = total_bytes * 8 / seconds;
     if (test->debug) {
-        iperf_printf(test,"Interval %ld - throughput %ld bps (limit %ld)\n", test->bitrate_limit_stats_count, bits_per_second, test->settings->bitrate_limit);
+        iperf_printf(test,"Interval %" PRIu64 " - throughput %" PRIu64 " bps (limit %" PRIu64 ")\n", test->bitrate_limit_stats_count, bits_per_second, test->settings->bitrate_limit);
     }
 
     if (bits_per_second  > test->settings->bitrate_limit) {
-	iperf_err(test, "Total throughput of %ld bps exceeded %ld bps limit", bits_per_second, test->settings->bitrate_limit);
+	iperf_err(test, "Total throughput of %" PRIu64 " bps exceeded %" PRIu64 " bps limit", bits_per_second, test->settings->bitrate_limit);
 	test->bitrate_limit_exceeded = 1;
     }
 }

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2018 The Regents of the University of
+ * iperf, Copyright (c) 2014-2020 The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -617,7 +617,7 @@ iperf_run_server(struct iperf_test *test)
 		    /* Ensure that total requested data rate is not above limit */
 		    iperf_size_t total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
 		    if (test->settings->bitrate_limit > 0 && total_requested_rate > test->settings->bitrate_limit) {
-			iperf_err(test, "Client total requested throughput rate of %ld bps exceeded %ld bps limit",
+			iperf_err(test, "Client total requested throughput rate of %" PRIu64 " bps exceeded %" PRIu64 " bps limit",
 				total_requested_rate, test->settings->bitrate_limit);
 			cleanup_server(test);
 			i_errno = IETOTALRATE;

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -52,7 +52,13 @@
 #if defined(HAVE_INTTYPES_H)
 # include <inttypes.h>
 #else
-# define PRIu64		"llu"
+# ifndef PRIu64
+#  if sizeof(long) == 8
+#   define PRIu64		"lu"
+#  else
+#   define PRIu64		"llu"
+#  endif
+# endif
 #endif
 
 /* iperf_udp_recv


### PR DESCRIPTION
Follow-up to #999.

* Adds manual page text for the new `--server-bitrate-limit` flag.

* Fixes compiler warnings on macOS.

