### PR TITLE
fix: Unbreak build on CentOS 6.

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -68,7 +68,9 @@
 #include <openssl/evp.h>
 #endif // HAVE_SSL
 
+#if !defined(__IPERF_API_H)
 typedef uint64_t iperf_size_t;
+#endif // __IPERF_API_H
 
 struct iperf_interval_results
 {

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -45,7 +45,9 @@ struct iperf_interval_results;
 struct iperf_stream;
 struct iperf_time;
 
+#if !defined(__IPERF_H)
 typedef uint64_t iperf_size_t;
+#endif // __IPERF_H
 
 /* default settings */
 #define Ptcp SOCK_STREAM


### PR DESCRIPTION
The fix eliminates a duplicate definition of the iperf_size_t datatype
when both iperf.h and iperf_api.h are included.

Fixes #1039.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

