### PR TITLE
set TCP_NODELAY flag for ctrl socket on server side

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -119,6 +119,9 @@ iperf_accept(struct iperf_test *test)
     if (test->ctrl_sck == -1) {
         /* Server free, accept new client */
         test->ctrl_sck = s;
+        // set TCP_NODELAY flag to "flush" control messages as quickly as possible
+        int flag = 1;
+        setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int));
         if (Nread(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
             i_errno = IERECVCOOKIE;
             return -1;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

current git HEAD

* Issues fixed (if any):

this is an attempt to fix #1045 
it might be a too niche use-case for the wider audience but it does fix the issue I am having in my setup

* Brief description of code changes (suitable for use as a commit message):

in scenarios with high packet loss rate, for example due
to overflowing the capacity of the channel, the TCP traffic
on the control socket might be delayed too much. In a
particular case with a high-bandwidth bi-directionl UDP
test that exceeded the channel capacity by far, the UDP traffic
generated at the server was already causing full tx queues.
this caused the "delayed" TCP control packet to the client to be
also dropped. thus, the client never entered the TEST_RUNNING state.

this patch sets the TCP_NODELAY flag on the server's control
socket and makes sure that the control traffic goes through the
client before the UDP stream is even started.