### PR TITLE
fix: Fix regression in #997 where JSON output was free-ed too early.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4214,13 +4214,18 @@ iperf_json_finish(struct iperf_test *test)
     if (test->server_output_text) {
 	cJSON_AddStringToObject(test->json_top, "server_output_text", test->server_output_text);
     }
-    test->json_output_string = cJSON_Print(test->json_top);
+    // Get ASCII rendering of JSON structure.  Then make our
+    // own copy of it and return the storage that cJSON allocated
+    // on our behalf.  We keep our own copy around.
+    char *str = cJSON_Print(test->json_top);
+    if (str == NULL)
+	return -1;
+    test->json_output_string = strdup(str);
+    cJSON_free(str);
     if (test->json_output_string == NULL)
         return -1;
     fprintf(test->outfile, "%s\n", test->json_output_string);
     iflush(test);
-    cJSON_free(test->json_output_string);
-    test->json_output_string = NULL;
     cJSON_Delete(test->json_top);
     test->json_top = test->json_start = test->json_connected = test->json_intervals = test->json_server_output = test->json_end = NULL;
     return 0;


### PR DESCRIPTION
It didn't make anything crash, but API clients wouldn't be able to
access the JSON output.

Bug pointed out, and fix suggested by, @scottmsilver.  Fixes #1058.

