### PR TITLE
enh: Set TCP_NODELAY on control connections.  Reimplementation of #1046.

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -345,8 +345,8 @@ iperf_connect(struct iperf_test *test)
     // set TCP_NODELAY for lower latency on control messages
     int flag = 1;
     if (setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int))) {
-	i_errno = IESETNODELAY;
-	return -1;
+        i_errno = IESETNODELAY;
+        return -1;
     }
 
     if (Nwrite(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -342,6 +342,13 @@ iperf_connect(struct iperf_test *test)
         return -1;
     }
 
+    // set TCP_NODELAY for lower latency on control messages
+    int flag = 1;
+    if (setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int))) {
+	i_errno = IESETNODELAY;
+	return -1;
+    }
+
     if (Nwrite(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
         i_errno = IESENDCOOKIE;
         return -1;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -119,12 +119,12 @@ iperf_accept(struct iperf_test *test)
     if (test->ctrl_sck == -1) {
         /* Server free, accept new client */
         test->ctrl_sck = s;
-	// set TCP_NODELAY for lower latency on control messages
-	int flag = 1;
-	if (setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int))) {
-	    i_errno = IESETNODELAY;
-	    return -1;
-	}
+        // set TCP_NODELAY for lower latency on control messages
+        int flag = 1;
+        if (setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int))) {
+            i_errno = IESETNODELAY;
+            return -1;
+        }
 
         if (Nread(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
             i_errno = IERECVCOOKIE;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -119,6 +119,13 @@ iperf_accept(struct iperf_test *test)
     if (test->ctrl_sck == -1) {
         /* Server free, accept new client */
         test->ctrl_sck = s;
+	// set TCP_NODELAY for lower latency on control messages
+	int flag = 1;
+	if (setsockopt(test->ctrl_sck, IPPROTO_TCP, TCP_NODELAY, (char *) &flag, sizeof(int))) {
+	    i_errno = IESETNODELAY;
+	    return -1;
+	}
+
         if (Nread(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
             i_errno = IERECVCOOKIE;
             return -1;


### PR DESCRIPTION
The goal is to improve the responsiveness and/or reliability of
messages on the control connection, particularly in cases where the
test traffic fills up the path between client and server.

Originally suggested and implemented by @andrepuschmann, this version
adds some error-checking and a version for the client side as well as
the server.
