### PR TITLE
Configurable value for time drift between client/server for authentication request issue1065

### DIFF
--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -209,6 +209,10 @@ the executable.
                  The  file  is  a  comma separated list of usernames and password
                  hashes; more information on the structure of  the  file  can  be
                  found in the EXAMPLES section.
+
+          --time-drift-threshold seconds
+                 time drift threshold (in seconds) between the server and client
+                 during the authentication process.
    
    CLIENT SPECIFIC OPTIONS
           -c, --client host

--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -210,8 +210,8 @@ the executable.
                  hashes; more information on the structure of  the  file  can  be
                  found in the EXAMPLES section.
 
-          --time-drift-threshold seconds
-                 time drift threshold (in seconds) between the server and client
+          --time-skew-threshold seconds
+                 time skew threshold (in seconds) between the server and client
                  during the authentication process.
    
    CLIENT SPECIFIC OPTIONS

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -286,7 +286,7 @@ struct iperf_test
 #if defined(HAVE_SSL)
     char      *server_authorized_users;
     EVP_PKEY  *server_rsa_private_key;
-    int       server_drift_threshold;
+    int       server_skew_threshold;
 #endif // HAVE_SSL
 
     /* boolean variables for Options */

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -286,6 +286,7 @@ struct iperf_test
 #if defined(HAVE_SSL)
     char      *server_authorized_users;
     EVP_PKEY  *server_rsa_private_key;
+    int       server_drift_threshold;
 #endif // HAVE_SSL
 
     /* boolean variables for Options */

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -209,8 +209,8 @@ The file is a comma separated list of usernames and password hashes;
 more information on the structure of the file can be found in the
 EXAMPLES section.
 .TP
-.BR --time-drift-threshold second " \fIseconds\fR"
-time drift threshold (in seconds) between the server and client
+.BR --time-skew-threshold second " \fIseconds\fR"
+time skew threshold (in seconds) between the server and client
 during the authentication process.
 .SH "CLIENT SPECIFIC OPTIONS"
 .TP

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -208,6 +208,10 @@ iperf tests (if built with OpenSSL support).
 The file is a comma separated list of usernames and password hashes;
 more information on the structure of the file can be found in the
 EXAMPLES section.
+.TP
+.BR --time-drift-threshold second " \fIseconds\fR"
+time drift threshold (in seconds) between the server and client
+during the authentication process.
 .SH "CLIENT SPECIFIC OPTIONS"
 .TP
 .BR -c ", " --client " \fIhost\fR"

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -642,6 +642,12 @@ iperf_set_test_server_authorized_users(struct iperf_test *ipt, const char *serve
 }
 
 void
+iperf_set_test_server_drift_threshold(struct iperf_test *ipt, int server_drift_threshold)
+{
+    ipt->server_drift_threshold = server_drift_threshold;
+}
+
+void
 iperf_set_test_server_rsa_privkey(struct iperf_test *ipt, const char *server_rsa_privkey_base64)
 {
     ipt->server_rsa_private_key = load_privkey_from_base64(server_rsa_privkey_base64);
@@ -927,6 +933,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     {"rsa-public-key-path", required_argument, NULL, OPT_CLIENT_RSA_PUBLIC_KEY},
     {"rsa-private-key-path", required_argument, NULL, OPT_SERVER_RSA_PRIVATE_KEY},
     {"authorized-users-path", required_argument, NULL, OPT_SERVER_AUTHORIZED_USERS},
+    {"time-drift-threshold", required_argument, NULL, OPT_SERVER_DRIFT_THRESHOLD},
 #endif /* HAVE_SSL */
 	{"fq-rate", required_argument, NULL, OPT_FQ_RATE},
 	{"pacing-timer", required_argument, NULL, OPT_PACING_TIMER},
@@ -1334,6 +1341,13 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         case OPT_SERVER_AUTHORIZED_USERS:
             test->server_authorized_users = strdup(optarg);
             break;
+        case OPT_SERVER_DRIFT_THRESHOLD:
+            test->server_drift_threshold = atoi(optarg);
+            if(test->server_drift_threshold <= 0){
+                i_errno = IEDRIFTTHRESHOLD;
+                return -1;
+            }
+            break;
 #endif /* HAVE_SSL */
 	    case OPT_PACING_TIMER:
 		test->settings->pacing_timer = unit_atoi(optarg);
@@ -1397,6 +1411,9 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     if (test->role == 'c' && (server_rsa_private_key || test->server_authorized_users)){
         i_errno = IESERVERONLY;
         return -1;
+    } else if (test->role == 'c' && (test->server_drift_threshold != 0)){
+        i_errno = IESERVERONLY;
+        return -1;
     } else if (test->role == 's' && (server_rsa_private_key || test->server_authorized_users) && 
         !(server_rsa_private_key && test->server_authorized_users)) {
          i_errno = IESETSERVERAUTH;
@@ -1407,8 +1424,13 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
             i_errno = IESETSERVERAUTH;
             return -1;
         }
-	free(server_rsa_private_key);
-	server_rsa_private_key = NULL;
+	    free(server_rsa_private_key);
+	    server_rsa_private_key = NULL;
+
+        if(test->server_drift_threshold == 0){
+            // Set default value for time drift threshold
+            test->server_drift_threshold=10;
+        }
     }
 
 #endif //HAVE_SSL
@@ -1722,7 +1744,7 @@ int test_is_authorized(struct iperf_test *test){
 	if (rc) {
 	    return -1;
 	}
-        int ret = check_authentication(username, password, ts, test->server_authorized_users);
+        int ret = check_authentication(username, password, ts, test->server_authorized_users, test->server_drift_threshold);
         if (ret == 0){
             iperf_printf(test, report_authentication_succeeded, username, ts);
             free(username);

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -642,9 +642,9 @@ iperf_set_test_server_authorized_users(struct iperf_test *ipt, const char *serve
 }
 
 void
-iperf_set_test_server_drift_threshold(struct iperf_test *ipt, int server_drift_threshold)
+iperf_set_test_server_skew_threshold(struct iperf_test *ipt, int server_skew_threshold)
 {
-    ipt->server_drift_threshold = server_drift_threshold;
+    ipt->server_skew_threshold = server_skew_threshold;
 }
 
 void
@@ -933,7 +933,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     {"rsa-public-key-path", required_argument, NULL, OPT_CLIENT_RSA_PUBLIC_KEY},
     {"rsa-private-key-path", required_argument, NULL, OPT_SERVER_RSA_PRIVATE_KEY},
     {"authorized-users-path", required_argument, NULL, OPT_SERVER_AUTHORIZED_USERS},
-    {"time-drift-threshold", required_argument, NULL, OPT_SERVER_DRIFT_THRESHOLD},
+    {"time-skew-threshold", required_argument, NULL, OPT_SERVER_SKEW_THRESHOLD},
 #endif /* HAVE_SSL */
 	{"fq-rate", required_argument, NULL, OPT_FQ_RATE},
 	{"pacing-timer", required_argument, NULL, OPT_PACING_TIMER},
@@ -1341,10 +1341,10 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         case OPT_SERVER_AUTHORIZED_USERS:
             test->server_authorized_users = strdup(optarg);
             break;
-        case OPT_SERVER_DRIFT_THRESHOLD:
-            test->server_drift_threshold = atoi(optarg);
-            if(test->server_drift_threshold <= 0){
-                i_errno = IEDRIFTTHRESHOLD;
+        case OPT_SERVER_SKEW_THRESHOLD:
+            test->server_skew_threshold = atoi(optarg);
+            if(test->server_skew_threshold <= 0){
+                i_errno = IESKEWTHRESHOLD;
                 return -1;
             }
             break;
@@ -1411,7 +1411,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     if (test->role == 'c' && (server_rsa_private_key || test->server_authorized_users)){
         i_errno = IESERVERONLY;
         return -1;
-    } else if (test->role == 'c' && (test->server_drift_threshold != 0)){
+    } else if (test->role == 'c' && (test->server_skew_threshold != 0)){
         i_errno = IESERVERONLY;
         return -1;
     } else if (test->role == 's' && (server_rsa_private_key || test->server_authorized_users) && 
@@ -1427,9 +1427,9 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 	    free(server_rsa_private_key);
 	    server_rsa_private_key = NULL;
 
-        if(test->server_drift_threshold == 0){
-            // Set default value for time drift threshold
-            test->server_drift_threshold=10;
+        if(test->server_skew_threshold == 0){
+            // Set default value for time skew threshold
+            test->server_skew_threshold=10;
         }
     }
 
@@ -1744,7 +1744,7 @@ int test_is_authorized(struct iperf_test *test){
 	if (rc) {
 	    return -1;
 	}
-        int ret = check_authentication(username, password, ts, test->server_authorized_users, test->server_drift_threshold);
+        int ret = check_authentication(username, password, ts, test->server_authorized_users, test->server_skew_threshold);
         if (ret == 0){
             iperf_printf(test, report_authentication_succeeded, username, ts);
             free(username);

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -79,7 +79,7 @@ typedef uint64_t iperf_size_t;
 #define OPT_BIDIRECTIONAL 20
 #define OPT_SERVER_BITRATE_LIMIT 21
 #define OPT_TIMESTAMPS 22
-#define OPT_SERVER_DRIFT_THRESHOLD 23
+#define OPT_SERVER_SKEW_THRESHOLD 23
 
 /* states */
 #define TEST_START 1
@@ -181,7 +181,7 @@ void    iperf_set_test_client_username(struct iperf_test *ipt, const char *clien
 void    iperf_set_test_client_password(struct iperf_test *ipt, const char *client_password);
 void    iperf_set_test_client_rsa_pubkey(struct iperf_test *ipt, const char *client_rsa_pubkey_base64);
 void    iperf_set_test_server_authorized_users(struct iperf_test *ipt, const char *server_authorized_users);
-void    iperf_set_test_server_drift_threshold(struct iperf_test *ipt, int server_drift_threshold);
+void    iperf_set_test_server_skew_threshold(struct iperf_test *ipt, int server_skew_threshold);
 void    iperf_set_test_server_rsa_privkey(struct iperf_test *ipt, const char *server_rsa_privkey_base64);
 #endif // HAVE_SSL
 
@@ -363,7 +363,7 @@ enum {
     IEBADPORT = 26,	    // Bad port number
     IETOTALRATE = 27,       // Total required bandwidth is larger than server's limit
     IETOTALINTERVAL = 28,   // Invalid time interval for calculating average data rate
-    IEDRIFTTHRESHOLD = 29,   // Invalid value specified as drift threshold
+    IESKEWTHRESHOLD = 29,   // Invalid value specified as skew threshold
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -79,6 +79,7 @@ typedef uint64_t iperf_size_t;
 #define OPT_BIDIRECTIONAL 20
 #define OPT_SERVER_BITRATE_LIMIT 21
 #define OPT_TIMESTAMPS 22
+#define OPT_SERVER_DRIFT_THRESHOLD 23
 
 /* states */
 #define TEST_START 1
@@ -180,6 +181,7 @@ void    iperf_set_test_client_username(struct iperf_test *ipt, const char *clien
 void    iperf_set_test_client_password(struct iperf_test *ipt, const char *client_password);
 void    iperf_set_test_client_rsa_pubkey(struct iperf_test *ipt, const char *client_rsa_pubkey_base64);
 void    iperf_set_test_server_authorized_users(struct iperf_test *ipt, const char *server_authorized_users);
+void    iperf_set_test_server_drift_threshold(struct iperf_test *ipt, int server_drift_threshold);
 void    iperf_set_test_server_rsa_privkey(struct iperf_test *ipt, const char *server_rsa_privkey_base64);
 #endif // HAVE_SSL
 
@@ -361,6 +363,7 @@ enum {
     IEBADPORT = 26,	    // Bad port number
     IETOTALRATE = 27,       // Total required bandwidth is larger than server's limit
     IETOTALINTERVAL = 28,   // Invalid time interval for calculating average data rate
+    IEDRIFTTHRESHOLD = 29,   // Invalid value specified as drift threshold
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -64,10 +64,10 @@ void sha256(const char *string, char outputBuffer[65])
     outputBuffer[64] = 0;
 }
 
-int check_authentication(const char *username, const char *password, const time_t ts, const char *filename, int drift_threshold){
+int check_authentication(const char *username, const char *password, const time_t ts, const char *filename, int skew_threshold){
     time_t t = time(NULL);
     time_t utc_seconds = mktime(localtime(&t));
-    if ( (utc_seconds - ts) > drift_threshold || (utc_seconds - ts) < -drift_threshold ) {
+    if ( (utc_seconds - ts) > skew_threshold || (utc_seconds - ts) < -skew_threshold ) {
         return 1;
     }
 

--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -64,10 +64,10 @@ void sha256(const char *string, char outputBuffer[65])
     outputBuffer[64] = 0;
 }
 
-int check_authentication(const char *username, const char *password, const time_t ts, const char *filename){
+int check_authentication(const char *username, const char *password, const time_t ts, const char *filename, int drift_threshold){
     time_t t = time(NULL);
     time_t utc_seconds = mktime(localtime(&t));
-    if ( (utc_seconds - ts) > 10 || (utc_seconds - ts) < -10 ) {
+    if ( (utc_seconds - ts) > drift_threshold || (utc_seconds - ts) < -drift_threshold ) {
         return 1;
     }
 

--- a/src/iperf_auth.h
+++ b/src/iperf_auth.h
@@ -37,5 +37,5 @@ EVP_PKEY *load_privkey_from_file(const char *file);
 EVP_PKEY *load_privkey_from_base64(const char *buffer);
 int encode_auth_setting(const char *username, const char *password, EVP_PKEY *public_key, char **authtoken);
 int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *private_key, char **username, char **password, time_t *ts);
-int check_authentication(const char *username, const char *password, const time_t ts, const char *filename);
+int check_authentication(const char *username, const char *password, const time_t ts, const char *filename, int drift_threshold);
 ssize_t iperf_getpass (char **lineptr, size_t *n, FILE *stream);

--- a/src/iperf_auth.h
+++ b/src/iperf_auth.h
@@ -37,5 +37,5 @@ EVP_PKEY *load_privkey_from_file(const char *file);
 EVP_PKEY *load_privkey_from_base64(const char *buffer);
 int encode_auth_setting(const char *username, const char *password, EVP_PKEY *public_key, char **authtoken);
 int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *private_key, char **username, char **password, time_t *ts);
-int check_authentication(const char *username, const char *password, const time_t ts, const char *filename, int drift_threshold);
+int check_authentication(const char *username, const char *password, const time_t ts, const char *filename, int skew_threshold);
 ssize_t iperf_getpass (char **lineptr, size_t *n, FILE *stream);

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -424,8 +424,8 @@ iperf_strerror(int int_errno)
 	case IETOTALRATE:
 	    snprintf(errstr, len, "total required bandwidth is larger than server limit");
             break;
-    case IEDRIFTTHRESHOLD:
-	    snprintf(errstr, len, "drift threshold must be a positive number");
+    case IESKEWTHRESHOLD:
+	    snprintf(errstr, len, "skew threshold must be a positive number");
             break;
 	default:
 	    snprintf(errstr, len, "int_errno=%d", int_errno);

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -424,6 +424,9 @@ iperf_strerror(int int_errno)
 	case IETOTALRATE:
 	    snprintf(errstr, len, "total required bandwidth is larger than server limit");
             break;
+    case IEDRIFTTHRESHOLD:
+	    snprintf(errstr, len, "drift threshold must be a positive number");
+            break;
 	default:
 	    snprintf(errstr, len, "int_errno=%d", int_errno);
 	    perr = 1;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -128,7 +128,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 			   "                            authentication credentials\n"
                            "  --authorized-users-path   path to the configuration file containing user\n"
                            "                            credentials\n"
-                           "  --time-drift-threshold    time drift threshold (in seconds) between the server\n"
+                           "  --time-skew-threshold    time skew threshold (in seconds) between the server\n"
                            "                            and client during the authentication process\n"
 #endif //HAVE_SSL
                            "Client specific:\n"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -128,6 +128,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 			   "                            authentication credentials\n"
                            "  --authorized-users-path   path to the configuration file containing user\n"
                            "                            credentials\n"
+                           "  --time-drift-threshold    time drift threshold (in seconds) between the server\n"
+                           "                            and client during the authentication process\n"
 #endif //HAVE_SSL
                            "Client specific:\n"
                            "  -c, --client    <host>    run in client mode, connecting to <host>\n"


### PR DESCRIPTION
* feature: Allow to configure a custom value for time drift between client/server for authentication requested in #1065 

The use case is to support scenarios where it's not possible to enforce sync between client and server times.
