### PR TITLE
iperf_server_api: start calculating CPU utilization right before TEST…

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -444,9 +444,6 @@ iperf_run_server(struct iperf_test *test)
         return -2;
     }
 
-    // Begin calculating CPU utilization
-    cpu_util(NULL);
-
     test->state = IPERF_START;
     send_streams_accepted = 0;
     rec_streams_accepted = 0;
@@ -630,6 +627,9 @@ iperf_run_server(struct iperf_test *test)
 			i_errno = IETOTALRATE;
 			return -1;
 		    }
+
+		    // Begin calculating CPU utilization
+		    cpu_util(NULL);
 
 		    if (iperf_set_send_state(test, TEST_START) != 0) {
 			cleanup_server(test);


### PR DESCRIPTION
…_START

Fixes issue 1076.

Signed-off-by: Jan Tluka <jtluka@redhat.com>

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

master

* Issues fixed (if any):

https://github.com/esnet/iperf/issues/1076

* Brief description of code changes (suitable for use as a commit message):

The cpu utilization counter initialization has been moved before sending TEST_START message instead of initialization right after iperf server process start. This fixes an issue if iperf server process is left running without client connected and the CPU utilization numbers are inaccurate.