### PR TITLE
fix tcp option -k bug when socket write return EAGAIN

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -183,6 +183,7 @@ struct iperf_stream
     int       green_light;
     int       buffer_fd;	/* data to send, file descriptor */
     char      *buffer;		/* data to send, mmapped */
+    int       pending_size;     /* pending data to send */
     int       diskfile_fd;	/* file to send, file descriptor */
     int	      diskfile_left;	/* remaining file data on disk */
 

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1629,7 +1629,8 @@ iperf_send(struct iperf_test *test, fd_set *write_setP)
 		}
 		streams_active = 1;
 		test->bytes_sent += r;
-		++test->blocks_sent;
+		if (!sp->pending_size)
+		    ++test->blocks_sent;
                 if (no_throttle_check)
 		    iperf_check_throttle(sp, &now);
 		if (multisend > 1 && test->settings->bytes != 0 && test->bytes_sent >= test->settings->bytes)
@@ -3927,6 +3928,7 @@ iperf_new_stream(struct iperf_test *test, int s, int sender)
         free(sp);
         return NULL;
     }
+    sp->pending_size = 0;
 
     /* Set socket */
     sp->socket = s;

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -85,19 +85,24 @@ iperf_tcp_send(struct iperf_stream *sp)
 {
     int r;
 
+    if (!sp->pending_size)
+	sp->pending_size = sp->settings->blksize;
+
     if (sp->test->zerocopy)
-	r = Nsendfile(sp->buffer_fd, sp->socket, sp->buffer, sp->settings->blksize);
+	r = Nsendfile(sp->buffer_fd, sp->socket, sp->buffer, sp->pending_size);
     else
-	r = Nwrite(sp->socket, sp->buffer, sp->settings->blksize, Ptcp);
+	r = Nwrite(sp->socket, sp->buffer, sp->pending_size, Ptcp);
 
     if (r < 0)
         return r;
 
+    sp->pending_size -= r;
     sp->result->bytes_sent += r;
     sp->result->bytes_sent_this_interval += r;
 
     if (sp->test->debug)
-	printf("sent %d bytes of %d, total %" PRIu64 "\n", r, sp->settings->blksize, sp->result->bytes_sent);
+	printf("sent %d bytes of %d, pending %d, total %" PRIu64 "\n",
+	    r, sp->settings->blksize, sp->pending_size, sp->result->bytes_sent);
 
     return r;
 }


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

If the socket write returns EAGAIN, the whole block is not completed, then the 
control variable blocks_sent should not be increased.
Due to network congestion, option -k cannot accurately control the number of packets to transmit,