### PR TITLE
fix: Hide auth diagnostics behind --debug to avoid polluting JSON out…

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1746,12 +1746,16 @@ int test_is_authorized(struct iperf_test *test){
 	}
         int ret = check_authentication(username, password, ts, test->server_authorized_users, test->server_skew_threshold);
         if (ret == 0){
-            iperf_printf(test, report_authentication_succeeded, username, ts);
+            if (test->debug) {
+              iperf_printf(test, report_authentication_succeeded, username, ts);
+            }
             free(username);
             free(password);
             return 0;
         } else {
-            iperf_printf(test, report_authentication_failed, username, ts);
+            if (test->debug) {
+                iperf_printf(test, report_authentication_failed, username, ts);
+            }
             free(username);
             free(password);
             return -1;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -281,7 +281,7 @@ const char report_connecting[] =
 "Connecting to host %s, port %d\n";
 
 const char report_authentication_succeeded[] =
-"Authentication successed for user '%s' ts %ld\n";
+"Authentication succeeded for user '%s' ts %ld\n";
 
 const char report_authentication_failed[] =
 "Authentication failed for user '%s' ts %ld\n";


### PR DESCRIPTION
…put.

Fixes #1086.

While here, fix wording of an error message.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:  master

* Issues fixed (if any): #1086

* Brief description of code changes (suitable for use as a commit message):

