### PR TITLE
Issue 1079

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -409,7 +409,11 @@ path to the RSA public key used to encrypt authentication credentials
 The authentication feature of iperf3 requires an RSA public keypair.
 The public key is used to encrypt the authentication token containing the 
 user credentials, while the private key is used to decrypt the authentication token.
-An example of a set of UNIX/Linux commands to generate correct keypair follows:
+The private key must be in PEM format and additionally must not have a
+password set.
+The public key must be in PEM format and use SubjectPrefixKeyInfo encoding.
+An example of a set of UNIX/Linux commands using OpenSSL
+to generate a correctly-formed keypair follows:
 .sp 1 
 .in +.5i
 > openssl genrsa -des3 -out private.pem 2048

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -89,6 +89,7 @@
 #include "version.h"
 #if defined(HAVE_SSL)
 #include <openssl/bio.h>
+#include <openssl/err.h>
 #include "iperf_auth.h"
 #endif /* HAVE_SSL */
 
@@ -1397,6 +1398,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
             return -1;
         } 
         if (test_load_pubkey_from_file(client_rsa_public_key) < 0){
+            iperf_err(test, "%s\n", ERR_error_string(ERR_get_error(), NULL));
             i_errno = IESETCLIENTAUTH;
             return -1;
         }
@@ -1421,6 +1423,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     } else if (test->role == 's' && server_rsa_private_key) {
         test->server_rsa_private_key = load_privkey_from_file(server_rsa_private_key);
         if (test->server_rsa_private_key == NULL){
+            iperf_err(test, "%s\n", ERR_error_string(ERR_get_error(), NULL));
             i_errno = IESETSERVERAUTH;
             return -1;
         }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #1079 

* Brief description of code changes (suitable for use as a commit message):

docs(auth): Add a few notes about RSA key formats used for auth.
enh(auth): If we can't read key files, emit appropriate OpenSSL error.
