### PR TITLE
API interface for setting/getting congestion control (#1036)

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -394,6 +394,12 @@ iperf_get_test_idle_timeout(struct iperf_test *ipt)
     return ipt->settings->idle_timeout;
 }
 
+char*
+iperf_get_test_congestion_control(struct iperf_test* ipt)
+{
+    return ipt->congestion;
+}
+
 /************** Setter routines for some fields inside iperf_test *************/
 
 void
@@ -729,6 +735,12 @@ void
 iperf_set_test_idle_timeout(struct iperf_test* ipt, int to)
 {
     ipt->settings->idle_timeout = to;
+}
+
+void
+iperf_set_test_congestion_control(struct iperf_test* ipt, char* cc)
+{
+    ipt->congestion = strdup(cc);
 }
 
 

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -140,6 +140,7 @@ char*	iperf_get_extra_data( struct iperf_test* ipt );
 char*	iperf_get_iperf_version(void);
 int	iperf_get_test_no_delay( struct iperf_test* ipt );
 int	iperf_get_test_connect_timeout( struct iperf_test* ipt );
+char*   iperf_get_test_congestion_control(struct iperf_test* ipt);
 
 /* Setter routines for some fields inside iperf_test. */
 void	iperf_set_verbose( struct iperf_test* ipt, int verbose );
@@ -177,6 +178,7 @@ void    iperf_set_test_tos( struct iperf_test* ipt, int tos );
 void	iperf_set_test_extra_data( struct iperf_test* ipt, const char *dat );
 void    iperf_set_test_bidirectional( struct iperf_test* ipt, int bidirectional);
 void    iperf_set_test_no_delay( struct iperf_test* ipt, int no_delay);
+void    iperf_set_test_congestion_control(struct iperf_test* ipt, char* cc);
 
 #if defined(HAVE_SSL)
 void    iperf_set_test_client_username(struct iperf_test *ipt, const char *client_username);


### PR DESCRIPTION
Same restrictions/compatibility applies as
the CLI -C/--congestion options.
(Linux and FreeBSD only)

Fixes #1036

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): Issue #1036 

* Brief description of code changes (suitable for use as a commit message):
```
API interface for setting/getting congestion control (#1036)

Same restrictions/compatibility applies as
the CLI -C/--congestion options.
(Linux and FreeBSD only)

Fixes #1036
```