### PR TITLE
Fix iperf_send() termination test in bytes/blocks mode

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1662,6 +1662,10 @@ iperf_send(struct iperf_test *test, fd_set *write_setP)
 	SLIST_FOREACH(sp, &test->streams, streams) {
 	    if ((sp->green_light && sp->sender &&
 		 (write_setP == NULL || FD_ISSET(sp->socket, write_setP)))) {
+        if (multisend > 1 && test->settings->bytes != 0 && test->bytes_sent >= test->settings->bytes)
+            break;
+        if (multisend > 1 && test->settings->blocks != 0 && test->blocks_sent >= test->settings->blocks)
+            break;
 		if ((r = sp->snd(sp)) < 0) {
 		    if (r == NET_SOFTERROR)
 			break;
@@ -1674,10 +1678,6 @@ iperf_send(struct iperf_test *test, fd_set *write_setP)
 		    ++test->blocks_sent;
                 if (no_throttle_check)
 		    iperf_check_throttle(sp, &now);
-		if (multisend > 1 && test->settings->bytes != 0 && test->bytes_sent >= test->settings->bytes)
-		    break;
-		if (multisend > 1 && test->settings->blocks != 0 && test->blocks_sent >= test->settings->blocks)
-		    break;
 	    }
 	}
 	if (!streams_active)


### PR DESCRIPTION
In iperf_send() function, the check for termination test
in bytes/blocks mode is at the end of the iteration loop
for multisend (outer loop) and streams (inner loop).
If for any iteration of multisend (outer) loop bytes/blocks
sent reaches the desired limit, it still continues to send
data until the loop is exhausted. (The `break;` command does not
help, since it is already inside the streams (inner) loop).

This is a simple fix which brings the condition check to the
beginning of the inner loop, so it will skip the iteration if
the bytes/blocks count is already reached the target; hence
avoiding to send more data to the network.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): N/A

* Brief description of code changes (suitable for use as a commit message):
```
Fix iperf_send() termination test in bytes/blocks mode

In iperf_send() function, the check for termination test
in bytes/blocks mode is at the end of the iteration loop
for multisend (outer loop) and streams (inner loop).
If for any iteration of multisend (outer) loop bytes/blocks
sent reaches the desired limit, it still continues to send
data until the loop is exhausted. (The `break;` command does not
help, since it is already inside the streams (inner) loop).

This is a simple fix which brings the condition check to the
beginning of the inner loop, so it will skip the iteration if
the bytes/blocks count is already reached the target; hence
avoiding to send more data to the network.
```
