### PR TITLE
Fix/optimize test termination condition check

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -555,7 +555,7 @@ iperf_run_client(struct iperf_test * test)
 	     * being the receiver.
 	     */
 	    if ((!test->omitting) &&
-	        ((test->duration != 0 && test->done) ||
+	        (test->done ||
 	         (test->settings->bytes != 0 && (test->bytes_sent >= test->settings->bytes ||
 						 test->bytes_received >= test->settings->bytes)) ||
 	         (test->settings->blocks != 0 && (test->blocks_sent >= test->settings->blocks ||


### PR DESCRIPTION
`test->done` represents the test completion.
In some modes, duration-based (-t) test, and file-transfer (-F)  in particular,
the `test->done` is set during the timeout handler or file-transfer functions.
For such configurations, and in general, `test->done` being set is sufficient
condition for terminating the test.

This commit generalizes the condition check to `test->done`,
removing the clause which limtis this condition case to duration-based test only.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): N/A

* Brief description of code changes (suitable for use as a commit message):
```
`test->done` represents the test completion.
In some modes, duration-based (-t) test, and file-transfer (-F)  in particular,
the `test->done` is set during the timeout handler or file-transfer functions.
For such configurations, and in general, `test->done` being set is sufficient
condition for terminating the test.

This commit generalizes the condition check to `test->done`,
removing the clause which limtis this condition case to duration-based test only.
```
