### PR TITLE
diskfile_send() sent data capped at file-size

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4088,24 +4088,46 @@ static int
 diskfile_send(struct iperf_stream *sp)
 {
     int r;
+    int buffer_left=0; // represents total data in buffer to be sent out 
     static int rtot;
 
     /* if needed, read enough data from the disk to fill up the buffer */
     if (sp->diskfile_left < sp->test->settings->blksize && !sp->test->done) {
-	r = read(sp->diskfile_fd, sp->buffer, sp->test->settings->blksize -
-		 sp->diskfile_left);
-	rtot += r;
-	if (sp->test->debug) {
-	    printf("read %d bytes from file, %d total\n", r, rtot);
-	    if (r != sp->test->settings->blksize - sp->diskfile_left)
-		printf("possible eof\n");
-	}
-	/* If there's no data left in the file or in the buffer, we're done */
-	if (r == 0 && sp->diskfile_left == 0) {
-	    sp->test->done = 1;
-	    if (sp->test->debug)
-		printf("done\n");
-	}
+    	r = read(sp->diskfile_fd, sp->buffer, sp->test->settings->blksize -
+    		 sp->diskfile_left);
+        buffer_left = r + sp->diskfile_left;
+    	rtot += r;
+    	if (sp->test->debug) {
+    	    printf("read %d bytes from file, %d total\n", r, rtot);	    
+    	}
+
+        // a.k.a.  buffer_left != sp->test->settings->blksize
+        if (r != sp->test->settings->blksize - sp->diskfile_left){
+            if (sp->test->debug) 
+                printf("possible eof\n");
+            // setting data size to be sent, 
+            // which is less than full block/buffer size 
+            // (to be used by iperf_tcp_send, etc.)
+            sp->pending_size = buffer_left; 
+        }
+
+    	
+    	if (r == 0 && sp->diskfile_left == 0) {
+        // a.k.a. buffer_left == 0
+    	    sp->test->done = 1;
+    	    if (sp->test->debug)
+    		  printf("done\n");
+    	}
+    }
+
+    // If there's no data left in the file or in the buffer, we're done. 
+    // No more data available to be sent.  
+    // Return without sending data to the network 
+    if( sp->test->done || buffer_left == 0 ){
+        if (sp->test->debug)
+              printf("already done\n");
+        sp->test->done = 1;
+        return 0;
     }
 
     r = sp->snd2(sp);
@@ -4118,7 +4140,7 @@ diskfile_send(struct iperf_stream *sp)
      * front of the buffer so they can hopefully go out on the next
      * pass.
      */
-    sp->diskfile_left = sp->test->settings->blksize - r;
+    sp->diskfile_left = buffer_left - r;
     if (sp->diskfile_left && sp->diskfile_left < sp->test->settings->blksize) {
 	memcpy(sp->buffer,
 	       sp->buffer + (sp->test->settings->blksize - sp->diskfile_left),


### PR DESCRIPTION
**Attention** Depends on pull request `Fix/Optimize test termination condition check #1114`

**Issue:** `diskfile_send()` unconditional call to `sp->snd2`
would result in sending full buffer size everytime,
regardless of the file size.

**Fix:** The function updated to check for end-of-file (reading 0 bytes)
and,
  1. set `sp->pending_size` to appropriate data length available to be sent 
  2. check for end condition and avoid sending data more than file size.

**Note:** The fix is only for the maximum cap on the data size sent on the network.
If other parameters (-t, -n, etc.) yield smaller size or shorter time then needed,
the file will still be partially sent to the network.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: 
`master` + Depends on pull request `Fix/Optimize test termination condition check #1114`

* Issues fixed (if any): N/A

* Brief description of code changes (suitable for use as a commit message):
```
**Issue:** `diskfile_send()` unconditional call to `sp->snd2`
would result in sending full buffer size everytime,
regardless of the file size.

**Fix:** The function updated to check for end-of-file (reading 0 bytes)
and,
  1. set `sp->pending_size` to appropriate data length available to be sent 
  2. check for end condition and avoid sending data more than file size.

**Note:** The fix is only for the maximum cap on the data size sent on the network.
If other parameters (-t, -n, etc.) yield smaller size or shorter time then needed,
the file will still be partially sent to the network.
```
