### PR TITLE
Auto adjustment of test-end condition for file-transfer

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1512,11 +1512,13 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         test->role == 'c'
         ){
         struct stat st;
-        stat(test->diskfile_name, &st);
-        iperf_size_t file_bytes = st.st_size;
-        test->settings->bytes = file_bytes;        
-        if (test->debug)
-            printf("End condition set to file-size: %d bytes\n", test->settings->bytes);
+        if( stat(test->diskfile_name, &st) == 0 ){
+            iperf_size_t file_bytes = st.st_size;
+            test->settings->bytes = file_bytes;        
+            if (test->debug)
+                printf("End condition set to file-size: %d bytes\n", test->settings->bytes);
+        }
+        // if failing to read file stat, it should fallback to default duration mode
     }    
 
     if ((test->settings->bytes != 0 || test->settings->blocks != 0) && ! duration_flag)

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1502,6 +1502,23 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     if (!rate_flag)
 	test->settings->rate = test->protocol->id == Pudp ? UDP_RATE : 0;
 
+    /* if no bytes or blocks specified, nor a duration_flag, and we have -F,
+    ** get the file-size as the bytes count to be transferred
+    */
+    if (test->settings->bytes == 0 && 
+        test->settings->blocks == 0 && 
+        ! duration_flag &&
+        test->diskfile_name != (char*) 0 &&
+        test->role == 'c'
+        ){
+        struct stat st;
+        stat(test->diskfile_name, &st);
+        iperf_size_t file_bytes = st.st_size;
+        test->settings->bytes = file_bytes;        
+        if (test->debug)
+            printf("End condition set to file-size: %d bytes\n", test->settings->bytes);
+    }    
+
     if ((test->settings->bytes != 0 || test->settings->blocks != 0) && ! duration_flag)
         test->duration = 0;
 


### PR DESCRIPTION
In file transfer mode (-F), if no test-end condition is set,
(bytes, blocks, duration), it will automatically adjust it to
file size (in bytes).
If call to stat() fails, it will skip setting the bytes count, hence defaulting to duration mode (10 seconds).

* Version of iperf3 to which this pull request applies: `master`

* Issues fixed (if any): N/A

* Brief description of code changes (suitable for use as a commit message):

**Auto adjustment of test-end condition for file-transfer**

In file transfer mode (-F), if no test-end condition is set,
(bytes, blocks, duration), it will automatically adjust it to
file size (in bytes).
If call to stat() fails, it will skip setting the bytes count, hence defaulting to duration mode (10 seconds).

