### PR TITLE
Issue 1118

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2020, The Regents of the University of
+ * iperf, Copyright (c) 2014-2021, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -1631,7 +1631,8 @@ iperf_check_total_rate(struct iperf_test *test, iperf_size_t last_interval_bytes
     }
 
     if (bits_per_second  > test->settings->bitrate_limit) {
-	iperf_err(test, "Total throughput of %" PRIu64 " bps exceeded %" PRIu64 " bps limit", bits_per_second, test->settings->bitrate_limit);
+        if (! test->json_output)
+            iperf_err(test, "Total throughput of %" PRIu64 " bps exceeded %" PRIu64 " bps limit", bits_per_second, test->settings->bitrate_limit);
 	test->bitrate_limit_exceeded = 1;
     }
 }

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1631,7 +1631,7 @@ iperf_check_total_rate(struct iperf_test *test, iperf_size_t last_interval_bytes
     }
 
     if (bits_per_second  > test->settings->bitrate_limit) {
-        if (! test->json_output)
+        if (iperf_get_verbose(test))
             iperf_err(test, "Total throughput of %" PRIu64 " bps exceeded %" PRIu64 " bps limit", bits_per_second, test->settings->bitrate_limit);
 	test->bitrate_limit_exceeded = 1;
     }

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -517,7 +517,7 @@ iperf_run_server(struct iperf_test *test)
                 else if (t_usecs > NO_MSG_RCVD_TIMEOUT * SEC_TO_US) {
                     test->server_forced_no_msg_restarts_count += 1;
                     i_errno = IENOMSG;
-                    if (! test->json_output)
+                    if (iperf_get_verbose(test))
                         iperf_err(test, "Server restart (#%d) in active test as no message was received for %d sec",
                                   test->server_forced_no_msg_restarts_count, NO_MSG_RCVD_TIMEOUT);
                     cleanup_server(test);
@@ -689,7 +689,7 @@ iperf_run_server(struct iperf_test *test)
 		    /* Ensure that total requested data rate is not above limit */
 		    iperf_size_t total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
 		    if (test->settings->bitrate_limit > 0 && total_requested_rate > test->settings->bitrate_limit) {
-                        if (! test->json_output)
+                        if (iperf_get_verbose(test))
                             iperf_err(test, "Client total requested throughput rate of %" PRIu64 " bps exceeded %" PRIu64 " bps limit",
                                       total_requested_rate, test->settings->bitrate_limit);
 			cleanup_server(test);

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -517,8 +517,9 @@ iperf_run_server(struct iperf_test *test)
                 else if (t_usecs > NO_MSG_RCVD_TIMEOUT * SEC_TO_US) {
                     test->server_forced_no_msg_restarts_count += 1;
                     i_errno = IENOMSG;
-                    iperf_err(test, "Server restart (#%d) in active test as no message was received for %d sec",
-                        test->server_forced_no_msg_restarts_count, NO_MSG_RCVD_TIMEOUT);
+                    if (! test->json_output)
+                        iperf_err(test, "Server restart (#%d) in active test as no message was received for %d sec",
+                                  test->server_forced_no_msg_restarts_count, NO_MSG_RCVD_TIMEOUT);
                     cleanup_server(test);
                     return -1;
                 }
@@ -688,8 +689,9 @@ iperf_run_server(struct iperf_test *test)
 		    /* Ensure that total requested data rate is not above limit */
 		    iperf_size_t total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
 		    if (test->settings->bitrate_limit > 0 && total_requested_rate > test->settings->bitrate_limit) {
-			iperf_err(test, "Client total requested throughput rate of %" PRIu64 " bps exceeded %" PRIu64 " bps limit",
-				total_requested_rate, test->settings->bitrate_limit);
+                        if (! test->json_output)
+                            iperf_err(test, "Client total requested throughput rate of %" PRIu64 " bps exceeded %" PRIu64 " bps limit",
+                                      total_requested_rate, test->settings->bitrate_limit);
 			cleanup_server(test);
 			i_errno = IETOTALRATE;
 			return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014, 2015, 2017, 2019, The Regents of the University of
+ * iperf, Copyright (c) 2014-2021, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -154,6 +154,12 @@ run(struct iperf_test *test)
                 test->server_last_run_rc =rc;
 		if (rc < 0) {
 		    iperf_err(test, "error - %s", iperf_strerror(i_errno));
+                    if (test->json_output) {
+                        if (iperf_json_finish(test) < 0)
+                            return -1;
+                    }
+                    iflush(test);
+
 		    if (rc < -1) {
 		        iperf_errexit(test, "exiting");
 		    }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): #1118 

* Brief description of code changes (suitable for use as a commit message):

Expose certain error conditions in JSON output.

Hide some error output behind --verbose to avoid putting multiple "error"
members in JSON output.

Fixes #1118.
