### PR TITLE
Move iperf.h include before tcp.h in net.c for _GNU_SOURCE definition

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -26,6 +26,9 @@
  */
 #include "iperf_config.h"
 
+// iperf.h include should preceed netinet/tcp.h for _GNU_SOURCE definition
+#include "iperf.h"
+
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
@@ -61,7 +64,6 @@
 #include <poll.h>
 #endif /* HAVE_POLL_H */
 
-#include "iperf.h"
 #include "iperf_util.h"
 #include "net.h"
 #include "timer.h"

--- a/src/net.c
+++ b/src/net.c
@@ -26,9 +26,6 @@
  */
 #include "iperf_config.h"
 
-// iperf.h include should preceed netinet/tcp.h for _GNU_SOURCE definition
-#include "iperf.h"
-
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
@@ -36,7 +33,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <netinet/in.h>
-#include <netinet/tcp.h>
 #include <assert.h>
 #include <netdb.h>
 #include <string.h>
@@ -64,6 +60,7 @@
 #include <poll.h>
 #endif /* HAVE_POLL_H */
 
+#include "iperf.h"
 #include "iperf_util.h"
 #include "net.h"
 #include "timer.h"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
3.9+

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):
Recently `iperf.h` include was included in `net.c`.  That caused make in Alpine to fail with error "_field 'tcpInfo' has incomplete type_".  `iperf.h` include was moved before `netinet/tcp.h` to apply the related fix by #518 - defining `_GNU_SOURCE`.
