### PR TITLE
Fix issue 1061 - not fail in WSL1 when cannot get defalt congestion a…

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -83,14 +83,20 @@ iperf_create_streams(struct iperf_test *test, int sender)
 	    {
 		socklen_t len = TCP_CA_NAME_MAX;
 		char ca[TCP_CA_NAME_MAX + 1];
-		if (getsockopt(s, IPPROTO_TCP, TCP_CONGESTION, ca, &len) < 0) {
+                int rc;
+		rc = getsockopt(s, IPPROTO_TCP, TCP_CONGESTION, ca, &len);
+                if (rc < 0 && test->congestion) {
 		    saved_errno = errno;
 		    close(s);
 		    errno = saved_errno;
 		    i_errno = IESETCONGESTION;
 		    return -1;
 		}
-		test->congestion_used = strdup(ca);
+                // Set actual used congestion alg, or set to unknown if could not get it
+                if (rc < 0)
+                    test->congestion_used = strdup("unknown");
+                else
+                    test->congestion_used = strdup(ca);
 		if (test->debug) {
 		    printf("Congestion algorithm is %s\n", test->congestion_used);
 		}


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
Latest 3.9+

* Issues fixed (if any):
#1061

* Brief description of code changes (suitable for use as a commit message):
Whn congestion algorithm is not set (`-C` option), do not fail when cannot get the algorithm used.  This issue happens at least with WSL1 that is a Linux but still doesn't support congestion algs.  Instead of failing, in this case the `congestion_used` is set to "**unknown**". 

