### PR TITLE
Fix to active TCP test termination by new connection

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -440,8 +440,11 @@ iperf_client_end(struct iperf_test *test)
     /* show final summary */
     test->reporter_callback(test);
 
-    if (iperf_set_send_state(test, IPERF_DONE) != 0)
-        return -1;
+    // Send response only if no error in server
+    if (test->state > 0) {
+        if (iperf_set_send_state(test, IPERF_DONE) != 0)
+            return -1;
+    }
 
     /* Close control socket */
     if (test->ctrl_sck)

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -575,61 +575,61 @@ iperf_run_server(struct iperf_test *test)
                         return -1;
 		    }
 
-#if defined(HAVE_TCP_CONGESTION)
-		    if (test->protocol->id == Ptcp) {
-			if (test->congestion) {
-			    if (setsockopt(s, IPPROTO_TCP, TCP_CONGESTION, test->congestion, strlen(test->congestion)) < 0) {
-				/*
-				 * ENOENT means we tried to set the
-				 * congestion algorithm but the algorithm
-				 * specified doesn't exist.  This can happen
-				 * if the client and server have different
-				 * congestion algorithms available.  In this
-				 * case, print a warning, but otherwise
-				 * continue.
-				 */
-				if (errno == ENOENT) {
-				    warning("TCP congestion control algorithm not supported");
-				}
-				else {
-				    saved_errno = errno;
-				    close(s);
-				    cleanup_server(test);
-				    errno = saved_errno;
-				    i_errno = IESETCONGESTION;
-				    return -1;
-				}
-			    } 
-			}
-			{
-			    socklen_t len = TCP_CA_NAME_MAX;
-			    char ca[TCP_CA_NAME_MAX + 1];
-			    if (getsockopt(s, IPPROTO_TCP, TCP_CONGESTION, ca, &len) < 0) {
-				saved_errno = errno;
-				close(s);
-				cleanup_server(test);
-				errno = saved_errno;
-				i_errno = IESETCONGESTION;
-				return -1;
-			    }
-                            /* 
-                             * If not the first connection, discard prior
-                             * congestion algorithm name so we don't leak
-                             * duplicated strings.  We probably don't need
-                             * the old string anyway.
-                             */
-                            if (test->congestion_used != NULL) {
-                                free(test->congestion_used);
-                            }
-                            test->congestion_used = strdup(ca);
-			    if (test->debug) {
-				printf("Congestion algorithm is %s\n", test->congestion_used);
-			    }
-			}
-		    }
-#endif /* HAVE_TCP_CONGESTION */
-
                     if (!is_closed(s)) {
+
+#if defined(HAVE_TCP_CONGESTION)
+                        if (test->protocol->id == Ptcp) {
+                            if (test->congestion) {
+                                if (setsockopt(s, IPPROTO_TCP, TCP_CONGESTION, test->congestion, strlen(test->congestion)) < 0) {
+                                    /*
+                                    * ENOENT means we tried to set the
+                                    * congestion algorithm but the algorithm
+                                    * specified doesn't exist.  This can happen
+                                    * if the client and server have different
+                                    * congestion algorithms available.  In this
+                                    * case, print a warning, but otherwise
+                                    * continue.
+                                    */
+                                    if (errno == ENOENT) {
+                                        warning("TCP congestion control algorithm not supported");
+                                    }
+                                    else {
+                                        saved_errno = errno;
+                                        close(s);
+                                        cleanup_server(test);
+                                        errno = saved_errno;
+                                        i_errno = IESETCONGESTION;
+                                        return -1;
+                                    }
+                                } 
+                            }
+                            {
+                                socklen_t len = TCP_CA_NAME_MAX;
+                                char ca[TCP_CA_NAME_MAX + 1];
+                                if (getsockopt(s, IPPROTO_TCP, TCP_CONGESTION, ca, &len) < 0) {
+                                    saved_errno = errno;
+                                    close(s);
+                                    cleanup_server(test);
+                                    errno = saved_errno;
+                                    i_errno = IESETCONGESTION;
+                                    return -1;
+                                }
+                                /* 
+                                * If not the first connection, discard prior
+                                * congestion algorithm name so we don't leak
+                                * duplicated strings.  We probably don't need
+                                * the old string anyway.
+                                */
+                                if (test->congestion_used != NULL) {
+                                    free(test->congestion_used);
+                                }
+                                test->congestion_used = strdup(ca);
+                                if (test->debug) {
+                                    printf("Congestion algorithm is %s\n", test->congestion_used);
+                                }
+                            }
+                        }
+#endif /* HAVE_TCP_CONGESTION */
 
                         if (rec_streams_accepted != streams_to_rec) {
                             flag = 0;

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -134,8 +134,7 @@ iperf_tcp_accept(struct iperf_test * test)
 
     if (strcmp(test->cookie, cookie) != 0) {
         if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Ptcp) < 0) {
-            i_errno = IESENDMESSAGE;
-            return -1;
+            iperf_err(test, "failed to send access denied from busy server to to new connecting client, errno=%d", errno);
         }
         close(s);
     }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
latest 3.9+

* Issues fixed (if any):
None

* Brief description of code changes (suitable for use as a commit message):

Fix two issues that caused an active TCP test to terminate if a new connection request was received while in streams creation phase.  One issue was in `iperf_tcp_accept()` - after identifying that the cookies of the new connection if from a new client, error was returned which caused the active test to terminate.  The other issue was in `iperf_run_server()` where congestion alg was set for the new client, although the stream to it was already closed by `iperf_tcp_accept()`.  That also cause the active test to terminate.

Another minor issue that was fixed is that after a client received a failure state (negative state) from the server, `iperf_client_end()` still tried to send back `IPERF_DONE` to the server.  That caused the client to issue failure message of "_unable to send control message: Connection reset by peer_" instead of "_the server is busy running a test_".
