### PR TITLE
Not sending state to to undefined socket and correct cookie buffer sizes

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -352,7 +352,7 @@ struct iperf_test
     uint server_forced_no_msg_restarts_count;    /* count number of forced server restarts to make sure it is not stack */
     uint server_test_number;                     /* count number of tests performed by a server */
 
-    char      cookie[COOKIE_SIZE];
+    char      cookie[COOKIE_SIZE + 1];
 //    struct iperf_stream *streams;               /* pointer to list of struct stream */
     SLIST_HEAD(slisthead, iperf_stream) streams;
     struct iperf_settings *settings;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1628,10 +1628,12 @@ int iperf_open_logfile(struct iperf_test *test)
 int
 iperf_set_send_state(struct iperf_test *test, signed char state)
 {
-    test->state = state;
-    if (Nwrite(test->ctrl_sck, (char*) &state, sizeof(state), Ptcp) < 0) {
-	i_errno = IESENDMESSAGE;
-	return -1;
+    if (test->ctrl_sck >= 0) {
+        test->state = state;
+        if (Nwrite(test->ctrl_sck, (char*) &state, sizeof(state), Ptcp) < 0) {
+	    i_errno = IESENDMESSAGE;
+	    return -1;
+        }
     }
     return 0;
 }

--- a/src/t_uuid.c
+++ b/src/t_uuid.c
@@ -34,7 +34,7 @@
 int
 main(int argc, char **argv)
 {
-    char     cookie[37];
+    char     cookie[37 + 1];
     make_cookie(cookie);
     printf("cookie: '%s'\n", cookie);
     if (strlen(cookie) != 36)


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
3.9+ latest

* Issues fixed (if any):
#1129

* Brief description of code changes (suitable for use as a commit message):

Combined two minor fixes:
1. Fix to issue #1129 - not sending state if control channel is not defined.
2. Add 1 byte to `make_cookie()` output buffer, as it creates a null terminated string (although the cookie is only used as a fixed `COOKIE_SIZE` length string).

