### PR TITLE
Fix issue 1129 for not sending stat to to undefined socket

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1628,10 +1628,12 @@ int iperf_open_logfile(struct iperf_test *test)
 int
 iperf_set_send_state(struct iperf_test *test, signed char state)
 {
-    test->state = state;
-    if (Nwrite(test->ctrl_sck, (char*) &state, sizeof(state), Ptcp) < 0) {
-	i_errno = IESENDMESSAGE;
-	return -1;
+    if (test->ctrl_sck >= 0) {
+        test->state = state;
+        if (Nwrite(test->ctrl_sck, (char*) &state, sizeof(state), Ptcp) < 0) {
+	    i_errno = IESENDMESSAGE;
+	    return -1;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
3.9+ latest

* Issues fixed (if any):
#1129

* Brief description of code changes (suitable for use as a commit message):
Fix to issue #1129 - not sending state if control channel is not defined.
(Replacing PR #1131 which will be canceled.)