### PR TITLE
Annotate server output and logs with "title" from the client.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,5 +68,5 @@ your work.
 
 We expect that iperf3 interactions via the issue tracker, mailing
 lists, and so forth will be conducted civilly.  Language that is
-deemed appropriate or abusive may be removed, and we reserve the right
+deemed inappropriate or abusive may be removed, and we reserve the right
 to ban users from accessing the project for repeated offense.

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -827,6 +827,8 @@ iperf_on_test_start(struct iperf_test *test)
 	    else
 		iperf_printf(test, test_start_time, test->protocol->name, test->num_streams, test->settings->blksize, test->omit, test->duration, test->settings->tos);
 	}
+	if (test->title)
+	  iperf_printf(test, test_start_title, test->title);
     }
 }
 

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -185,7 +185,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #endif /* HAVE_FLOWLABEL */
                            "  -Z, --zerocopy            use a 'zero copy' method of sending data\n"
                            "  -O, --omit N              omit the first n seconds\n"
-                           "  -T, --title str           prefix every output line with this string\n"
+                           "  -T, --title str           prefix every output line with this string; Logged on the server\n"
                            "  --extra-data str          data string to include in client and server JSON\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
@@ -282,6 +282,8 @@ const char test_start_bytes[] =
 const char test_start_blocks[] =
 "Starting Test: protocol: %s, %d streams, %d byte blocks, omitting %d seconds, %d blocks to send, tos %d\n";
 
+const char test_start_title[] =
+"Client set test title: %s\n";
 
 /* -------------------------------------------------------------------
  * reports

--- a/src/iperf_locale.h
+++ b/src/iperf_locale.h
@@ -48,6 +48,7 @@ extern const char wait_server_threads[] ;
 extern const char test_start_time[];
 extern const char test_start_bytes[];
 extern const char test_start_blocks[];
+extern const char test_start_title[];
 
 extern const char report_time[] ;
 extern const char report_connecting[] ;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
None in functionality; new feature
Typo in documentation.

* Brief description of code changes (suitable for use as a commit message):

I had a desire to annotate server output (and logs) from the client.  The use case example:

1. I test my laptop (client) on wired network.
2. I test the same laptop a few minutes later from wireless network.

I would like to be able to identify what I was doing when browsing the server-side output.  So I would like to leave a 'breadcrumb' (annotation) on the server invoked from the client.

This change accomplishes that.  The client-set "--title" option now is also included on the Server output.
This parameter was already exchanged between server and client, so no major changes were necessary; just iperf_printf.
