### PR TITLE
fix: Don't try to close the control connection if it never got opened.

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -450,7 +450,7 @@ iperf_client_end(struct iperf_test *test)
         return -1;
 
     /* Close control socket */
-    if (test->ctrl_sck)
+    if (test->ctrl_sck >= 0)
         close(test->ctrl_sck);
 
     return 0;


### PR DESCRIPTION
This prevents an "undefined socket" error, which can be incorrect if
the control connection didn't get opened due to a (for example)
"connection refused" type error.

This can be tested by running iperf3 in client mode and pointing it
towards a non-existent (or not-running) server.

Fixes #1129 (#1132 was an earlier, partial fix).
