### PR TITLE
fix: Fix a couple of buffer overrun hazards.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4571,12 +4571,15 @@ iperf_printf(struct iperf_test *test, const char* format, ...)
                 return r0;
             r += r0;
 	}
-	va_start(argp, format);
-	r0 = vsnprintf(linebuffer + r, sizeof(linebuffer) - r, format, argp);
-	va_end(argp);
-        if (r0 < 0)
-            return r0;
-        r += r0;
+        /* Should always be true as long as sizeof(ct) < sizeof(linebuffer) */
+        if (r < sizeof(linebuffer)) {
+            va_start(argp, format);
+            r0 = vsnprintf(linebuffer + r, sizeof(linebuffer) - r, format, argp);
+            va_end(argp);
+            if (r0 < 0)
+                return r0;
+            r += r0;
+        }
 	fprintf(test->outfile, "%s", linebuffer);
 
 	if (test->role == 's' && iperf_get_test_get_server_output(test)) {

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4518,7 +4518,7 @@ int
 iperf_printf(struct iperf_test *test, const char* format, ...)
 {
     va_list argp;
-    int r = -1;
+    int r = 0, r0;
     time_t now;
     struct tm *ltm = NULL;
     char *ct = NULL;
@@ -4545,24 +4545,38 @@ iperf_printf(struct iperf_test *test, const char* format, ...)
      */
     if (test->role == 'c') {
 	if (ct) {
-	    fprintf(test->outfile, "%s", ct);
+            r0 = fprintf(test->outfile, "%s", ct);
+            if (r0 < 0)
+                return r0;
+            r += r0;
 	}
-	if (test->title)
-	    fprintf(test->outfile, "%s:  ", test->title);
+	if (test->title) {
+	    r0 = fprintf(test->outfile, "%s:  ", test->title);
+            if (r0 < 0)
+                return r0;
+            r += r0;
+        }
 	va_start(argp, format);
-	r = vfprintf(test->outfile, format, argp);
+	r0 = vfprintf(test->outfile, format, argp);
 	va_end(argp);
+        if (r0 < 0)
+            return r0;
+        r += r0;
     }
     else if (test->role == 's') {
 	char linebuffer[1024];
-	int i = 0;
 	if (ct) {
-	    i = snprintf(linebuffer, sizeof(linebuffer), "%s", ct);
+	    r0 = snprintf(linebuffer, sizeof(linebuffer), "%s", ct);
+            if (r0 < 0)
+                return r0;
+            r += r0;
 	}
 	va_start(argp, format);
-	r = vsnprintf(linebuffer + i, sizeof(linebuffer) - i, format, argp);
-        r += i;
+	r0 = vsnprintf(linebuffer + r, sizeof(linebuffer) - r, format, argp);
 	va_end(argp);
+        if (r0 < 0)
+            return r0;
+        r += r0;
 	fprintf(test->outfile, "%s", linebuffer);
 
 	if (test->role == 's' && iperf_get_test_get_server_output(test)) {

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4512,7 +4512,8 @@ iperf_clearaffinity(struct iperf_test *test)
 #endif /* neither HAVE_SCHED_SETAFFINITY nor HAVE_CPUSET_SETAFFINITY nor HAVE_SETPROCESSAFFINITYMASK */
 }
 
-char iperf_timestr[100];
+static char iperf_timestr[100];
+static char linebuffer[1024];
 
 int
 iperf_printf(struct iperf_test *test, const char* format, ...)
@@ -4564,7 +4565,6 @@ iperf_printf(struct iperf_test *test, const char* format, ...)
         r += r0;
     }
     else if (test->role == 's') {
-	char linebuffer[1024];
 	if (ct) {
 	    r0 = snprintf(linebuffer, sizeof(linebuffer), "%s", ct);
             if (r0 < 0)

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4557,10 +4557,11 @@ iperf_printf(struct iperf_test *test, const char* format, ...)
 	char linebuffer[1024];
 	int i = 0;
 	if (ct) {
-	    i = sprintf(linebuffer, "%s", ct);
+	    i = snprintf(linebuffer, sizeof(linebuffer), "%s", ct);
 	}
 	va_start(argp, format);
-	r = vsnprintf(linebuffer + i, sizeof(linebuffer), format, argp);
+	r = vsnprintf(linebuffer + i, sizeof(linebuffer) - i, format, argp);
+        r += i;
 	va_end(argp);
 	fprintf(test->outfile, "%s", linebuffer);
 


### PR DESCRIPTION
Pointed out by @berkakinci.

Fixes #1134.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #1134

* Brief description of code changes (suitable for use as a commit message):
See above.
