### PR TITLE
Server does not fail when rejecting connection during running test

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -150,10 +150,15 @@ iperf_accept(struct iperf_test *test)
 	/*
 	 * Don't try to read from the socket.  It could block an ongoing test. 
 	 * Just send ACCESS_DENIED.
+         * Also, if sending failed, don't return an error, as the request is not related
+         * to the ongoing test, and returning an error will terminate the test.
 	 */
         if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Ptcp) < 0) {
-            i_errno = IESENDMESSAGE;
-            return -1;
+            if (test->debug)
+                printf("failed to send ACCESS_DENIED to an unsolicited connection requist during active test\n");
+        } else {
+            if (test->debug)
+                printf("successfully sent ACCESS_DENIED to an unsolicited connection requist during active test\n");
         }
         close(s);
     }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
3.9+ (self build)

* Issues fixed (if any):
#1135

* Brief description of code changes (suitable for use as a commit message):

Do not return error from `iperf_accept()` if it fails to send `ACCESS_DENIED` while running a test.  This is because the new connection request is not related to the running test, and is probably coming from another client or other networking activity (like ports scanning), and returning an error will terminate the active test.

A similar change may be required for the `acccept()` at the beginning of `iperf_accept()` when `test->ctrl_sck != -1`.  I dind't do it because I am not sure if this can happen because a client was able to close the socket before the `accept()` or it means there is a real problem.  Can be added if needed.
