### PR TITLE
fix: Handle correctly some errors on initial client connect.

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2020, The Regents of the University of
+ * iperf, Copyright (c) 2014-2021, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -446,8 +446,11 @@ iperf_client_end(struct iperf_test *test)
     /* show final summary */
     test->reporter_callback(test);
 
-    if (iperf_set_send_state(test, IPERF_DONE) != 0)
-        return -1;
+    /* Send response only if no error in server */
+    if (test->state > 0) {
+        if (iperf_set_send_state(test, IPERF_DONE) != 0)
+            return -1;
+    }
 
     /* Close control socket */
     if (test->ctrl_sck >= 0)

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -580,6 +580,8 @@ iperf_run_server(struct iperf_test *test)
                         return -1;
 		    }
 
+                    if (!is_closed(s)) {
+
 #if defined(HAVE_TCP_CONGESTION)
 		    if (test->protocol->id == Ptcp) {
 			if (test->congestion) {
@@ -639,8 +641,6 @@ iperf_run_server(struct iperf_test *test)
 			}
 		    }
 #endif /* HAVE_TCP_CONGESTION */
-
-                    if (!is_closed(s)) {
 
                         if (rec_streams_accepted != streams_to_rec) {
                             flag = 0;

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2019, The Regents of the University of
+ * iperf, Copyright (c) 2014-2021, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -134,8 +134,7 @@ iperf_tcp_accept(struct iperf_test * test)
 
     if (strcmp(test->cookie, cookie) != 0) {
         if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Ptcp) < 0) {
-            i_errno = IESENDMESSAGE;
-            return -1;
+            iperf_err(test, "failed to send access denied from busy server to new connecting client, errno = %d\n", errno);
         }
         close(s);
     }


### PR DESCRIPTION
This is a mostly-cosmetic reimplementation of pull request #1128.

Original commit log:

Fix two issues that caused an active TCP test to terminate if a new
connection request was received while in streams creation phase.
One issue was in iperf_tcp_accept() - after identifying that the cookies
of the new connection if from a new client, error was returned which
caused the active test to terminate. The other issue was in
iperf_run_server() where congestion alg was set for the new client,
although the stream to it was already closed by iperf_tcp_accept().
That also cause the active test to terminate.

Another minor issue that was fixed is that after a client received a
failure state (negative state) from the server, iperf_client_end()
still tried to send back IPERF_DONE to the server. That caused the
client to issue failure message of "unable to send control message:
Connection reset by peer" instead of "the server is busy running a test".

Originally submitted by: @davidBar-On

