### PR TITLE
iperf_udp: implement UDP connect retry mechanism

### DIFF
--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -556,26 +556,49 @@ iperf_udp_connect(struct iperf_test *test)
     setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (struct timeval *)&tv, sizeof(struct timeval));
 #endif
 
-    /*
-     * Write a datagram to the UDP stream to let the server know we're here.
-     * The server learns our address by obtaining its peer's address.
-     */
-    buf = 123456789;		/* this can be pretty much anything */
-    if (write(s, &buf, sizeof(buf)) < 0) {
-        // XXX: Should this be changed to IESTREAMCONNECT? 
-        i_errno = IESTREAMWRITE;
-        return -1;
-    }
+    for (int i=0; i<5; i++){
+        /* retry the connection setup for up to 5 times */
 
-    /*
-     * Wait until the server replies back to us.
-     */
-    if ((sz = recv(s, &buf, sizeof(buf), 0)) < 0) {
-        i_errno = IESTREAMREAD;
-        return -1;
-    }
+        /*
+         * Write a datagram to the UDP stream to let the server know we're here.
+         * The server learns our address by obtaining its peer's address.
+         */
+        buf = 123456789;		/* this can be pretty much anything */
+        if (write(s, &buf, sizeof(buf)) < 0) {
+            // XXX: Should this be changed to IESTREAMCONNECT? 
+            i_errno = IESTREAMWRITE;
+            return -1;
+        }
 
-    return s;
+        int result;
+        fd_set read_set;
+        struct timeval timeout;
+
+        timeout.tv_sec = 1;
+
+        memcpy(&read_set, &test->read_set, sizeof(fd_set));
+        result = select(test->max_fd + 1, &read_set, NULL, NULL, &timeout);
+        if (result < 0 && errno != EINTR) {
+            i_errno = IESELECT;
+            return -1;
+        } else if (result > 0) {
+            /*
+             * Wait until the server replies back to us.
+             */
+            if ((sz = recv(s, &buf, sizeof(buf), 0)) < 0) {
+                i_errno = IESTREAMREAD;
+                return -1;
+            } else {
+                return s;
+            }
+        } else {
+            if (test->debug)
+                fprintf(stderr, "Retrying udp connection in 1s.");
+            sleep(1);
+        }
+    }
+    i_errno = IESTREAMREAD;
+    return -1;
 }
 
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): from our investigation we encountered issue #862 and this is an attempt to resolve that issue.

* Brief description of code changes (suitable for use as a commit message):

This implements a simple retry mechanism for the `iperf_udp_connect` function using a static iteration loop with a select call and attempting to resend the connect datagram.

This is mostly as a suggestion for a fix, there's probably a better way to implement some parts of this, for example the number of iterations should probably be either a constant or could be a new cli argument that could change the value. The retry mechanism could also be optionally disabled. Another idea is that the timeout value for the `select` function could also be  configurable, a 1 second wait here may not always be a good idea depending on the specific network that is being measured.1

I'm also not 100% sure if this doesn't potentially have side effects for the test initialization state transition on the slave side in case the connect datagram is not in fact lost and instead the reply is delayed or lost.

From my internal testing on servers this resolves our issues when running multiple iperf instances to simulate stress on the network stack by running multiple network applications.