### PR TITLE
Make sure Client logs terminating error message inside the JSON output

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -651,9 +651,13 @@ iperf_run_client(struct iperf_test * test)
     return 0;
 
   cleanup_and_fail:
+    iperf_errexit(test, "error - %s", iperf_strerror(i_errno));
     iperf_client_end(test);
-    if (test->json_output)
-	iperf_json_finish(test);
+    if (test->json_output) {
+	if (iperf_json_finish(test) < 0)
+	    return -1;  // It is o.k. that error will be logged later outside the JSON output since its creation failed
+    }
     iflush(test);
-    return -1;
+    return 0;   // Return 0 and not -1 since all terminating function were done here.
+                // Also prevents error message logging outside the already closed JSON output.
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
3.10

* Issues fixed (if any):
#1143

* Brief description of code changes (suitable for use as a commit message):
When an active test is terminating with error, make sure the Client logs the error before creating the JSON output, so the error message will be included inside the JSON output.
