### PR TITLE
Add tcp_info.snd_wnd to JSON output.

### DIFF
--- a/configure
+++ b/configure
@@ -1881,6 +1881,63 @@ fi
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_header_mongrel
+
+# ac_fn_c_check_member LINENO AGGR MEMBER VAR INCLUDES
+# ----------------------------------------------------
+# Tries to find if the field MEMBER exists in type AGGR, after including
+# INCLUDES, setting cache variable VAR accordingly.
+ac_fn_c_check_member ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2.$3" >&5
+$as_echo_n "checking for $2.$3... " >&6; }
+if eval \${$4+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$5
+int
+main ()
+{
+static $2 ac_aggr;
+if (ac_aggr.$3)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$4=yes"
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$5
+int
+main ()
+{
+static $2 ac_aggr;
+if (sizeof ac_aggr.$3)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$4=yes"
+else
+  eval "$4=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$4
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_member
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -13383,6 +13440,19 @@ else
 fi
 
 
+for ac_header in linux/tcp.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "linux/tcp.h" "ac_cv_header_linux_tcp_h" "$ac_includes_default"
+if test "x$ac_cv_header_linux_tcp_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LINUX_TCP_H 1
+_ACEOF
+
+fi
+
+done
+
+
 # Check for SCTP support
 if $try_sctp; then
 for ac_header in sys/socket.h
@@ -14017,6 +14087,26 @@ $as_echo "$iperf3_cv_header_dontfragment" >&6; }
 if test "x$iperf3_cv_header_dontfragment" = "xyes"; then
 
 $as_echo "#define HAVE_DONT_FRAGMENT 1" >>confdefs.h
+
+fi
+
+ac_fn_c_check_member "$LINENO" "struct tcp_info" "tcpi_snd_wnd" "ac_cv_member_struct_tcp_info_tcpi_snd_wnd" "#ifdef HAVE_LINUX_TCP_H
+#include <linux/tcp.h>
+#else
+#include <netinet/tcp.h>
+#endif
+
+"
+if test "x$ac_cv_member_struct_tcp_info_tcpi_snd_wnd" = xyes; then :
+  iperf3_cv_header_tcp_info_snd_wnd=yes
+else
+  iperf3_cv_header_tcp_info_snd_wnd=no
+fi
+
+
+if test "x$iperf3_cv_header_tcp_info_snd_wnd" = "xyes"; then
+
+$as_echo "#define HAVE_TCP_INFO_SND_WND 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,8 @@ AC_ARG_WITH([sctp],
     ]
 )
 
+AC_CHECK_HEADERS([linux/tcp.h])
+
 # Check for SCTP support
 if $try_sctp; then
 AC_CHECK_HEADERS([sys/socket.h])
@@ -256,6 +258,19 @@ AC_EGREP_CPP(yes,
 ],iperf3_cv_header_dontfragment=yes,iperf3_cv_header_dontfragment=no))
 if test "x$iperf3_cv_header_dontfragment" = "xyes"; then
     AC_DEFINE([HAVE_DONT_FRAGMENT], [1], [Have IP_MTU_DISCOVER/IP_DONTFRAG sockopt.])
+fi
+
+AC_CHECK_MEMBER([struct tcp_info.tcpi_snd_wnd],
+[iperf3_cv_header_tcp_info_snd_wnd=yes], [iperf3_cv_header_tcp_info_snd_wnd=no],
+[#ifdef HAVE_LINUX_TCP_H
+#include <linux/tcp.h>
+#else
+#include <netinet/tcp.h>
+#endif
+])
+
+if test "x$iperf3_cv_header_tcp_info_snd_wnd" = "xyes"; then
+  AC_DEFINE([HAVE_TCP_INFO_SND_WND], [1], [Have tcpi_snd_wnd field in tcp_info.])
 fi
 
 # Check if we need -lrt for clock_gettime

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -39,7 +39,11 @@
 #ifndef _GNU_SOURCE
 # define _GNU_SOURCE
 #endif
+#ifdef HAVE_LINUX_TCP_H
+#include <linux/tcp.h>
+#else
 #include <netinet/tcp.h>
+#endif
 #include <net/if.h> // for IFNAMSIZ
 
 #if defined(HAVE_CPUSET_SETAFFINITY)
@@ -100,6 +104,7 @@ struct iperf_interval_results
     int interval_retrans;
     int interval_sacks;
     int snd_cwnd;
+    int snd_wnd;
     TAILQ_ENTRY(iperf_interval_results) irlistentries;
     void     *custom_data;
     int rtt;
@@ -123,6 +128,7 @@ struct iperf_stream_result
     int stream_sum_rtt;
     int stream_count_rtt;
     int stream_max_snd_cwnd;
+    int stream_max_snd_wnd;
     struct iperf_time start_time;
     struct iperf_time end_time;
     struct iperf_time start_time_fixed;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -277,6 +277,7 @@ int has_tcpinfo_retransmits(void);
 void save_tcpinfo(struct iperf_stream *sp, struct iperf_interval_results *irp);
 long get_total_retransmits(struct iperf_interval_results *irp);
 long get_snd_cwnd(struct iperf_interval_results *irp);
+long get_snd_wnd(struct iperf_interval_results *irp);
 long get_rtt(struct iperf_interval_results *irp);
 long get_rttvar(struct iperf_interval_results *irp);
 long get_pmtu(struct iperf_interval_results *irp);

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -30,6 +30,9 @@
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 
+/* Define to 1 if you have the <linux/tcp.h> header file. */
+#undef HAVE_LINUX_TCP_H
+
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 
@@ -89,6 +92,9 @@
 
 /* Have TCP_CONGESTION sockopt. */
 #undef HAVE_TCP_CONGESTION
+
+/* Have tcpi_snd_wnd field in tcp_info. */
+#undef HAVE_TCP_INFO_SND_WND
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H

--- a/src/tcp_info.c
+++ b/src/tcp_info.c
@@ -145,6 +145,26 @@ get_snd_cwnd(struct iperf_interval_results *irp)
 
 /*************************************************************/
 /*
+ * Return snd_wnd in octets.
+ */
+long
+get_snd_wnd(struct iperf_interval_results *irp)
+{
+#if !defined(HAVE_TCP_INFO_SND_WND)
+    return -1;
+#elif defined(linux) && defined(TCP_MD5SIG)
+    return irp->tcpInfo.tcpi_snd_wnd;
+#elif defined(__FreeBSD__) && __FreeBSD_version >= 600000
+    return irp->tcpInfo.tcpi_snd_wnd;
+#elif defined(__NetBSD__) && defined(TCP_INFO)
+    return irp->tcpInfo.tcpi_snd_wnd * irp->tcpInfo.tcpi_snd_mss;
+#else
+    return -1;
+#endif
+}
+
+/*************************************************************/
+/*
  * Return rtt in usec.
  */
 long


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

tcp_info.snd_wnd is available on FreeBSD and NetBSD since TCP_INFO was
added.  It was added to Linux 5.4 in late 2019 and becomes available in Ubuntu 20.04
and Debian 11. This commit adds it to JSON output if available.

Tested on:
* Debian 11 running on x86-64 with this field.
* Debian 10 armv7 running on Raspberry Pi 2 without this field.
* NetBSD 9.2 armv7 running on Raspberry Pi 3 with this field.
* FreeBSD 13 aarch64 running on Raspberry Pi 4 with this field.
