### PR TITLE
Fix --bind-dev options for TCP streams. (#1099)

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -119,12 +119,13 @@ timeout_connect(int s, const struct sockaddr *name, socklen_t namelen,
  * Copyright: http://swtch.com/libtask/COPYRIGHT
 */
 
-/* make connection to server */
+/* create a socket */
 int
-netdial(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, int timeout)
+create_socket(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, struct addrinfo **server_res_out)
 {
     struct addrinfo hints, *local_res = NULL, *server_res = NULL;
     int s, saved_errno;
+    char portstr[6];
 
     if (local) {
         memset(&hints, 0, sizeof(hints));
@@ -137,8 +138,12 @@ netdial(int domain, int proto, const char *local, const char *bind_dev, int loca
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = domain;
     hints.ai_socktype = proto;
-    if ((gerror = getaddrinfo(server, NULL, &hints, &server_res)) != 0)
+    snprintf(portstr, sizeof(portstr), "%d", port);
+    if ((gerror = getaddrinfo(server, portstr, &hints, &server_res)) != 0) {
+	if (local)
+	    freeaddrinfo(local_res);
         return -1;
+    }
 
     s = socket(server_res->ai_family, proto, 0);
     if (s < 0) {
@@ -204,6 +209,8 @@ netdial(int domain, int proto, const char *local, const char *bind_dev, int loca
 	}
 	/* Unknown protocol */
 	else {
+	    close(s);
+	    freeaddrinfo(server_res);
 	    errno = EAFNOSUPPORT;
             return -1;
 	}
@@ -217,7 +224,22 @@ netdial(int domain, int proto, const char *local, const char *bind_dev, int loca
         }
     }
 
-    ((struct sockaddr_in *) server_res->ai_addr)->sin_port = htons(port);
+    *server_res_out = server_res;
+    return s;
+}
+
+/* make connection to server */
+int
+netdial(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, int timeout)
+{
+    struct addrinfo *server_res = NULL;
+    int s, saved_errno;
+
+    s = create_socket(domain, proto, local, bind_dev, local_port, server, port, &server_res);
+    if (s < 0) {
+      return -1;
+    }
+
     if (timeout_connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen, timeout) < 0 && errno != EINPROGRESS) {
 	saved_errno = errno;
 	close(s);

--- a/src/net.h
+++ b/src/net.h
@@ -28,6 +28,7 @@
 #define __NET_H
 
 int timeout_connect(int s, const struct sockaddr *name, socklen_t namelen, int timeout);
+int create_socket(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, struct addrinfo **server_res_out);
 int netdial(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, int timeout);
 int netannounce(int domain, int proto, const char *local, const char *bind_dev, int port);
 int Nread(int fd, char *buf, size_t count, int prot);


### PR DESCRIPTION
netdial() honors --bind-dev option but iperf_tcp_connect() doesn't,
as a result, only the control socket is bound to the device, but not
the data socket.

Instead of duplicaing code from netdial to iperf_tcp_connect(), this
fix extracts a common util function create_socket() from netdial() and
let iperf_tcp_connect() call create_socket() to create a socket with
optional bindings.

Tested on Raspberry Pi 3 with eth0 and wlan0.


* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any): #1099 

* Brief description of code changes (suitable for use as a commit message):
See above.
