### PR TITLE
Allow write to file without fsync to improve performance

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -274,7 +274,8 @@ struct iperf_test
     int       server_port;
     int       omit;                             /* duration of omit period (-O flag) */
     int       duration;                         /* total duration of test (-t flag) */
-    char     *diskfile_name;			/* -F option */
+    char      *diskfile_name;			/* -F option */
+    int       no_fsync;                         /* --no_fsync option */
     int       affinity, server_affinity;	/* -A option */
 #if defined(HAVE_CPUSET_SETAFFINITY)
     cpuset_t cpumask;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1007,6 +1007,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 	{"connect-timeout", required_argument, NULL, OPT_CONNECT_TIMEOUT},
         {"idle-timeout", required_argument, NULL, OPT_IDLE_TIMEOUT},
         {"rcv-timeout", required_argument, NULL, OPT_RCV_TIMEOUT},
+        {"no-fsync", no_argument, NULL, OPT_NO_FSYNC},
         {"debug", no_argument, NULL, 'd'},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
@@ -1328,6 +1329,9 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 break;
             case 'F':
                 test->diskfile_name = optarg;
+                break;
+            case OPT_NO_FSYNC:
+                test->no_fsync = 1;
                 break;
             case OPT_IDLE_TIMEOUT:
                 test->settings->idle_timeout = atoi(optarg);
@@ -2619,6 +2623,7 @@ iperf_defaults(struct iperf_test *testp)
     testp->omit = OMIT;
     testp->duration = DURATION;
     testp->diskfile_name = (char*) 0;
+    testp->no_fsync = 0;
     testp->affinity = -1;
     testp->server_affinity = -1;
     TAILQ_INIT(&testp->xbind_addrs);
@@ -4277,7 +4282,9 @@ diskfile_recv(struct iperf_stream *sp)
     r = sp->rcv2(sp);
     if (r > 0) {
 	(void) write(sp->diskfile_fd, sp->buffer, r);
-	(void) fsync(sp->diskfile_fd);
+        if (!sp->test->no_fsync) {
+	    (void) fsync(sp->diskfile_fd);
+        }
     }
     return r;
 }

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -87,6 +87,7 @@ typedef uint64_t iperf_size_t;
 #define OPT_IDLE_TIMEOUT 25
 #define OPT_DONT_FRAGMENT 26
 #define OPT_RCV_TIMEOUT 27
+#define OPT_NO_FSYNC 28
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -102,6 +102,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -i, --interval  #         seconds between periodic throughput reports\n"
                            "  -I, --pidfile file        write PID file\n"
                            "  -F, --file name           xmit/recv the specified file\n"
+                           "  --no-fsync                do not fsync output file after writing to it\n"
+                           "                            (default is fsync after each write)\n"
 #if defined(HAVE_CPU_AFFINITY)
                            "  -A, --affinity n/n,m      set CPU affinity\n"
 #endif /* HAVE_CPU_AFFINITY */


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
3.10 local build

* Issues fixed (if any):
 #1159 

* Brief description of code changes (suitable for use as a commit message):
Add option `--no-fsync` to allow better throughput when **receiver** output is a disk file (`-F` option).  When the option is set, no `fsync` is done after write to the file.  Default remains `fsync` after each write to the file.
