### PR TITLE
Fix --dscp

### DIFF
--- a/src/dscp.c
+++ b/src/dscp.c
@@ -136,10 +136,11 @@ parse_qos(const char *cp)
 			return ipqos[i].value;
 	}
 	/* Try parsing as an integer */
+    /* Max DSCP value is 2**6 - 1 */
 	val = strtol(cp, &ep, 0);
-	if (*cp == '\0' || *ep != '\0' || val < 0 || val > 255)
+	if (*cp == '\0' || *ep != '\0' || val < 0 || val > 63)
 		return -1;
-	return val;
+	return val << 2;
 }
 
 const char *

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -336,7 +336,8 @@ i.e. 52, 064 and 0x34 all specify the same value.
 .TP
 .BR "--dscp " \fIdscp\fR
 set the IP DSCP bits.  Both numeric and symbolic values are accepted. Numeric
-values can be specified in decimal, octal and hex (see --tos above).
+values can be specified in decimal, octal and hex (see --tos above). To set
+both the DSCP bits and the ECN bits, use --tos.
 .TP
 .BR -L ", " --flowlabel " \fIn\fR"
 set the IPv6 flow label (currently only supported on Linux)


### PR DESCRIPTION
Maybe I am missing something obvious, but when I call iperf3 with --tos XX, where XX is DSCP << 2, it works fine. But if I call iperf3 with --dscp DSCP (e.g., with the unshifted value) it doesn't work. In looking at the code, I am not seeing where the DSCP is shifted left 2 bits.