### PR TITLE
Systemd-based socket activation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,5 +306,14 @@ AC_SEARCH_LIBS(clock_gettime, [rt posix4])
 # Check for clock_gettime support
 AC_CHECK_FUNCS([clock_gettime])
 
+
+#
+# Check for systemd to support socket-based activation
+#
+AC_CHECK_HEADERS([systemd/sd-daemon.h],
+		 AC_DEFINE([HAVE_SD_DAEMON_H], [1], [Have sd-daemon support.])
+		 AC_SEARCH_LIBS(sd_listen_fds, [systemd]))
+
+
 AC_CONFIG_FILES([Makefile src/Makefile src/version.h examples/Makefile iperf3.spec])
 AC_OUTPUT

--- a/contrib/iperf3_@.service
+++ b/contrib/iperf3_@.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Socket-Activated iperf3
+
+[Service]
+ExecStart=/usr/local/bin/iperf3 -s -1 -p %i --forceflush

--- a/contrib/iperf3_@.socket
+++ b/contrib/iperf3_@.socket
@@ -1,0 +1,6 @@
+[Socket]
+ListenStream=%i
+
+[Install]
+WantedBy=sockets.target
+

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -54,6 +54,9 @@
 /* Have SCTP support. */
 #undef HAVE_SCTP_H
 
+/* Have sd-daemon support. */
+#undef HAVE_SD_DAEMON_H
+
 /* Define to 1 if you have the `sendfile' function. */
 #undef HAVE_SENDFILE
 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -66,10 +66,25 @@
 #endif /* TCP_CA_NAME_MAX */
 #endif /* HAVE_TCP_CONGESTION */
 
+#if defined(HAVE_SD_DAEMON_H)
+#include <systemd/sd-daemon.h>
+#endif
+
 int
 iperf_server_listen(struct iperf_test *test)
 {
+    int n = 0;
     retry:
+    #if defined(HAVE_SD_DAEMON_H)
+    n = sd_listen_fds(0);
+    if (n > 1) {
+            return -1;
+    }
+    if (n == 1) {
+            test->listener = SD_LISTEN_FDS_START + 0;
+    }
+    #endif
+    if (n == 0) {
     if((test->listener = netannounce(test->settings->domain, Ptcp, test->bind_address, test->bind_dev, test->server_port)) < 0) {
 	if (errno == EAFNOSUPPORT && (test->settings->domain == AF_INET6 || test->settings->domain == AF_UNSPEC)) {
 	    /* If we get "Address family not supported by protocol", that
@@ -84,6 +99,7 @@ iperf_server_listen(struct iperf_test *test)
 	    i_errno = IELISTEN;
 	    return -1;
 	}
+    }
     }
 
     if (!test->json_output) {


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #742 

* Brief description of code changes (suitable for use as a commit message): Allow iperf3 to receive sockets from systemd.


This patch enables systemd-based socket activation of iperf3. To test, build and install this fork, then:
* `mv contrib/iperf3_@.*  /etc/systemd/system/`
*  `systemctl daemon-reload`
* `systemctl start iperf3_5201`

This will make systemd listen on port 5201. As soon as a client tries to connect, iperf3 is started and takes over.

I originally wanted to add multi-user support, but this is not as easy due to the separate control / data connections.
In combination with loadbalancing (i.e. based on the IP address, client could be NATted to a socket-activated iperf3 instance) it might still be useful..
Also, as the socket-activation was a separate issue, maybe it's useful to others. :)