### PR TITLE
Added {end}{sum_sent} and {end}{sum_received} to UDP JSON output

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3710,9 +3710,14 @@ iperf_print_results(struct iperf_test *test)
                 else {
                     lost_percent = 0.0;
                 }
-                if (test->json_output)
+                if (test->json_output) {
                     cJSON_AddItemToObject(test->json_end, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f sender: %b", (double) start_time, (double) receiver_time, (double) receiver_time, (int64_t) total_sent, bandwidth * 8, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) total_packets, (double) lost_percent, stream_must_be_sender));
-                else {
+                    /* Modifications to add sum_sent and sum_received to UDP JSON results - DJ */
+                    /* For historical reasons (and hysterical raisins), "sum" section NOT REMOVED */
+                    cJSON_AddItemToObject(test->json_end, "sum_sent", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  sender: %b", (double) start_time, (double) sender_time, (double) sender_time, (int64_t) total_sent, (double) total_sent * 8 / sender_time, (double) 0.0, (int64_t) 0, (int64_t) sender_total_packets, (double) 0.0, 1));
+                    cJSON_AddItemToObject(test->json_end, "sum_received", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  sender: %b", (double) start_time, (double) receiver_time, (double) receiver_time, (int64_t) total_received, (double) total_received * 8 / receiver_time, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) receiver_total_packets, (double) lost_percent, 0));
+                    /* End Modifications to add sum_sent and sum_received to UDP JSON results - DJ */
+                } else {
                     /*
                      * On the client we have both sender and receiver overall summary
                      * stats.  On the server we have only the side that was on the


### PR DESCRIPTION
* Version of iperf3:
**master**

* Issues fixed (if any):
**JSON output missing {end}{sum_sent} and {end}{sum_received} for UDP tests**

* Brief description of code changes (suitable for use as a commit message):
Changes made in `iperf_api.c` adding {end}{sum_sent} and {end}{sum_received} JSON objects with appropriate values for UDP tests. I did NOT remove or modify the existing {end}{sum} object to preserve any existing implementations. Existing {end}{sum} always shows sending side's byte count and bits_per_sec which is misleading in many situations.