### PR TITLE
Remove fsync(2) call after every write to a receiving --file.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4277,7 +4277,6 @@ diskfile_recv(struct iperf_stream *sp)
     r = sp->rcv2(sp);
     if (r > 0) {
 	(void) write(sp->diskfile_fd, sp->buffer, r);
-	(void) fsync(sp->diskfile_fd);
     }
     return r;
 }


### PR DESCRIPTION
This removes a performance pessimization that wasn't really
needed in the first place.

Fixes #1159.
