### PR TITLE
Reliable receiving (-r) data as sent by sender

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -275,6 +275,7 @@ struct iperf_test
     int       omit;                             /* duration of omit period (-O flag) */
     int       duration;                         /* total duration of test (-t flag) */
     char     *diskfile_name;			/* -F option */
+    int       reliable_receive_in_full;     /* -r option. For reciever only. */
     int       affinity, server_affinity;	/* -A option */
 #if defined(HAVE_CPUSET_SETAFFINITY)
     cpuset_t cpumask;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -970,6 +970,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         {"zerocopy", no_argument, NULL, 'Z'},
         {"omit", required_argument, NULL, 'O'},
         {"file", required_argument, NULL, 'F'},
+        {"reliable", required_argument, NULL, 'r'},
         {"repeating-payload", no_argument, NULL, OPT_REPEATING_PAYLOAD},
         {"timestamps", optional_argument, NULL, OPT_TIMESTAMPS},
 #if defined(HAVE_CPU_AFFINITY)
@@ -1029,7 +1030,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     char *client_username = NULL, *client_rsa_public_key = NULL, *server_rsa_private_key = NULL;
 #endif /* HAVE_SSL */
 
-    while ((flag = getopt_long(argc, argv, "p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:A:T:C:dI:hX:", longopts, NULL)) != -1) {
+    while ((flag = getopt_long(argc, argv, "p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:rA:T:C:dI:hX:", longopts, NULL)) != -1) {
         switch (flag) {
             case 'p':
 		portno = atoi(optarg);
@@ -1327,6 +1328,9 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 break;
             case 'F':
                 test->diskfile_name = optarg;
+                break;
+            case 'r':
+                test->reliable_receive_in_full = 1;
                 break;
             case OPT_IDLE_TIMEOUT:
                 test->settings->idle_timeout = atoi(optarg);
@@ -2637,6 +2641,7 @@ iperf_defaults(struct iperf_test *testp)
     testp->omit = OMIT;
     testp->duration = DURATION;
     testp->diskfile_name = (char*) 0;
+    testp->reliable_receive_in_full = 0;
     testp->affinity = -1;
     testp->server_affinity = -1;
     TAILQ_INIT(&testp->xbind_addrs);

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -625,6 +625,13 @@ iperf_run_client(struct iperf_test * test)
 		test->stats_callback(test);
 		if (iperf_set_send_state(test, TEST_END) != 0)
                     goto cleanup_and_fail;
+        // sending total bytes count for server,
+        //  to be used if needed for reliable data saving in file on server (-F)
+        int32_t netBytesSent = htonl(test->bytes_sent);
+        if (Nwrite(test->ctrl_sck, (char*) &netBytesSent, sizeof(netBytesSent), Ptcp) < 0) {
+            i_errno = IECTRLWRITE;
+            return -1;
+        }
 	    }
 	}
 	// If we're in reverse mode, continue draining the data


### PR DESCRIPTION
* Version of iperf3 to which this pull request applies: `master`

* Issues fixed (if any): N/A

* Brief description of code changes (suitable for use as a commit message):

**Reliable receiving (-r) data as sent by sender**

Two changes implemented:

1. On client, Following TEST_END signal, it sends the total number of bytes sent for server over control-socket.

2. On server,
    a. following TEST_END it receives the total number of bytes and sets to test->settings->bytes
    b. (if reliability requested) it defers the test termination and cleanup until that exact number of bytes are received (timer-based solution)
