### PR TITLE
Partial file transfer

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -275,6 +275,8 @@ struct iperf_test
     int       omit;                             /* duration of omit period (-O flag) */
     int       duration;                         /* total duration of test (-t flag) */
     char     *diskfile_name;			/* -F option */
+    int       diskfile_seek;            /* optional with -F option (sender only) */ 
+    int       diskfile_append;          /* optional with -F option (receiver only) */
     int       affinity, server_affinity;	/* -A option */
 #if defined(HAVE_CPUSET_SETAFFINITY)
     cpuset_t cpumask;

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -120,7 +120,7 @@ default is 1, use 0 to disable
 .BR -I ", " --pidfile " \fIfile\fR"
 write a file with the process ID, most useful when running as a daemon.
 .TP
-.BR -F ", " --file " \fIname\fR"
+.BR -F ", " --file " \fIname[,(append|#)]\fR"
 Use a file as the source (on the sender) or sink (on the receiver) of
 data, rather than just generating random data or throwing it away.
 This feature is used for finding whether or not the storage subsystem
@@ -128,6 +128,10 @@ is the bottleneck for file transfers.
 It does not turn iperf3 into a file transfer tool.
 The length, attributes, and in some cases contents of the received
 file may not match those of the original file.
+Optional second parameter after filename: for sender, it
+may be a number showing the offset in the file to start reading from.
+For receiver, 'append' will tell the server to append the received 
+bytes to the end of file (default behaviour is to overwrite the file).
 .TP
 .BR -A ", " --affinity " \fIn/n,m\fR"
 Set the CPU affinity, if possible (Linux, FreeBSD, and Windows only).

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -101,7 +101,10 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -f, --format   [kmgtKMGT] format to report: Kbits, Mbits, Gbits, Tbits\n"
                            "  -i, --interval  #         seconds between periodic throughput reports\n"
                            "  -I, --pidfile file        write PID file\n"
-                           "  -F, --file name           xmit/recv the specified file\n"
+                           "  -F, --file name[,(append|#)]  xmit/recv the specified file\n"
+                           "                            (optional second argument after comma: \n"
+                           "                             # file offset to read from for sender,\n"
+                           "                             'append' content to file for receiver )\n"
 #if defined(HAVE_CPU_AFFINITY)
                            "  -A, --affinity n/n,m      set CPU affinity\n"
 #endif /* HAVE_CPU_AFFINITY */


### PR DESCRIPTION
* Version of iperf3 to which this pull request applies: `master`

* Issues fixed (if any): N/A

* Brief description of code changes (suitable for use as a commit message):

**Optional sender file seek and receiver append parameters with -F**

File transfer `-F` switch updated to take an optional second parameter, 
`-F, --file name[,(append|#)]`
The parameter after comma will either be,
- `#` the number of bytes to seek in the file and start sending from specific offset (for sender)
- `append` to append newly received data to the end of file in receiver (default behaviour is to overwrite the file)
