### PR TITLE
Fix to support address%interface syntax

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -425,7 +425,9 @@ enum {
     IEAUTHTEST = 142,       // Test authorization failed
     IEBINDDEV = 143,        // Unable to bind-to-device (check perror, maybe permissions?)
     IENOMSG = 144,          // No message was received for NO_MSG_RCVD_TIMEOUT time period
-    IESETDONTFRAGMENT = 145,    // Unable to set IP Do-Not-Fragment
+    IESETDONTFRAGMENT = 145,   // Unable to set IP Do-Not-Fragment
+    IEBINDDEVNOSUPPORT = 146,  // `ip%%dev` is not supported as system does not support bind to device
+    IEHOSTDEV = 147,        // host device name (ip%%<dev>) is supported (and required) only for IPv6 link-local address
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -438,6 +438,15 @@ iperf_strerror(int int_errno)
 	case IEIDLETIMEOUT:
 	    snprintf(errstr, len, "idle timeout parameter is not positive or larget then allowed limit");
             break;
+	case IEBINDDEV:
+	    snprintf(errstr, len, "Unable to bind-to-device (check perror, maybe permissions?)");
+            break;
+    case IEBINDDEVNOSUPPORT:
+	    snprintf(errstr, len, "`<ip>%%<dev>` is not supported as system does not support bind to device");
+            break;
+    case IEHOSTDEV:
+	    snprintf(errstr, len, "host device name (ip%%<dev>) is supported (and required) only for IPv6 link-local address");
+            break;        
 	case IENOMSG:
 	    snprintf(errstr, len, "idle timeout for receiving data");
             break;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -105,9 +105,12 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #if defined(HAVE_CPU_AFFINITY)
                            "  -A, --affinity n/n,m      set CPU affinity\n"
 #endif /* HAVE_CPU_AFFINITY */
-                           "  -B, --bind      <host>    bind to the interface associated with the address <host>\n"
 #if defined(HAVE_SO_BINDTODEVICE)
-                           "  --bind-dev      <dev>     bind to the network interface with SO_BINDTODEVICE\n"
+                           "  -B, --bind <host>[%<dev>] bind to the interface associated with the address <host>\n"
+                           "                            (optional <dev> equivalent to `--bind-dev <dev>`)\n"
+                           "  --bind-dev <dev>          bind to the network interface with SO_BINDTODEVICE\n"
+#else /* HAVE_SO_BINDTODEVICE */
+                           "  -B, --bind      <host>    bind to the interface associated with the address <host>\n"
 #endif /* HAVE_SO_BINDTODEVICE */
                            "  -V, --verbose             more detailed output\n"
                            "  -J, --json                output in JSON format\n"
@@ -139,7 +142,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "                            and client during the authentication process\n"
 #endif //HAVE_SSL
                            "Client specific:\n"
-                           "  -c, --client    <host>    run in client mode, connecting to <host>\n"
+                           "  -c, --client <host>[%<dev>] run in client mode, connecting to <host>\n"
+                           "                              %<dev> is supported and required when <host> is IPv6 Link-local\n"
 #if defined(HAVE_SCTP_H)
                            "  --sctp                    use SCTP rather than TCP\n"
                            "  -X, --xbind <name>        bind SCTP association to links\n"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
Latest 3.10.1

* Issues fixed (if any):
#1157

* Brief description of code changes (suitable for use as a commit message):

Simple suggested change to support `<address>%<device>` format for both `-c` and `-B` options.  As far as I understand issue #1157 and the related iperf2 implementation, the change supports at least the main suggested functionality.

No change was done to the device binding functionality, assuming current support is sufficient, although it may be that iperf2 support extended binding functionality - e.g. it uses two separate binding devices for Tx (from `-c`) and Rx (from `-B`).

The changes are:

1. **`-c`**: verify that `%device` is included only when the host address is IPv6 link-local.  No real functionality was added/changed.  (I was not able to test IPv6 link-local functionality, but according to iperf2 implementation this should be o.k.  In in any case, since there is no real functionality change there is no risk of iperf3 functionality degradation.)

2.  **`-B`**: allow using the `<ip>%<device>` (only when `SO_BINDTODEVICE` is supported).  When `%<device>` is specified handle it as it was defined by `--bind-dev`.  No check is done about whether device was specified by both `-B` and `--bind-dev` - the last one defined in the command line will be used.