### PR TITLE
Don't exit in cleanup_and_fail

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -651,13 +651,13 @@ iperf_run_client(struct iperf_test * test)
     return 0;
 
   cleanup_and_fail:
-    iperf_errexit(test, "error - %s", iperf_strerror(i_errno));
     iperf_client_end(test);
     if (test->json_output) {
-	if (iperf_json_finish(test) < 0)
-	    return -1;  // It is o.k. that error will be logged later outside the JSON output since its creation failed
+        cJSON_AddStringToObject(test->json_top, "error", iperf_strerror(i_errno));
+        iperf_json_finish(test);
+        iflush(test);
+        return 0;
     }
     iflush(test);
-    return 0;   // Return 0 and not -1 since all terminating function were done here.
-                // Also prevents error message logging outside the already closed JSON output.
+    return -1;
 }


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: 3.10 +

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

<https://github.com/esnet/iperf/pull/1146> which aimed to add the error message inside the JSON output did so by invoking iperf_errexit.
While this works it also has the side effect of terminating the parent process when the test run is invoked from python like with <https://github.com/thiezn/iperf3-python>

This PR provides the desired output that was requested in #1143 without exiting during cleanup.
