### PR TITLE
Move sndbuf size warning to stderr

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -325,7 +325,7 @@ iperf_tcp_listen(struct iperf_test *test)
 	return -1;
     }
     if (test->debug) {
-	printf("SNDBUF is %u, expecting %u\n", sndbuf_actual, test->settings->socket_bufsize);
+	fprintf(stderr, "SNDBUF is %u, expecting %u\n", sndbuf_actual, test->settings->socket_bufsize);
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > sndbuf_actual) {
 	i_errno = IESETBUF2;
@@ -518,7 +518,7 @@ iperf_tcp_connect(struct iperf_test *test)
 	return -1;
     }
     if (test->debug) {
-	printf("SNDBUF is %u, expecting %u\n", sndbuf_actual, test->settings->socket_bufsize);
+	fprintf(stderr, "SNDBUF is %u, expecting %u\n", sndbuf_actual, test->settings->socket_bufsize);
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > sndbuf_actual) {
 	i_errno = IESETBUF2;

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -332,7 +332,7 @@ iperf_udp_buffercheck(struct iperf_test *test, int s)
 	return -1;
     }
     if (test->debug) {
-	printf("RCVBUF is %u, expecting %u\n", rcvbuf_actual, test->settings->socket_bufsize);
+	fprintf(stderr, "RCVBUF is %u, expecting %u\n", rcvbuf_actual, test->settings->socket_bufsize);
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > rcvbuf_actual) {
 	i_errno = IESETBUF2;


### PR DESCRIPTION
When do perf test with -J, sndbuf warning
is also printed to stdout. Move it to stderr..

Signed-off-by: ushen <yshxxsjt715@gmail.com>

