### PR TITLE
Don't close stdout when using external logfile

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2913,7 +2913,7 @@ iperf_free_test(struct iperf_test *test)
     if (test->logfile) {
 	free(test->logfile);
 	test->logfile = NULL;
-	if (test->outfile) {
+	if (test->outfile && test->outfile != stdout) {
 	    fclose(test->outfile);
 	    test->outfile = NULL;
 	}


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any):
  * If using an external logfile via `iperf_set_test_logfile()` and not running the test (e.g. avoiding `iperf_run_client()`), the function `iperf_free_test()` closes stdout.
* Brief description of code changes (suitable for use as a commit message):
  * Only close `test->outfile` if it is not `stdout`

* How to reproduce
```
    struct iperf_test *test_ = iperf_new_test();
    iperf_defaults(test_);
    iperf_set_test_role(test_, 'c');
    iperf_set_test_get_server_output(test_, 1);
    iperf_set_test_json_output(test_, 1);
    iperf_set_test_logfile(test_, "/tmp/iperf3.log");
    printf("This message will be shown");
    iperf_free_test(test_);
    printf("This message will not be shown");
```