### PR TITLE
Force iperf3 server to exit if it can't open its log file.

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -437,7 +437,7 @@ iperf_run_server(struct iperf_test *test)
 
     if (test->logfile)
         if (iperf_open_logfile(test) < 0)
-            return -1;
+            return -2;
 
     if (test->affinity != -1)
 	if (iperf_setaffinity(test, test->affinity) != 0)


### PR DESCRIPTION
Fixes #1225.

