### PR TITLE
Use different Up/Downlink ports when cport and bdir options are set

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -64,9 +64,15 @@ iperf_create_streams(struct iperf_test *test, int sender)
     for (i = 0; i < test->num_streams; ++i) {
 
         test->bind_port = orig_bind_port;
-	if (orig_bind_port)
+	if (orig_bind_port) {
 	    test->bind_port += i;
-        if ((s = test->protocol->connect(test)) < 0)
+            // If Bidir make sure send and receive ports are different
+            if (!sender && test->mode == BIDIRECTIONAL)
+                test->bind_port += test->num_streams;
+        }
+        s = test->protocol->connect(test);
+        test->bind_port = orig_bind_port;
+        if (s < 0)
             return -1;
 
 #if defined(HAVE_TCP_CONGESTION)


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
Latest 3.10+

* Issues fixed (if any):
* #1249

* Brief description of code changes (suitable for use as a commit message):
When both `--cport` and `--bdir` options are set, make sure that the ports used for one direction are different from the ports used for the other direction.
