### PR TITLE
Ignore out of order packts during UDP connection in Reverse Mode

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -421,4 +421,11 @@ struct iperf_test
 
 extern int gerror; /* error value from getaddrinfo(3), for use in internal error handling */
 
+/* UDP "connect" message and reply (textual value for Wireshark, etc. readability - legacy was numeric) */
+#define UDP_CONNECT_MSG 0x36373839   // "6789" - legacy value was 123456789
+#define UDP_CONNECT_REPLY 0x39383736 // "9876" - legacy value was 987654321
+
+/* In Reverse mode, maxmimum number of packtes to wait for "accept" response - to handle out of order packets */
+#define MAX_REVERSE_OUT_OF_ORDER_PACKETS 2
+
 #endif /* !__IPERF_H */

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -365,7 +365,7 @@ int
 iperf_udp_accept(struct iperf_test *test)
 {
     struct sockaddr_storage sa_peer;
-    int       buf;
+    unsigned int buf;
     socklen_t len;
     int       sz, s;
     int	      rc;
@@ -452,7 +452,7 @@ iperf_udp_accept(struct iperf_test *test)
     test->max_fd = (test->max_fd < test->prot_listener) ? test->prot_listener : test->max_fd;
 
     /* Let the client know we're ready "accept" another UDP "stream" */
-    buf = 987654321;		/* any content will work here */
+    buf = UDP_CONNECT_REPLY;
     if (write(s, &buf, sizeof(buf)) < 0) {
         i_errno = IESTREAMWRITE;
         return -1;
@@ -494,11 +494,13 @@ iperf_udp_listen(struct iperf_test *test)
 int
 iperf_udp_connect(struct iperf_test *test)
 {
-    int s, buf, sz;
+    int s, sz;
+    unsigned int buf;
 #ifdef SO_RCVTIMEO
     struct timeval tv;
 #endif
     int rc;
+    int i, max_len_wait_for_reply;
 
     /* Create and bind our local socket. */
     if ((s = netdial(test->settings->domain, Pudp, test->bind_address, test->bind_dev, test->bind_port, test->server_hostname, test->server_port, -1)) < 0) {
@@ -564,7 +566,10 @@ iperf_udp_connect(struct iperf_test *test)
      * Write a datagram to the UDP stream to let the server know we're here.
      * The server learns our address by obtaining its peer's address.
      */
-    buf = 123456789;		/* this can be pretty much anything */
+    buf = UDP_CONNECT_MSG;
+    if (test->debug) {
+        printf("Sending Connect message to Sockt %d\n", s);
+    }
     if (write(s, &buf, sizeof(buf)) < 0) {
         // XXX: Should this be changed to IESTREAMCONNECT?
         i_errno = IESTREAMWRITE;
@@ -572,9 +577,24 @@ iperf_udp_connect(struct iperf_test *test)
     }
 
     /*
-     * Wait until the server replies back to us.
+     * Wait until the server replies back to us with the "accept" response.
      */
-    if ((sz = recv(s, &buf, sizeof(buf), 0)) < 0) {
+    i = 0;
+    max_len_wait_for_reply = sizeof(buf);
+    if (test->reverse) /* In reverse mode allow few packets to have the "accept" response - to handle out of order packets */
+        max_len_wait_for_reply += MAX_REVERSE_OUT_OF_ORDER_PACKETS * test->settings->blksize;
+    do {
+        if ((sz = recv(s, &buf, sizeof(buf), 0)) < 0) {
+            i_errno = IESTREAMREAD;
+            return -1;
+        }
+        if (test->debug) {
+            printf("Connect received for Socket %d, sz=%d, buf=%x, i=%d, max_len_wait_for_reply=%d\n", s, sz, buf, i, max_len_wait_for_reply);
+        }
+        i += sz;
+    } while (buf != UDP_CONNECT_REPLY && i < max_len_wait_for_reply);
+
+    if (buf != UDP_CONNECT_REPLY) {
         i_errno = IESTREAMREAD;
         return -1;
     }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

Latest 3.10+

* Issues fixed (if any):

#1123, #1212 and probably #914, #1182

* Brief description of code changes (suitable for use as a commit message):

Based on the analysis done by @aahoward in #1123.  In UDP Reverse mode, the server starts sending the UDP packets immediately after sending the Connect response.  Sometimes, before network packets reordering, the first UDP packet arrives to the client before the Connection response.  In this case the client wrongly handles the first packet as the connection response.

The proposed solution is that the client will wait until receiving the connect response.  Current implementation is that the client allows one packet out of order (hardcoded as it seems that the chance that two packets will arrive before the connection response is minimal).  It is also assumed that the first packets does not include the 4 bytes connection response static value in a 4 bytes alignment offset.

Note that based on a suggestion in a previous issue (I couldn't find it now) I changed the connection and response 4 bytes messages values to textual value, to allow easier Wireshark, etc. readability.
