### PR TITLE
Fix --bind missing a .TP in iperf3.1

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -145,6 +145,7 @@ bind to the specific interface associated with address \fIhost\fR.
 If an optional interface is specified, it is treated as a shortcut
 for \fB--bind-dev \fIdev\fR.
 Note that a percent sign and interface device name are required for IPv6 link-local address literals.
+.TP
 .BR --bind-dev " \fIdev\fR"
 bind to the specified network interface.
 This option uses SO_BINDTODEVICE, and may require root permissions.


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master and latest stable

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message): Add a missing .TP in the iperf.1 manual page

