### PR TITLE
Omit help text enhancement

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -384,7 +384,7 @@ Use a "zero copy" method of sending data, such as sendfile(2),
 instead of the usual write(2).
 .TP
 .BR -O ", " --omit " \fIn\fR"
-Omit the first n seconds of the test, to skip past the TCP slow-start
+Perform pre-test for N seconds and omit the pre-test statistics, to skip past the TCP slow-start
 period.
 .TP
 .BR -T ", " --title " \fIstr\fR"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -190,7 +190,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -L, --flowlabel N         set the IPv6 flow label (only supported on Linux)\n"
 #endif /* HAVE_FLOWLABEL */
                            "  -Z, --zerocopy            use a 'zero copy' method of sending data\n"
-                           "  -O, --omit N              omit the first n seconds\n"
+                           "  -O, --omit N              perform pre-test for N seconds and omit the pre-test statistics\n"
                            "  -T, --title str           prefix every output line with this string\n"
                            "  --extra-data str          data string to include in client and server JSON\n"
                            "  --get-server-output       get results from server\n"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
3.11

* Issues fixed (if any):
* #1261

* Brief description of code changes (suitable for use as a commit message):
Enhance help text for `--omit` to make sure it is clear that the omitted time is not included in the `-t` test time.
