### PR TITLE
Added linux version checking in flowlabel.h

### DIFF
--- a/src/flowlabel.h
+++ b/src/flowlabel.h
@@ -29,15 +29,18 @@
 
 
 #include <linux/types.h>
+#include <linux/version.h>
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0)
+#include <linux/in6.h>
+#else
+#ifndef __ANDROID__
 /*
    It is just a stripped copy of the Linux kernel header "linux/in6.h"
    "Flow label" things are still not defined in "netinet/in*.h" headers,
    but we cannot use "linux/in6.h" immediately because it currently
-   conflicts with "netinet/in.h" .
+   conflicts with "netinet/in.h" . (in kernel versions < 3.7.0)
 */
-
-#ifndef __ANDROID__
 struct in6_flowlabel_req
 {
     struct in6_addr flr_dst;
@@ -68,6 +71,7 @@ struct in6_flowlabel_req
 #define IPV6_FLOWINFO_FLOWLABEL 0x000fffff
 #define IPV6_FLOWINFO_PRIORITY  0x0ff00000
 
+#endif
 #define IPV6_FLOWLABEL_MGR      32
 #define IPV6_FLOWINFO_SEND      33
 


### PR DESCRIPTION
The current version of src/flowlabel.h is just a copy of linux/in6.h because it conflicts with "netinet/in.h".
But after linux >=v3.7 (adding uapi) this conflict was removed and this copy became useless.
I've added a Linux version check.
This fix is very useful for eg mp-tcp linux where iperf can build successfully.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

