### PR TITLE
suppress -Wunused-variable when HAVE_SENDFILE is undefined

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -445,8 +445,8 @@ has_sendfile(void)
 int
 Nsendfile(int fromfd, int tofd, const char *buf, size_t count)
 {
-    off_t offset;
 #if defined(HAVE_SENDFILE)
+    off_t offset;
 #if defined(__FreeBSD__) || (defined(__APPLE__) && defined(__MACH__) && defined(MAC_OS_X_VERSION_10_6))
     off_t sent;
 #endif


### PR DESCRIPTION
Suppress following compiler warning when there is no HAVE_SENDFILE
support:

```
  /lib/iperf3/src/net.c: In function 'Nsendfile':
  /lib/iperf3/src/net.c:449:11: warning: unused variable 'offset' [-Wunused-variable]
    449 |     off_t offset;
        |           ^~~~~~
```