### PR TITLE
Fix help output for some compilers

### DIFF
--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -106,7 +106,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -A, --affinity n/n,m      set CPU affinity\n"
 #endif /* HAVE_CPU_AFFINITY */
 #if defined(HAVE_SO_BINDTODEVICE)
-                           "  -B, --bind <host>[%<dev>] bind to the interface associated with the address <host>\n"
+                           "  -B, --bind <host>[%%<dev>] bind to the interface associated with the address <host>\n"
                            "                            (optional <dev> equivalent to `--bind-dev <dev>`)\n"
                            "  --bind-dev <dev>          bind to the network interface with SO_BINDTODEVICE\n"
 #else /* HAVE_SO_BINDTODEVICE */
@@ -145,7 +145,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "                            and client during the authentication process\n"
 #endif //HAVE_SSL
                            "Client specific:\n"
-                           "  -c, --client <host>[%<dev>] run in client mode, connecting to <host>\n"
+                           "  -c, --client <host>[%%<dev>] run in client mode, connecting to <host>\n"
                            "                              (option <dev> equivalent to `--bind-dev <dev>`)\n"
 #if defined(HAVE_SCTP_H)
                            "  --sctp                    use SCTP rather than TCP\n"


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
`master`

* Issues fixed (if any):
#1329

* Brief description of code changes (suitable for use as a commit message):
```
Use the "%%" format specifier in usage_longstr when the desired output
is '%'.

Using the single '%' causes the '--help' output to be empty or condensed
on some versions of gcc.
```