### PR TITLE
Add set iperf callback functions.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -791,6 +791,30 @@ iperf_set_test_mss(struct iperf_test *ipt, int mss)
     ipt->settings->mss = mss;
 }
 
+void 
+iperf_set_on_new_stream_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_new_stream = callback;
+}
+
+void 
+iperf_set_on_test_start_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_test_start = callback;
+}
+
+void 
+iperf_set_on_test_connect_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_connect = callback;
+}
+
+void 
+iperf_set_on_test_finish_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_test_finish = callback;
+}
+
 /********************** Get/set test protocol structure ***********************/
 
 struct protocol *

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -195,6 +195,10 @@ void    iperf_set_test_no_delay( struct iperf_test* ipt, int no_delay);
 void    iperf_set_dont_fragment( struct iperf_test* ipt, int dont_fragment );
 void    iperf_set_test_congestion_control(struct iperf_test* ipt, char* cc);
 void    iperf_set_test_mss(struct iperf_test* ipt, int mss);
+void    iperf_set_on_new_stream_callback(struct iperf_test* ipt, void (*callback)());
+void    iperf_set_on_test_start_callback(struct iperf_test* ipt, void (*callback)());
+void    iperf_set_on_test_connect_callback(struct iperf_test* ipt, void (*callback)());
+void    iperf_set_on_test_finish_callback(struct iperf_test* ipt, void (*callback)());
 
 #if defined(HAVE_SSL)
 void    iperf_set_test_client_username(struct iperf_test *ipt, const char *client_username);


### PR DESCRIPTION
Signed-off-by: Dee.H.Y <dongfengweixiao@hotmail.com>

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master
* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):
when call iperf as library, caller can set callback functions:

``` c

void
my_iperf_on_new_stream(struct iperf_stream *sp) {
    iperf_on_new_stream(sp);
    printf("on_new_stream...");
}

void
my_iperf_on_connect(struct iperf_test *test) {
    iperf_on_connect(test);
    printf("on_connect...");
}

void
my_iperf_on_test_finish(struct iperf_test *test) {
    iperf_on_test_finish(test);
    printf("on_test_finish...");
}

void
my_iperf_on_test_start(struct iperf_test *test) {
    iperf_on_test_start(test);
    printf("on_test_start...");
}

iperf_set_on_new_stream_callback(test, my_iperf_on_new_stream);
iperf_set_on_test_connect_callback(test, my_iperf_on_connect);
iperf_set_on_test_finish_callback(test, my_iperf_on_test_finish);
iperf_set_on_test_start_callback(test, my_iperf_on_test_start);
```
