### PR TITLE
Add one function callback for recevie output

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -371,6 +371,7 @@ struct iperf_test
     void      (*on_test_start)(struct iperf_test *);
     void      (*on_connect)(struct iperf_test *);
     void      (*on_test_finish)(struct iperf_test *);
+    void      (*on_new_output)(const char* format, ...);
 
     /* cJSON handles for use when in -J mode */\
     cJSON *json_top;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -791,6 +791,12 @@ iperf_set_test_mss(struct iperf_test *ipt, int mss)
     ipt->settings->mss = mss;
 }
 
+void
+iperf_set_on_new_output_callback(struct iperf_test* ipt, void (*callback)())
+{
+    ipt->on_new_output = callback;
+}
+
 /********************** Get/set test protocol structure ***********************/
 
 struct protocol *
@@ -945,6 +951,10 @@ iperf_on_test_finish(struct iperf_test *test)
 {
 }
 
+void
+iperf_on_new_output(const char* format, ...)
+{
+}
 
 /******************************************************************************/
 
@@ -2855,6 +2865,7 @@ iperf_defaults(struct iperf_test *testp)
     testp->on_test_start = iperf_on_test_start;
     testp->on_connect = iperf_on_connect;
     testp->on_test_finish = iperf_on_test_finish;
+    testp->on_new_output = iperf_on_new_output;
 
     TAILQ_INIT(&testp->server_output_list);
 
@@ -4796,6 +4807,8 @@ iperf_printf(struct iperf_test *test, const char* format, ...)
                 return r0;
             r += r0;
         }
+    if (test->on_new_output)
+        test->on_new_output("%s", linebuffer);
 	fprintf(test->outfile, "%s", linebuffer);
 
 	if (test->role == 's' && iperf_get_test_get_server_output(test)) {

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -312,11 +312,13 @@ void iperf_reset_stats(struct iperf_test * test);
 
 struct protocol *get_protocol(struct iperf_test *, int);
 int set_protocol(struct iperf_test *, int);
+void iperf_set_on_new_output_callback(struct iperf_test* ipt, void (*callback)());
 
 void iperf_on_new_stream(struct iperf_stream *);
 void iperf_on_test_start(struct iperf_test *);
 void iperf_on_connect(struct iperf_test *);
 void iperf_on_test_finish(struct iperf_test *);
+void iperf_on_new_output(const char* format, ...);
 
 extern jmp_buf env;
 


### PR DESCRIPTION
Signed-off-by: Dee.H.Y <dongfengweixiao@hotmail.com>

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master
* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):
when call iperf as library, caller can handle output :

``` c
void
my_iperf_on_new_output(const char* format, const char* str) {
    LOGD(format, str);
}

iperf_set_on_new_output_callback(test, my_iperf_on_new_output);
```
