### PR TITLE
Correct UDP link capability in JSON and CPU Utlization for Server Text output

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4735,13 +4735,12 @@ iperf_print_results(struct iperf_test *test)
         }
         else {
             if (test->verbose) {
-                if (stream_must_be_sender) {
-                    if (test->bidirectional) {
-                        iperf_printf(test, report_cpu, report_local, stream_must_be_sender?report_sender:report_receiver, test->cpu_util[0], test->cpu_util[1], test->cpu_util[2], report_remote, stream_must_be_sender?report_receiver:report_sender, test->remote_cpu_util[0], test->remote_cpu_util[1], test->remote_cpu_util[2]);
-                        iperf_printf(test, report_cpu, report_local, !stream_must_be_sender?report_sender:report_receiver, test->cpu_util[0], test->cpu_util[1], test->cpu_util[2], report_remote, !stream_must_be_sender?report_receiver:report_sender, test->remote_cpu_util[0], test->remote_cpu_util[1], test->remote_cpu_util[2]);
-                    } else
-                        iperf_printf(test, report_cpu, report_local, stream_must_be_sender?report_sender:report_receiver, test->cpu_util[0], test->cpu_util[1], test->cpu_util[2], report_remote, stream_must_be_sender?report_receiver:report_sender, test->remote_cpu_util[0], test->remote_cpu_util[1], test->remote_cpu_util[2]);
-                }
+                if (test->bidirectional) {
+                    iperf_printf(test, report_cpu, report_local, stream_must_be_sender?report_sender:report_receiver, test->cpu_util[0], test->cpu_util[1], test->cpu_util[2], report_remote, stream_must_be_sender?report_receiver:report_sender, test->remote_cpu_util[0], test->remote_cpu_util[1], test->remote_cpu_util[2]);
+                    iperf_printf(test, report_cpu, report_local, !stream_must_be_sender?report_sender:report_receiver, test->cpu_util[0], test->cpu_util[1], test->cpu_util[2], report_remote, !stream_must_be_sender?report_receiver:report_sender, test->remote_cpu_util[0], test->remote_cpu_util[1], test->remote_cpu_util[2]);
+                } else
+                    iperf_printf(test, report_cpu, report_local, stream_must_be_sender?report_sender:report_receiver, test->cpu_util[0], test->cpu_util[1], test->cpu_util[2], report_remote, stream_must_be_sender?report_receiver:report_sender, test->remote_cpu_util[0], test->remote_cpu_util[1], test->remote_cpu_util[2]);
+
                 if (test->protocol->id == Ptcp) {
                     char *snd_congestion = NULL, *rcv_congestion = NULL;
                     if (stream_must_be_sender) {

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4272,12 +4272,12 @@ iperf_print_results(struct iperf_test *test)
     }
 
     /*
-     * We must to sum streams separately.
-     * For bidirectional mode we must to display
+     * We must sum streams separately.
+     * For bidirectional mode we must display
      * information about sender and receiver streams.
      * For client side we must handle sender streams
      * firstly and receiver streams for server side.
-     * The following design allows us to do this.
+     * The following design allows us to do that.
      */
 
     if (test->mode == BIDIRECTIONAL) {
@@ -4312,6 +4312,7 @@ iperf_print_results(struct iperf_test *test)
         double sender_time = 0.0, receiver_time = 0.0;
         struct iperf_time temp_time;
         double bandwidth;
+        iperf_size_t bytes_count;
 
         char mbuf[UNIT_LEN];
         int stream_must_be_sender = current_mode * current_mode;
@@ -4459,7 +4460,7 @@ iperf_print_results(struct iperf_test *test)
                          * information for both the sender and receiver
                          * side.
                          *
-                         * The JSON format as currently defined only includes one
+                         * The JSON format as currently defined to only include one
                          * value for the number of packets.  We usually want that
                          * to be the sender's value (how many packets were sent
                          * by the sender).  However this value might not be
@@ -4469,8 +4470,19 @@ iperf_print_results(struct iperf_test *test)
                          * is the case, then use the receiver's count of packets
                          * instead.
                          */
+                        // Choose sum of sent/received bytes count based on mode
                         int64_t packet_count = sender_packet_count ? sender_packet_count : receiver_packet_count;
-                        cJSON_AddItemToObject(json_summary_stream, "udp", iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  out_of_order: %d sender: %b", (int64_t) sp->socket, (double) start_time, (double) sender_time, (double) sender_time, (int64_t) bytes_sent, bandwidth * 8, (double) sp->jitter * 1000.0, (int64_t) (sp->cnt_error - sp->omitted_cnt_error), (int64_t) (packet_count - sp->omitted_packet_count), (double) lost_percent, (int64_t) (sp->outoforder_packets - sp->omitted_outoforder_packets), stream_must_be_sender));
+                        if (test->mode == SENDER)
+                            bytes_count = bytes_sent;
+                        else if (test->mode == RECEIVER)
+                            bytes_count = bytes_received;
+                        else { // BIDIRECTIONAL
+                            if (stream_must_be_sender)
+                                bytes_count = bytes_sent;
+                            else
+                                bytes_count = bytes_received;
+                        }
+                        cJSON_AddItemToObject(json_summary_stream, "udp", iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  out_of_order: %d sender: %b", (int64_t) sp->socket, (double) start_time, (double) sender_time, (double) sender_time, (int64_t) bytes_count, bandwidth * 8, (double) sp->jitter * 1000.0, (int64_t) (sp->cnt_error - sp->omitted_cnt_error), (int64_t) (packet_count - sp->omitted_packet_count), (double) lost_percent, (int64_t) (sp->outoforder_packets - sp->omitted_outoforder_packets), stream_must_be_sender));
                     }
                     else {
                         /*
@@ -4568,7 +4580,7 @@ iperf_print_results(struct iperf_test *test)
                 }
             }
         }
-        }
+        } // End of if at least one steram
 
         if (test->num_streams > 1 || test->json_output) {
             /*
@@ -4662,7 +4674,8 @@ iperf_print_results(struct iperf_test *test)
                      * structure is not recommended due to
                      * ambiguities between the sender and receiver.
                      */
-                    cJSON_AddItemToObject(test->json_end, sum_name, iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f sender: %b", (double) start_time, (double) receiver_time, (double) receiver_time, (int64_t) total_sent, bandwidth * 8, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) total_packets, (double) lost_percent, stream_must_be_sender));
+                    bytes_count = stream_must_be_sender ? total_sent : total_received;
+                    cJSON_AddItemToObject(test->json_end, sum_name, iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f sender: %b", (double) start_time, (double) receiver_time, (double) receiver_time, (int64_t) bytes_count, bandwidth * 8, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) total_packets, (double) lost_percent, stream_must_be_sender));
                     
                     double sent_bandwidth = sender_time > 0 ? ((double) total_sent * 8 / sender_time) : 0.0;
                     double recv_bandwidth = receiver_time > 0 ? ((double) total_received * 8 / receiver_time) : 0.0;
@@ -4764,7 +4777,7 @@ iperf_print_results(struct iperf_test *test)
                 }
             }
         }
-    }
+    } // Loop between lower and upper modes
 
     /* Set real sender_has_retransmits for current side */
     if (test->mode == BIDIRECTIONAL)


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
* #754
* #1552

* Brief description of code changes (suitable for use as a commit message):

Suggested fix for issue #754 - correct UDP JSON output.  The main issue was on the server's side since the call to `reporter_callback()` was done prior to results exchange with the client.  In addition, some enhancements were done to the reported received and sent bytes count.

**Update - 26Jul2023:**
Added a suggested fix to #1552 since it also requires the same move of the call to `reporter_callback()`.  Since this is a minor and related change, I believe that it is o.k. to handle both fixes together.
