### PR TITLE
Prevent -k / -n when combined with -R from leaking into future tests.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2119,10 +2119,8 @@ send_parameters(struct iperf_test *test)
 	if (test->server_affinity != -1)
 	    cJSON_AddNumberToObject(j, "server_affinity", test->server_affinity);
 	cJSON_AddNumberToObject(j, "time", test->duration);
-	if (test->settings->bytes)
-	    cJSON_AddNumberToObject(j, "num", test->settings->bytes);
-	if (test->settings->blocks)
-	    cJSON_AddNumberToObject(j, "blockcount", test->settings->blocks);
+        cJSON_AddNumberToObject(j, "num", test->settings->bytes);
+        cJSON_AddNumberToObject(j, "blockcount", test->settings->blocks);
 	if (test->settings->mss)
 	    cJSON_AddNumberToObject(j, "MSS", test->settings->mss);
 	if (test->no_delay)
@@ -2232,8 +2230,10 @@ get_parameters(struct iperf_test *test)
 	    test->server_affinity = j_p->valueint;
 	if ((j_p = cJSON_GetObjectItem(j, "time")) != NULL)
 	    test->duration = j_p->valueint;
+        test->settings->bytes = 0;
 	if ((j_p = cJSON_GetObjectItem(j, "num")) != NULL)
 	    test->settings->bytes = j_p->valueint;
+        test->settings->blocks = 0;
 	if ((j_p = cJSON_GetObjectItem(j, "blockcount")) != NULL)
 	    test->settings->blocks = j_p->valueint;
 	if ((j_p = cJSON_GetObjectItem(j, "MSS")) != NULL)


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #1363

* Brief description of code changes (suitable for use as a commit message):

The problem was that the -k / -n parameters would get sent to the
server for a reverse tests, but never cleared for future reverse tests,
because these parameters were only sent from the client if they were
non-zero.
.
This is fixed in two ways as a belt-and-suspenders approach.

1. The server always clears the variables used for -k / -n when
receiving parameters, so if the client doesn't send them, they
get cleared (set to zero) anyway.

2. The client sends values for -k / -n even if they're zero. Sending
zero values doesn't hurt anything (except for wasting a few bytes),
and it makes this use case work even for servers that don't have
the fix in item 1 above.
