### PR TITLE
Corrected binding where the --bind <host>%<dev> syntax is used.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1304,8 +1304,8 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 if (iperf_parse_hostname(test, optarg, &p, &p1)) {
 #if defined(HAVE_SO_BINDTODEVICE)
                     /* Get rid of the hostname we saved earlier. */
-                    free(iperf_get_test_server_hostname(test));
-                    iperf_set_test_server_hostname(test, p);
+                    free(iperf_get_test_bind_address(test));
+                    iperf_set_test_bind_address(test, p);
                     iperf_set_test_bind_dev(test, p1);
 #else /* HAVE_SO_BINDTODEVICE */
                     i_errno = IEBINDDEVNOSUPPORT;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
```
all (as far as I know)
```

* Issues fixed (if any):
```
Corrected binding where the --bind <host>%<dev> syntax is used.
Binding can use --bind and --bind-dev or all together using --bind <host>%<dev>.
There was a bug in the code whereby the successfully split host and dev were not
being used correctly to setup the socket.
```

* Brief description of code changes (suitable for use as a commit message):
```
Corrected binding where the --bind <host>%<dev> syntax is used.
```