### PR TITLE
Don’t misprint TCP info values as negative numbers

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -102,7 +102,6 @@ struct iperf_interval_results
     char *tcpInfo;
 #endif
     int interval_retrans;
-    int interval_sacks;
     int snd_cwnd;
     int snd_wnd;
     TAILQ_ENTRY(iperf_interval_results) irlistentries;
@@ -121,8 +120,6 @@ struct iperf_stream_result
     iperf_size_t bytes_sent_omit;
     int stream_prev_total_retrans;
     int stream_retrans;
-    int stream_prev_total_sacks;
-    int stream_sacks;
     int stream_max_rtt;
     int stream_min_rtt;
     int stream_sum_rtt;

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -101,14 +101,14 @@ struct iperf_interval_results
     /* Just placeholders, never accessed. */
     char *tcpInfo;
 #endif
-    int interval_retrans;
-    int snd_cwnd;
-    int snd_wnd;
+    long interval_retrans;
+    long snd_cwnd;
+    long snd_wnd;
     TAILQ_ENTRY(iperf_interval_results) irlistentries;
     void     *custom_data;
-    int rtt;
-    int rttvar;
-    int pmtu;
+    long rtt;
+    long rttvar;
+    long pmtu;
 };
 
 struct iperf_stream_result
@@ -118,14 +118,14 @@ struct iperf_stream_result
     iperf_size_t bytes_received_this_interval;
     iperf_size_t bytes_sent_this_interval;
     iperf_size_t bytes_sent_omit;
-    int stream_prev_total_retrans;
-    int stream_retrans;
-    int stream_max_rtt;
-    int stream_min_rtt;
-    int stream_sum_rtt;
+    long stream_prev_total_retrans;
+    long stream_retrans;
+    long stream_max_rtt;
+    long stream_min_rtt;
+    long stream_sum_rtt;
     int stream_count_rtt;
-    int stream_max_snd_cwnd;
-    int stream_max_snd_wnd;
+    long stream_max_snd_cwnd;
+    long stream_max_snd_wnd;
     struct iperf_time start_time;
     struct iperf_time end_time;
     struct iperf_time start_time_fixed;

--- a/src/tcp_info.c
+++ b/src/tcp_info.c
@@ -133,11 +133,11 @@ long
 get_snd_cwnd(struct iperf_interval_results *irp)
 {
 #if defined(linux) && defined(TCP_MD5SIG)
-    return irp->tcpInfo.tcpi_snd_cwnd * irp->tcpInfo.tcpi_snd_mss;
+    return (long)irp->tcpInfo.tcpi_snd_cwnd * irp->tcpInfo.tcpi_snd_mss;
 #elif defined(__FreeBSD__) && __FreeBSD_version >= 600000
     return irp->tcpInfo.tcpi_snd_cwnd;
 #elif defined(__NetBSD__) && defined(TCP_INFO)
-    return irp->tcpInfo.tcpi_snd_cwnd * irp->tcpInfo.tcpi_snd_mss;
+    return (long)irp->tcpInfo.tcpi_snd_cwnd * irp->tcpInfo.tcpi_snd_mss;
 #else
     return -1;
 #endif
@@ -157,7 +157,7 @@ get_snd_wnd(struct iperf_interval_results *irp)
 #elif defined(__FreeBSD__) && __FreeBSD_version >= 600000
     return irp->tcpInfo.tcpi_snd_wnd;
 #elif defined(__NetBSD__) && defined(TCP_INFO)
-    return irp->tcpInfo.tcpi_snd_wnd * irp->tcpInfo.tcpi_snd_mss;
+    return (long)irp->tcpInfo.tcpi_snd_wnd * irp->tcpInfo.tcpi_snd_mss;
 #else
     return -1;
 #endif


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master
* Issues fixed (if any):
* Brief description of code changes (suitable for use as a commit message):

Hello there,

this PR works around some TCP info values _occasionally_ being misprinted as negative numbers, mainly `snd_cwnd`:
```
[ ID] Interval           Transfer     Bandwidth       Retr  Cwnd
[  4]   0.00-1.00   sec  10.5 GBytes  90.1 Gbits/sec    0   -65483.00 Bytes       
```

Previously, values like `snd_(c)wnd` were stored as int in `struct iperf_interval_results`, while being handled as long before and double after. This could lead to overflows and values being wrongly printed as negative values, when e.g. the product of `snd_cwnd` and `tcpi_snd_mss` in `get_snd_cwnd()` resulted in a large return value that was squeezed into an int.

In practice, I observed the negative numbers only with CWND. But changed the type of all similarly-handled values (coming from similar `get_*()` functions) in  `struct iperf_interval_results` for consistency.

This change is still not without issues. Ideally, the products of two uint32_ts in `get_snd_cwnd()` would be returned as a uint64_t. But that would make -1 unavailable as a placeholder for missing values.