### PR TITLE
Do not count UDP messages that were not sent

### DIFF
--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -250,8 +250,15 @@ iperf_udp_send(struct iperf_stream *sp)
 
     r = Nwrite(sp->socket, sp->buffer, size, Pudp);
 
-    if (r < 0)
-	return r;
+    if (r <= 0) {
+        --sp->packet_count;     /* Don't count messages that no data was sent from them.
+                                 * Allows "resending" a massage with the same numbering */
+        if (r < 0) {
+            if (r == NET_SOFTERROR && sp->test->debug_level >= DEBUG_LEVEL_INFO)
+                printf("UDP send failed on NET_SOFTERROR. errno=%s\n", strerror(errno));
+            return r;
+        }
+    }
 
     sp->result->bytes_sent += r;
     sp->result->bytes_sent_this_interval += r;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
#1367

* Brief description of code changes (suitable for use as a commit message):

When sending a UDP packet fails, do not increase the packet count.  That should improve the statistics, as the next packet will be sent with the same number - practically retry of sending the failed packet instead of sending a new packet.  Therefore, the client will not count the "retry" as new packet, and more important, the server will not consider the packet that was not sent as a lots packet.

In addition, added debug message in case of `NET_SOFTERROR` when sending UDP messages, to help debugging.