### PR TITLE
Remove potentially objectionable language from ltmain.sh

### DIFF
--- a/config/ltmain.sh
+++ b/config/ltmain.sh
@@ -143,7 +143,7 @@ nl='
 '
 IFS="$sp	$nl"
 
-# There are apparently some retarded systems that use ';' as a PATH separator!
+# There are apparently some systems that use ';' as a PATH separator!
 if test "${PATH_SEPARATOR+set}" != set; then
   PATH_SEPARATOR=:
   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
@@ -2688,7 +2688,6 @@ libtool_validate_options ()
         && test yes != "$build_old_libs" \
         && func_fatal_configuration "not configured to build any kind of library"
 
-      # Darwin sucks
       eval std_shrext=\"$shrext_cmds\"
 
       # Only execute mode is allowed to have -dlopen flags.


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
Many companies have policies against some language used in code comments. I've removed language that may inhibit the adoption of this fantastic project. Feel free to apply or not...

* Brief description of code changes (suitable for use as a commit message):
Removed language that may inhibit the adoption of this fantastic project.
