### PR TITLE
Revert a small part of PR#1369 to fix an output glitch.

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -208,7 +208,6 @@ iperf_handle_message_server(struct iperf_test *test)
                 FD_CLR(sp->socket, &test->read_set);
                 FD_CLR(sp->socket, &test->write_set);
                 close(sp->socket);
-                sp->socket = -1;
             }
             test->reporter_callback(test);
 	    if (iperf_set_send_state(test, EXCHANGE_RESULTS) != 0)
@@ -239,7 +238,6 @@ iperf_handle_message_server(struct iperf_test *test)
                 FD_CLR(sp->socket, &test->read_set);
                 FD_CLR(sp->socket, &test->write_set);
                 close(sp->socket);
-                sp->socket = -1;
             }
             test->state = IPERF_DONE;
             break;
@@ -392,7 +390,6 @@ cleanup_server(struct iperf_test *test)
             FD_CLR(sp->socket, &test->read_set);
             FD_CLR(sp->socket, &test->write_set);
             close(sp->socket);
-            sp->socket = -1;
 	}
     }
 


### PR DESCRIPTION
The original change overwrote closed file descriptors with -1 in the stream records to avoid them being used again, however there were some cases in which the file descriptor numbers were needed in output. This short-term fix reverts just that part of the change to restore the output behavior.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): No issue filed, but related to PR #1369 

* Brief description of code changes (suitable for use as a commit message):

