### PR TITLE
Print the shorter usage hint on argument error

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1572,7 +1572,8 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 		usage_long(stdout);
 		exit(0);
             default:
-                usage_long(stderr);
+                fprintf(stderr, "\n");
+                usage();
                 exit(1);
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -101,7 +101,7 @@ main(int argc, char **argv)
     if (iperf_parse_arguments(test, argc, argv) < 0) {
         iperf_err(test, "parameter error - %s", iperf_strerror(i_errno));
         fprintf(stderr, "\n");
-        usage_long(stdout);
+        usage();
         exit(1);
     }
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master
* Issues fixed (if any):
* Brief description of code changes (suitable for use as a commit message):

Hi there,

in my iperf3 usage I found it a bit unhandy that the whole, long help text is printed when there is an error in the given arguments. I changed the error handling here to only print the short usage hint on such an error. I’m happy about feedback whether this change is welcome.

Citing my commit message below for more reasoning:

When an argument error is printed it is often the result of a simple typo. A user familiar with iperf3 does not need the whole help text to figure out how to fix the command-line. A brief pointer to the erroneous argument is sufficient.

Until now, with the *long* help text printed after an argument error, a user often needs to scroll up to find the message about the erroneous argument.

Another user not yet familiar with iperf3 will still be informed how to access the long help text---or might already have it opened on the side, anyway.