### PR TITLE
Update for cjson for compile fix

### DIFF
--- a/src/cjson.c
+++ b/src/cjson.c
@@ -381,7 +381,7 @@ loop_end:
     }
     else
     {
-        item->valueint = (int)number;
+        item->valueint = (int64_t)number;
     }
 
     item->type = cJSON_Number;
@@ -403,7 +403,7 @@ CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number)
     }
     else
     {
-        object->valueint = (int)number;
+        object->valueint = (int64_t)number;
     }
 
     return object->valuedouble = number;
@@ -466,7 +466,7 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
 
     if (needed > LLONG_MAX)
     {
-        /* sizes bigger than INT_MAX are currently not supported */
+        /* sizes bigger than LLONG_MAX are currently not supported */
         return NULL;
     }
 
@@ -574,10 +574,10 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     {
         length = sprintf((char*)number_buffer, "null");
     }
-	else if(d == (double)item->valueint)
-	{
-		length = sprintf((char*)number_buffer, "%ld", item->valueint);
-	}
+    else if(d == (double)item->valueint)
+    {
+        length = sprintf((char*)number_buffer, "%ld", item->valueint);
+    }
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
@@ -2457,7 +2457,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
         }
         else
         {
-            item->valueint = (int)num;
+            item->valueint = (int64_t)num;
         }
     }
 

--- a/src/cjson.c
+++ b/src/cjson.c
@@ -90,6 +90,18 @@
 #endif
 #endif
 
+#if defined(HAVE_INTTYPES_H)
+# include <inttypes.h>
+#else
+# ifndef PRIu64
+#  if sizeof(long) == 8
+#   define PRIu64		"lu"
+#  else
+#   define PRIu64		"llu"
+#  endif
+# endif
+#endif
+
 typedef struct {
     const unsigned char *json;
     size_t position;
@@ -576,7 +588,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     }
     else if(d == (double)item->valueint)
     {
-        length = sprintf((char*)number_buffer, "%ld", item->valueint);
+        length = sprintf((char*)number_buffer, "%" PRIu64, item->valueint);
     }
     else
     {

--- a/src/cjson.c
+++ b/src/cjson.c
@@ -37,6 +37,7 @@
 #pragma warning (disable : 4001)
 #endif
 
+#include "iperf_config.h"
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
@@ -61,7 +62,6 @@
 #endif
 
 #include "cjson.h"
-#include "iperf_config.h"
 
 /* define our own boolean type */
 #ifdef true
@@ -464,9 +464,9 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
         return NULL;
     }
 
-    if (needed > LLONG_MAX)
+    if (needed > SIZE_MAX)
     {
-        /* sizes bigger than LLONG_MAX are currently not supported */
+        /* sizes bigger than SIZE_MAX are currently not supported */
         return NULL;
     }
 
@@ -481,12 +481,12 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
     }
 
     /* calculate new buffer size */
-    if (needed > (LLONG_MAX / 2))
+    if (needed > (SIZE_MAX / 2))
     {
-        /* overflow of int, use LLONG_MAX if possible */
-        if (needed <= LLONG_MAX)
+        /* overflow of int, use SIZE_MAX if possible */
+        if (needed <= SIZE_MAX)
         {
-            newsize = LLONG_MAX;
+            newsize = SIZE_MAX;
         }
         else
         {

--- a/src/cjson.h
+++ b/src/cjson.h
@@ -23,6 +23,10 @@
 #ifndef cJSON__h
 #define cJSON__h
 
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* master

* Issues fixed (if any):
* Potentially solves a compile issue for certain users for the new cJSON code


* Brief description of code changes (suitable for use as a commit message):
* Updated to look more like old cjson file with a stdint include and int64_t's instead of ints

