### PR TITLE
Fix crash when server mode with --logfile and --json

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -828,7 +828,6 @@ iperf_run_server(struct iperf_test *test)
 	}
     }
 
-    cleanup_server(test);
 
     if (test->json_output) {
 	if (iperf_json_finish(test) < 0)
@@ -836,6 +835,7 @@ iperf_run_server(struct iperf_test *test)
     }
 
     iflush(test);
+    cleanup_server(test);
 
     if (test->server_affinity != -1)
 	if (iperf_clearaffinity(test) != 0)


### PR DESCRIPTION
as tile
#1392 

The reason : log file fd has closed by cleanup_server(), but write it later

