### PR TITLE
Cleanup endian handling on OpenBSD.

### DIFF
--- a/src/portable_endian.h
+++ b/src/portable_endian.h
@@ -20,18 +20,7 @@
 #elif defined(HAVE_SYS_ENDIAN_H)
 #	include <sys/endian.h>
 
-#	if defined(__OpenBSD__)
-
-#		define be16toh(x) betoh16(x)
-#		define le16toh(x) letoh16(x)
-
-#		define be32toh(x) betoh32(x)
-#		define le32toh(x) letoh32(x)
-
-#		define be64toh(x) betoh64(x)
-#		define le64toh(x) letoh64(x)
-
-#	elif defined(__sgi)
+#	if defined(__sgi)
 
 #		include <netinet/in.h>
 #		include <inttypes.h>


### PR DESCRIPTION
OpenBSD has had the endian.h header for 8+ years.