### PR TITLE
fix exit value of iperf when using json format

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -704,7 +704,6 @@ iperf_run_client(struct iperf_test * test)
     return 0;
 
   cleanup_and_fail:
-    cleanup_and_fail:
     iperf_client_end(test);
     iflush(test);
     return -1;

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -704,15 +704,8 @@ iperf_run_client(struct iperf_test * test)
     return 0;
 
   cleanup_and_fail:
+    cleanup_and_fail:
     iperf_client_end(test);
-    if (test->json_output) {
-        cJSON_AddStringToObject(test->json_top, "error", iperf_strerror(i_errno));
-        iperf_json_finish(test);
-        iflush(test);
-        // Return 0 and not -1 since all terminating function were done here.
-        // Also prevents error message logging outside the already closed JSON output.
-        return 0;
-    }
     iflush(test);
     return -1;
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: 
since iperf3.11 & also master

* Issues fixed (if any):
Have a look at [Issue 1405](https://github.com/esnet/iperf/issues/1405)

* Brief description of code changes (suitable for use as a commit message):
change the cleanup_and_fail in iperf_client_api.c to

```
cleanup_and_fail:
    iperf_client_end(test);
    iflush(test);
    return -1;
```
