### PR TITLE
Address UDP connect message endian issue

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -430,9 +430,10 @@ struct iperf_test
 extern int gerror; /* error value from getaddrinfo(3), for use in internal error handling */
 
 /* UDP "connect" message and reply (textual value for Wireshark, etc. readability - legacy was numeric) */
-#define UDP_CONNECT_MSG 0x36373839          // "6789" - legacy value was 123456789
-#define UDP_CONNECT_REPLY 0x39383736        // "9876" - legacy value was 987654321
-#define LEGACY_UDP_CONNECT_REPLY 987654321  // Old servers may still reply with the legacy value
+#define UDP_CONNECT_MSG 0x36373839                 // "6789" - legacy value was 123456789
+#define UDP_CONNECT_REPLY 0x39383736               // "9876" - legacy value was 987654321
+#define LEGACY_UDP_CONNECT_REPLY 987654321         // Old servers may still reply with legacy value
+#define LEGACY_UDP_CONNECT_REPLY_ENDIAN 2976439866 // Old servers may still reply with legacy value
 
 /* In Reverse mode, maximum number of packets to wait for "accept" response - to handle out of order packets */
 #define MAX_REVERSE_OUT_OF_ORDER_PACKETS 2

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -592,9 +592,9 @@ iperf_udp_connect(struct iperf_test *test)
             printf("Connect received for Socket %d, sz=%d, buf=%x, i=%d, max_len_wait_for_reply=%d\n", s, sz, buf, i, max_len_wait_for_reply);
         }
         i += sz;
-    } while (buf != UDP_CONNECT_REPLY && buf != LEGACY_UDP_CONNECT_REPLY && i < max_len_wait_for_reply);
+    } while (buf != UDP_CONNECT_REPLY && buf != LEGACY_UDP_CONNECT_REPLY && buf != UDP_CONNECT_MSG && buf != LEGACY_UDP_CONNECT_REPLY_ENDIAN && i < max_len_wait_for_reply);
 
-    if (buf != UDP_CONNECT_REPLY  && buf != LEGACY_UDP_CONNECT_REPLY) {
+    if (buf != UDP_CONNECT_REPLY && buf != LEGACY_UDP_CONNECT_REPLY && buf != UDP_CONNECT_MSG && buf != LEGACY_UDP_CONNECT_REPLY_ENDIAN) {
         i_errno = IESTREAMREAD;
         return -1;
     }


### PR DESCRIPTION
Accept big-endian and little-endian format for both legacy and new messages since the value is sent in host byte order.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any):
#1414

* Brief description of code changes (suitable for use as a commit message):
Accept UDP connect message replies in little-endian or big-endian order.
There was discussion and concern about accepting two values in the original pull request #1260, this makes that problem worse. This is a solution that allows mixed-endian and mixed-version operations if the client is updated.
