### PR TITLE
Allow setting of TOS/DHCP for reverse tests

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -297,6 +297,7 @@ struct iperf_test
     FILE     *outfile;
 
     int       ctrl_sck;
+    int       mapped_v4;
     int       listener;
     int       prot_listener;
 

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -153,6 +153,7 @@ int	iperf_get_test_connect_timeout( struct iperf_test* ipt );
 int	iperf_get_dont_fragment( struct iperf_test* ipt );
 char*   iperf_get_test_congestion_control(struct iperf_test* ipt);
 int iperf_get_test_mss(struct iperf_test* ipt);
+int     iperf_get_mapped_v4(struct iperf_test* ipt);
 
 /* Setter routines for some fields inside iperf_test. */
 void	iperf_set_verbose( struct iperf_test* ipt, int verbose );
@@ -195,6 +196,7 @@ void    iperf_set_test_no_delay( struct iperf_test* ipt, int no_delay);
 void    iperf_set_dont_fragment( struct iperf_test* ipt, int dont_fragment );
 void    iperf_set_test_congestion_control(struct iperf_test* ipt, char* cc);
 void    iperf_set_test_mss(struct iperf_test* ipt, int mss);
+void    iperf_set_mapped_v4(struct iperf_test* ipt, const int val);
 
 #if defined(HAVE_SSL)
 void    iperf_set_test_client_username(struct iperf_test *ipt, const char *client_username);
@@ -280,6 +282,12 @@ int       iperf_init_stream(struct iperf_stream *, struct iperf_test *);
  *
  */
 void      iperf_free_stream(struct iperf_stream * sp);
+
+/**
+ * iperf_common_sockopts -- init stream socket with common socket options
+ *
+ */
+int       iperf_common_sockopts(struct iperf_test *, int s);
 
 int has_tcpinfo(void);
 int has_tcpinfo_retransmits(void);

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -610,7 +610,11 @@ iperf_run_server(struct iperf_test *test)
 		    }
 
 		    /* apply other common socket options */
-		    iperf_common_sockopts(test, s);
+                    if (iperf_common_sockopts(test, s) < 0)
+                    {
+                        cleanup_server(test);
+                        return -1;
+                    }
 
                     if (!is_closed(s)) {
 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -609,6 +609,9 @@ iperf_run_server(struct iperf_test *test)
                         return -1;
 		    }
 
+		    /* apply other common socket options */
+		    iperf_common_sockopts(test, s);
+
                     if (!is_closed(s)) {
 
 #if defined(HAVE_TCP_USER_TIMEOUT)

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -545,6 +545,9 @@ iperf_tcp_connect(struct iperf_test *test)
 	}
     }
 
+    /* Set common socket options */
+    iperf_common_sockopts(test, s);
+
     if (connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen) < 0 && errno != EINPROGRESS) {
 	saved_errno = errno;
 	close(s);

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -555,6 +555,9 @@ iperf_udp_connect(struct iperf_test *test)
 	}
     }
 
+    /* Set common socket options */
+    iperf_common_sockopts(test, s);
+
 #ifdef SO_RCVTIMEO
     /* 30 sec timeout for a case when there is a network problem. */
     tv.tv_sec = 30;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* iperf master

* TOS is not set properly on mapped IPv6 addresses in reverse mode

* Add fix for setting TOS for mapped IPv6 addresses in reverse mode and error handling

