### PR TITLE
json_read checks read_set

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -101,7 +101,7 @@ static int diskfile_send(struct iperf_stream *sp);
 static int diskfile_recv(struct iperf_stream *sp);
 static int JSON_write(int fd, cJSON *json);
 static void print_interval_results(struct iperf_test *test, struct iperf_stream *sp, cJSON *json_interval_streams);
-static cJSON *JSON_read(int fd);
+static cJSON *JSON_read(int fd, struct iperf_test *test);
 
 
 /*************************** Print usage functions ****************************/
@@ -2232,7 +2232,7 @@ get_parameters(struct iperf_test *test)
     cJSON *j;
     cJSON *j_p;
 
-    j = JSON_read(test->ctrl_sck);
+    j = JSON_read(test->ctrl_sck, test);
     if (j == NULL) {
 	i_errno = IERECVPARAMS;
         r = -1;
@@ -2458,7 +2458,7 @@ get_results(struct iperf_test *test)
     int retransmits;
     struct iperf_stream *sp;
 
-    j = JSON_read(test->ctrl_sck);
+    j = JSON_read(test->ctrl_sck, test);
     if (j == NULL) {
 	i_errno = IERECVRESULTS;
         r = -1;
@@ -2619,12 +2619,24 @@ JSON_write(int fd, cJSON *json)
 /*************************************************************/
 
 static cJSON *
-JSON_read(int fd)
+JSON_read(int fd, struct iperf_test *test)
 {
     uint32_t hsize, nsize;
     char *str;
     cJSON *json = NULL;
     int rc;
+
+    /*
+    * Wait until test->ctrl_sck is ready to read
+    */
+    while (1)
+    {   
+        select(test->max_fd + 1, &test->read_set,  NULL, NULL, NULL);
+        if (FD_ISSET(fd, &test->read_set))
+            break;
+        else
+            FD_SET(test->ctrl_sck, &test->read_set);
+    }
 
     /*
      * Read a four-byte integer, which is the length of the JSON to follow.
@@ -2636,6 +2648,17 @@ JSON_read(int fd)
 	/* Allocate a buffer to hold the JSON */
 	str = (char *) calloc(sizeof(char), hsize+1);	/* +1 for trailing null */
 	if (str != NULL) {
+        /*
+        * Wait until test->ctrl_sck is ready to read
+        */
+        while (1)
+        {   
+            select(test->max_fd + 1, &test->read_set,  NULL, NULL, NULL);
+            if (FD_ISSET(fd, &test->read_set))
+                break;
+            else
+                FD_SET(test->ctrl_sck, &test->read_set);
+        }
 	    rc = Nread(fd, str, hsize, Ptcp);
 	    if (rc >= 0) {
 		/*


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: main

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

I observe one case where test->ctrl_sck is not ready to be read while JSON_read tries to invoke Nread.  JSON_read does not have retry mechanisms. So I add a select check for JSON_read. Please feel free to comment and discuss.

