### PR TITLE
a fix for A resource leak bug in function iperf_create_pidfile

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4611,8 +4611,8 @@ iperf_create_pidfile(struct iperf_test *test)
 	}
 	snprintf(buf, sizeof(buf), "%d", getpid()); /* no trailing newline */
 	if (write(fd, buf, strlen(buf)) < 0) {
-        (void)close(fd);
-	    return -1;
+		(void)close(fd);
+		return -1;
 	}
 	if (close(fd) < 0) {
 	    return -1;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4611,8 +4611,8 @@ iperf_create_pidfile(struct iperf_test *test)
 	}
 	snprintf(buf, sizeof(buf), "%d", getpid()); /* no trailing newline */
 	if (write(fd, buf, strlen(buf)) < 0) {
-		(void)close(fd);
-		return -1;
+	    (void)close(fd);
+	    return -1;
 	}
 	if (close(fd) < 0) {
 	    return -1;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4611,6 +4611,7 @@ iperf_create_pidfile(struct iperf_test *test)
 	}
 	snprintf(buf, sizeof(buf), "%d", getpid()); /* no trailing newline */
 	if (write(fd, buf, strlen(buf)) < 0) {
+        (void)close(fd);
 	    return -1;
 	}
 	if (close(fd) < 0) {


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: 3.11

* Issues fixed (if any):#1442

* Brief description of code changes (suitable for use as a commit message):
Add code "close(fd)" after "write(fd, buf, strlen(buf))" fails, and then return -1.
