### PR TITLE
Add getter for test bidirectional

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -225,6 +225,12 @@ iperf_get_test_reverse(struct iperf_test *ipt)
 }
 
 int
+iperf_get_test_bidirectional(struct iperf_test *ipt)
+{
+    return ipt->bidirectional;
+}
+
+int
 iperf_get_test_blksize(struct iperf_test *ipt)
 {
     return ipt->settings->blksize;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -118,6 +118,7 @@ int	iperf_get_test_omit( struct iperf_test* ipt );
 int	iperf_get_test_duration( struct iperf_test* ipt );
 char	iperf_get_test_role( struct iperf_test* ipt );
 int	iperf_get_test_reverse( struct iperf_test* ipt );
+int	iperf_get_test_bidirectional( struct iperf_test* ipt );
 int	iperf_get_test_blksize( struct iperf_test* ipt );
 FILE*	iperf_get_test_outfile( struct iperf_test* ipt );
 uint64_t iperf_get_test_rate( struct iperf_test* ipt );


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
`master`

* Issues fixed (if any):
I didn't add an issue but can. 

* Brief description of code changes (suitable for use as a commit message):
Adds a simple getter for bidirectional field of the test. Matches the pattern for all other getter functions and follows after reverse as it is laid out in the struct. 

The setter already exists.  
