### PR TITLE
Fix crash on rcv-timeout with JSON logfile

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3033,6 +3033,8 @@ iperf_reset_test(struct iperf_test *test)
     struct iperf_stream *sp;
     int i;
 
+    iperf_close_logfile(test);
+
     /* Free streams */
     while (!SLIST_EMPTY(&test->streams)) {
         sp = SLIST_FIRST(&test->streams);

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4681,7 +4681,8 @@ iperf_json_finish(struct iperf_test *test)
     cJSON_free(str);
     if (test->json_output_string == NULL)
         return -1;
-    fprintf(test->outfile, "%s\n", test->json_output_string);
+    if (test->outfile)
+        fprintf(test->outfile, "%s\n", test->json_output_string);
     iflush(test);
     cJSON_Delete(test->json_top);
     test->json_top = test->json_start = test->json_connected = test->json_intervals = test->json_server_output = test->json_end = NULL;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4681,8 +4681,7 @@ iperf_json_finish(struct iperf_test *test)
     cJSON_free(str);
     if (test->json_output_string == NULL)
         return -1;
-    if (test->outfile)
-        fprintf(test->outfile, "%s\n", test->json_output_string);
+    fprintf(test->outfile, "%s\n", test->json_output_string);
     iflush(test);
     cJSON_Delete(test->json_top);
     test->json_top = test->json_start = test->json_connected = test->json_intervals = test->json_server_output = test->json_end = NULL;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -390,6 +390,7 @@ cleanup_server(struct iperf_test *test)
             FD_CLR(sp->socket, &test->read_set);
             FD_CLR(sp->socket, &test->write_set);
             close(sp->socket);
+            sp->socket = -1;
 	}
     }
 
@@ -560,8 +561,8 @@ iperf_run_server(struct iperf_test *test)
                 else if (test->mode != SENDER && t_usecs > rcv_timeout_us) {
                     test->server_forced_no_msg_restarts_count += 1;
                     i_errno = IENOMSG;
-                    if (iperf_get_verbose(test))
-                        iperf_err(test, "Server restart (#%d) during active test due to idle data for receiving data",
+                    if (iperf_get_verbose(test) || test->debug_level > 0)
+                        iperf_err(test, "Server restart (#%d) during active test due to idle timeout for receiving data",
                                   test->server_forced_no_msg_restarts_count);
                     cleanup_server(test);
                     return -1;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -382,7 +382,6 @@ static void
 cleanup_server(struct iperf_test *test)
 {
     struct iperf_stream *sp;
-    iperf_close_logfile(test);
 
     /* Close open streams */
     SLIST_FOREACH(sp, &test->streams, streams) {
@@ -561,7 +560,7 @@ iperf_run_server(struct iperf_test *test)
                 else if (test->mode != SENDER && t_usecs > rcv_timeout_us) {
                     test->server_forced_no_msg_restarts_count += 1;
                     i_errno = IENOMSG;
-                    if (iperf_get_verbose(test) || test->debug_level > 0)
+                    if (iperf_get_verbose(test))
                         iperf_err(test, "Server restart (#%d) during active test due to idle timeout for receiving data",
                                   test->server_forced_no_msg_restarts_count);
                     cleanup_server(test);

--- a/src/main.c
+++ b/src/main.c
@@ -151,7 +151,7 @@ run(struct iperf_test *test)
             for (;;) {
 		int rc;
 		rc = iperf_run_server(test);
-                test->server_last_run_rc =rc;
+                test->server_last_run_rc = rc;
 		if (rc < 0) {
 		    iperf_err(test, "error - %s", iperf_strerror(i_errno));
                     if (test->json_output) {


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
* #1460

* Brief description of code changes (suitable for use as a commit message):

Prevent the segmentation fault when server fails and JSON output to a logfile was specified, by removing a redundant logfile close before the JSON output is written.

Also added minor/cosmetic changes for issues found during the evaluation.
