### PR TITLE
doc: Fix copy-and-paste error leading to wrong error message.

### DIFF
--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -459,7 +459,7 @@ iperf_strerror(int int_errno)
 	    snprintf(errstr, len, "unable to set IP Do-Not-Fragment flag");
             break;
         case IESETUSERTIMEOUT:
-            snprintf(errstr, len, "unable to set TCP/SCTP MSS");
+            snprintf(errstr, len, "unable to set TCP USER_TIMEOUT");
             perr = 1;
             break;
 	default:


### PR DESCRIPTION
Fixes #1441.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): #1441 

* Brief description of code changes (suitable for use as a commit message):

