### PR TITLE
fix endian type of udp connect / reply messages

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -67,6 +67,7 @@
 #include "queue.h"
 #include "cjson.h"
 #include "iperf_time.h"
+#include "portable_endian.h"
 
 #if defined(HAVE_SSL)
 #include <openssl/bio.h>
@@ -431,9 +432,16 @@ struct iperf_test
 extern int gerror; /* error value from getaddrinfo(3), for use in internal error handling */
 
 /* UDP "connect" message and reply (textual value for Wireshark, etc. readability - legacy was numeric) */
+
+#if BYTE_ORDER == BIG_ENDIAN
+#define UDP_CONNECT_MSG 0x39383736
+#define UDP_CONNECT_REPLY 0x36373839
+#define LEGACY_UDP_CONNECT_REPLY 0xb168de3a
+#else
 #define UDP_CONNECT_MSG 0x36373839          // "6789" - legacy value was 123456789
 #define UDP_CONNECT_REPLY 0x39383736        // "9876" - legacy value was 987654321
 #define LEGACY_UDP_CONNECT_REPLY 987654321  // Old servers may still reply with the legacy value
+#endif
 
 /* In Reverse mode, maximum number of packets to wait for "accept" response - to handle out of order packets */
 #define MAX_REVERSE_OUT_OF_ORDER_PACKETS 2

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -47,7 +47,6 @@
 #include "timer.h"
 #include "net.h"
 #include "cjson.h"
-#include "portable_endian.h"
 
 #if defined(HAVE_INTTYPES_H)
 # include <inttypes.h>


### PR DESCRIPTION
for example. if you run a iperf3 server on a little endian host, but client is big endian it will result in the following error if you try to start a udp bandwidth test

Connect received for Socket 5, sz=4, buf=36373839, i=0, max_len_wait_for_reply=4 iperf3: error - unable to read from stream socket: Invalid argument

the reason that that all messages are reversed. fix this by swapping the message values to little endian host order on big endian systems

Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

