### PR TITLE
Release engineering changes for iperf-3.13

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-"iperf, Copyright (c) 2014-2022, The Regents of the University of California,
+"iperf, Copyright (c) 2014-2023, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy).  All rights reserved."
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ responsibility for the content of these pages.
 Copyright
 ---------
 
-iperf, Copyright (c) 2014-2022, The Regents of the University of
+iperf, Copyright (c) 2014-2023, The Regents of the University of
 California, through Lawrence Berkeley National Laboratory (subject
 to receipt of any required approvals from the U.S. Dept. of
 Energy).  All rights reserved.

--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -1,6 +1,45 @@
 iperf3 Release Notes
 ====================
 
+iperf-3.13 2023-02-16
+---------------------
+
+* Notable user-visible changes
+
+  * fq-rate (PR #1461, Issue #1366), and bidirectional flag (Issue #1428,
+    PR #1429) were added to the JSON output.
+
+  * Added support for OpenBSD including cleaning up endian handling (PR #1396)
+    and support for TCP_INFO on systems where it was implemented (PR #1397).
+
+  * Fixed bug in how TOS is set in mapped v4 (PR #1427).
+
+  * Corrected documentation, such as updating binary download links and text
+    (Issue #1459), updating version on iperf3 websites, and fixing an
+    incorrect error message (Issue #1441).
+
+  * Fixed crash on rcv-timeout with JSON logfile (#1463, #1460, issue #1360,
+    PR #1369).
+
+  * Fixed a bug that prevented TOS/DSCP from getting set correctly for reverse
+    tests (PR #1427, Issue #638).
+
+* Developer-visible changes
+
+  * Getter and setter are now available for bind_dev (PR #1419).
+
+  * Added missing getter for bidirectional tests (PR #1453).
+
+  * Added minor changes to clean up .gitignore and error messages (#1408).
+
+  * Made sure configure scripts are runnable with /bin/sh (PR #1398).
+
+  * Cleaned up RPM spec, such as adding missing RPM build dependencies, dropping
+    EL5 and removing outdated %changelog (PR #1401) to make.
+
+  * Added a fix for a resource leak bug in function iperf_create_pidfile(#1443).
+
+
 iperf-3.12 2022-09-30
 ---------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@
 
 # Initialize the autoconf system for the specified tool, version and mailing list
 AC_PREREQ([2.71])
-AC_INIT([iperf],[3.12+],[https://github.com/esnet/iperf],[iperf],[https://software.es.net/iperf/])
+AC_INIT([iperf],[3.13],[https://github.com/esnet/iperf],[iperf],[https://software.es.net/iperf/])
 m4_include([config/ax_check_openssl.m4])
 m4_include([config/iperf_config_static_bin.m4])
 AC_LANG(C)


### PR DESCRIPTION
    * Draft release notes for iperf-3.13.

    * iperf-3.13 version number bumps.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

