### PR TITLE
enh: Add support for SO_PRIORITY socket option.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -277,6 +277,18 @@ if test "x$iperf3_cv_header_so_bindtodevice" = "xyes"; then
     AC_DEFINE([HAVE_SO_BINDTODEVICE], [1], [Have SO_BINDTODEVICE sockopt.])
 fi
 
+# Check for SO_PRIORITY sockopt (believed to be Linux only)
+AC_CACHE_CHECK([SO_PRIORITY socket option],
+[iperf3_cv_header_so_priority],
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <sys/socket.h>]],
+                   [[int foo = SO_PRIORITY;]])],
+  iperf3_cv_header_so_priority=yes,
+  iperf3_cv_header_so_priority=no))
+if test "x$iperf3_cv_header_so_priority" = "xyes"; then
+    AC_DEFINE([HAVE_SO_PRIORITY], [1], [Have SO_PRIORITY sockopt.])
+fi
+
 # Check for IP_MTU_DISCOVER (mostly on Linux)
 AC_CACHE_CHECK([IP_MTU_DISCOVER socket option],
 [iperf3_cv_header_ip_mtu_discover],

--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -415,7 +415,15 @@ the executable.
                  Set the IP type of service bits.  The usual prefixes  for  octal
                  and  hex can be used, i.e. 52, 064 and 0x34 all specify the same
                  value.
-   
+
+          --sock-prio n
+                 Set the protocol-defined priority for all packets to be sent
+                 on this socket. The value must be between 0 and 6 inclusive.
+                 This value is used to order the networking queues: packets
+                 with a higher priority may be processed first depending on the
+                 selected device queueing discipline.
+                 capability
+
           --dscp dscp
                  Set the IP DSCP bits.  Both numeric and symbolic values are  ac-
                  cepted.  Numeric  values  can be specified in decimal, octal and

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -170,6 +170,9 @@ struct iperf_settings
     int       mss;                  /* for TCP MSS */
     int       ttl;                  /* IP TTL option */
     int       tos;                  /* type of service bit */
+#if defined(HAVE_SO_PRIORITY)
+    int       sock_prio;            /* protocol-defined priority, -1 indicates not set */
+#endif // HAVE_SO_PRIORITY
     int       flowlabel;            /* IPv6 flow label */
     iperf_size_t bytes;             /* number of bytes to send */
     iperf_size_t blocks;            /* number of blocks (packets) to send */

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -940,6 +940,11 @@ iperf_on_test_start(struct iperf_test *test)
         cJSON_AddNumberToObject(json_start_data, "fqrate", test->settings->fqrate);
         cJSON_AddNumberToObject(json_start_data, "interval", test->stats_interval);
 
+#if defined(HAVE_SO_PRIORITY)
+        if (test->settings->sock_prio >= 0)
+            cJSON_AddNumberToObject(json_start_data, "sock_prio", test->settings->sock_prio);
+#endif
+
         cJSON_AddItemToObject(test->json_start, "test_start", json_start_data);
     } else {
 	if (test->verbose) {
@@ -1154,6 +1159,9 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         {"version4", no_argument, NULL, '4'},
         {"version6", no_argument, NULL, '6'},
         {"tos", required_argument, NULL, 'S'},
+#if defined(HAVE_SO_PRIORITY)
+        {"sock-prio", required_argument, NULL, OPT_SOCK_PRIO},
+#endif /* HAVE_SO_PRIORITY */
         {"dscp", required_argument, NULL, OPT_DSCP},
 	{"extra-data", required_argument, NULL, OPT_EXTRA_DATA},
 #if defined(HAVE_FLOWLABEL)
@@ -1525,6 +1533,18 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 		}
 		client_flag = 1;
                 break;
+#if defined(HAVE_SO_PRIORITY)
+            case OPT_SOCK_PRIO:
+                test->settings->sock_prio = strtol(optarg, &endptr, 0);
+                if (endptr == optarg ||
+                    test->settings->sock_prio < 0 ||
+                    test->settings->sock_prio > 6) {
+                    i_errno = IEBADSOPRIO;
+                    return -1;
+                }
+                client_flag = 1;
+                break;
+#endif /* HAVE_SO_PRIORITY */
 	    case OPT_DSCP:
                 test->settings->tos = parse_qos(optarg);
 		if(test->settings->tos < 0) {
@@ -2479,6 +2499,10 @@ send_parameters(struct iperf_test *test)
 	    cJSON_AddNumberToObject(j, "burst", test->settings->burst);
 	if (test->settings->tos)
 	    cJSON_AddNumberToObject(j, "TOS", test->settings->tos);
+#if defined(HAVE_SO_PRIORITY)
+        if (test->settings->sock_prio >= 0)
+            cJSON_AddNumberToObject(j, "sock_prio", test->settings->sock_prio);
+#endif /* HAVE_SO_PRIORITY */
 	if (test->settings->flowlabel)
 	    cJSON_AddNumberToObject(j, "flowlabel", test->settings->flowlabel);
 	if (test->title)
@@ -2612,6 +2636,10 @@ get_parameters(struct iperf_test *test)
 	    test->settings->tos = j_p->valueint;
 	if ((j_p = iperf_cJSON_GetObjectItemType(j, "flowlabel", cJSON_Number)) != NULL)
 	    test->settings->flowlabel = j_p->valueint;
+#if defined(HAVE_SO_PRIORITY)
+	if ((j_p = iperf_cJSON_GetObjectItemType(j, "sock_prio", cJSON_Number)) != NULL)
+            test->settings->sock_prio = j_p->valueint;
+#endif /* HAVE_SO_PRIORITY */
 	if ((j_p = iperf_cJSON_GetObjectItemType(j, "title", cJSON_String)) != NULL)
 	    test->title = strdup(j_p->valuestring);
 	if ((j_p = iperf_cJSON_GetObjectItemType(j, "extra_data", cJSON_String)) != NULL)
@@ -3572,6 +3600,9 @@ iperf_reset_test(struct iperf_test *test)
     test->settings->burst = 0;
     test->settings->mss = 0;
     test->settings->tos = 0;
+#if defined(HAVE_SO_PRIORITY)
+    test->settings->sock_prio = -1; /* -1 indicates not set by user */
+#endif /* HAVE_SO_PRIORITY */
     test->settings->dont_fragment = 0;
     test->zerocopy = 0;
     test->settings->skip_rx_copy = 0;
@@ -4882,6 +4913,17 @@ iperf_common_sockopts(struct iperf_test *test, int s)
             }
         }
     }
+
+#if defined(HAVE_SO_PRIORITY)
+    if (test->settings->sock_prio >= 0) {
+        int opt = test->settings->sock_prio;
+        if (setsockopt(s, SOL_SOCKET, SO_PRIORITY, &opt, sizeof(opt)) < 0) {
+            i_errno = IESETSOPRIO;
+            return -1;
+        }
+    }
+#endif /* HAVE_SO_PRIORITY */
+
     return 0;
 }
 

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -919,8 +919,28 @@ iperf_on_new_stream(struct iperf_stream *sp)
 void
 iperf_on_test_start(struct iperf_test *test)
 {
+    cJSON *json_start_data = NULL;
+
     if (test->json_output) {
-	cJSON_AddItemToObject(test->json_start, "test_start", iperf_json_printf("protocol: %s  num_streams: %d  blksize: %d  omit: %d  duration: %d  bytes: %d  blocks: %d  reverse: %d  tos: %d  target_bitrate: %d bidir: %d fqrate: %d interval: %f", test->protocol->name, (int64_t) test->num_streams, (int64_t) test->settings->blksize, (int64_t) test->omit, (int64_t) test->duration, (int64_t) test->settings->bytes, (int64_t) test->settings->blocks, test->reverse?(int64_t)1:(int64_t)0, (int64_t) test->settings->tos, (int64_t) test->settings->rate, (int64_t) test->bidirectional, (uint64_t) test->settings->fqrate, test->stats_interval));
+        json_start_data = cJSON_CreateObject();
+        if (json_start_data == NULL)
+            return;
+
+        cJSON_AddStringToObject(json_start_data, "protocol", test->protocol->name);
+        cJSON_AddNumberToObject(json_start_data, "num_streams", test->num_streams);
+        cJSON_AddNumberToObject(json_start_data, "blksize", test->settings->blksize);
+        cJSON_AddNumberToObject(json_start_data, "omit", test->omit);
+        cJSON_AddNumberToObject(json_start_data, "duration", test->duration);
+        cJSON_AddNumberToObject(json_start_data, "bytes", test->settings->bytes);
+        cJSON_AddNumberToObject(json_start_data, "blocks", test->settings->blocks);
+        cJSON_AddNumberToObject(json_start_data, "reverse", test->reverse?(int64_t)1:(int64_t)0);
+        cJSON_AddNumberToObject(json_start_data, "tos", test->settings->tos);
+        cJSON_AddNumberToObject(json_start_data, "target_bitrate", test->settings->rate);
+        cJSON_AddNumberToObject(json_start_data, "bidir", test->bidirectional);
+        cJSON_AddNumberToObject(json_start_data, "fqrate", test->settings->fqrate);
+        cJSON_AddNumberToObject(json_start_data, "interval", test->stats_interval);
+
+        cJSON_AddItemToObject(test->json_start, "test_start", json_start_data);
     } else {
 	if (test->verbose) {
 	    if (test->settings->bytes)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -106,6 +106,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_SKIP_RX_COPY 32
 #define OPT_JSON_STREAM_FULL_OUTPUT 33
 #define OPT_SERVER_MAX_DURATION 34
+#define OPT_SOCK_PRIO 35
 
 /* states */
 #define TEST_START 1
@@ -444,6 +445,7 @@ enum {
     IECNTLKA = 36,          // Control connection Keepalive period should be larger than the full retry period (interval * count)
     IEMAXSERVERTESTDURATIONEXCEEDED = 37, // Client's duration exceeds server's maximum duration
     IEUNITVAL = 38,         // Invalid unit value or suffix
+    IEBADSOPRIO = 39,       // Bad socket priority value
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)
@@ -504,6 +506,7 @@ enum {
     IESETCNTLKAINTERVAL = 157, // Unable to set/get socket keepalive TCP retry interval (TCP_KEEPINTVL) option
     IESETCNTLKACOUNT = 158,    // Unable to set/get socket keepalive TCP number of retries (TCP_KEEPCNT) option
     IEPTHREADSIGMASK=159,      // Unable to initialize sub thread signal mask (check perror)
+    IESETSOPRIO = 160,      // Unable to set socket priority (check perror)
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -219,6 +219,9 @@ iperf_strerror(int int_errno)
         case IESERVERAUTHUSERS:
              snprintf(errstr, len, "cannot access authorized users file");
             break;
+        case IEBADSOPRIO:
+            snprintf(errstr, len, "bad socket priority value (must be between 0 and 6 inclusive)");
+            break;
         case IEBADFORMAT:
             snprintf(errstr, len, "bad format specifier (valid formats are in the set [kmgtKMGT])");
             break;
@@ -532,6 +535,10 @@ iperf_strerror(int int_errno)
             break;
         case IEPTHREADSIGMASK:
             snprintf(errstr, len, "unable to change mask of blocked signals");
+            break;
+        case IESETSOPRIO:
+            snprintf(errstr, len, "unable to set socket priority");
+            perr = 1;
             break;
         case IEPTHREADATTRDESTROY:
             snprintf(errstr, len, "unable to destroy thread attributes");

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -207,6 +207,9 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  --dscp N or --dscp val    set the IP dscp value, either 0-63 or symbolic.\n"
                            "                            Numeric values can be specified in decimal,\n"
                            "                            octal and hex (see --tos above).\n"
+#if defined(HAVE_SO_PRIORITY)
+                           "      --sock-prio N         set the socket priority\n"
+#endif /* HAVE_SO_PRIORITY */
 #if defined(HAVE_FLOWLABEL)
                            "  -L, --flowlabel N         set the IPv6 flow label (only supported on Linux)\n"
 #endif /* HAVE_FLOWLABEL */


### PR DESCRIPTION
This functionality is needed to test mutliqueue support of Ethernet drivers.

Here is one use case example how this functionality can be tested:
```
On the server side:
# create mqprio queue discipline on lan2 interface
tc qdisc add dev lan2 parent root handle 100 mqprio num_tc 4 map 0 1 2 3  queues 1@0 1@1 1@2 1@3  hw 0
iperf3 -s &
# collect queue stats
tc -s qdisc show dev lan2

On the client side:
# start tcp reverse stream with socket priority 2
iperf3 -c  172.17.0.1 -b100M  -l1472 -t100 -R --sock-prio 2

On the server side:
# collect queue stats
tc -s qdisc show dev lan2

qdisc mqprio 100: root tc 4 map 0 1 2 3 0 0 0 0 0 0 0 0 0 0 0 0 
             queues:(0:0) (1:1) (2:2) (3:3) 
 Sent 35748478 bytes 23639 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
qdisc fq_codel 0: parent 100:4 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64 
 Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
  maxpacket 0 drop_overlimit 0 new_flow_count 0 ecn_mark 0
  new_flows_len 0 old_flows_len 0
qdisc fq_codel 0: parent 100:3 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64 
 **Sent 17628922 bytes 11649 pkt** (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
  maxpacket 0 drop_overlimit 0 new_flow_count 0 ecn_mark 0
  new_flows_len 0 old_flows_len 0
qdisc fq_codel 0: parent 100:2 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64 
 Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
  maxpacket 0 drop_overlimit 0 new_flow_count 0 ecn_mark 0
  new_flows_len 0 old_flows_len 0
qdisc fq_codel 0: parent 100:1 limit 10240p flows 1024 quantum 1514 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64 
 Sent 18119556 bytes 11990 pkt (dropped 0, overlimits 0 requeues 0) 
 backlog 0b 0p requeues 0
  maxpacket 0 drop_overlimit 0 new_flow_count 0 ecn_mark 0
  new_flows_len 0 old_flows_len 0
```

At this point we should be able to see increasing counters on "qdisc fq_codel 0: parent 100:3 ..."