### PR TITLE
Fix issue #1482 - not allow using option as missing argument for an o…

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1121,6 +1121,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     struct xbind_entry *xbe;
     double farg;
     int rcv_timeout_in = 0;
+    int option_index = 0;
 
     blksize = 0;
     server_flag = client_flag = rate_flag = duration_flag = rcv_timeout_flag = snd_timeout_flag =0;
@@ -1128,7 +1129,15 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     char *client_username = NULL, *client_rsa_public_key = NULL, *server_rsa_private_key = NULL;
 #endif /* HAVE_SSL */
 
-    while ((flag = getopt_long(argc, argv, "p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:A:T:C:dI:hX:", longopts, NULL)) != -1) {
+    while ((flag = getopt_long(argc, argv, "p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:A:T:C:dI:hX:", longopts, &option_index)) != -1) {
+        if (optarg && *optarg == '-') {
+            if ((flag >= 'A' && flag <= 'Z') || (flag >= 'a' && flag <= 'z'))
+                iperf_err(test, "Argument for option '%c' is missing or is negative", flag);
+            else
+                iperf_err(test, "Argument for option '%s' is missing or is negative", longopts[option_index].name);
+            i_errno = IEMISSINGOPTARG;
+            return -1;
+        }
         switch (flag) {
             case 'p':
 		portno = atoi(optarg);

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -401,6 +401,7 @@ enum {
     IERCVTIMEOUT = 31,      // Illegal message receive timeout
     IERVRSONLYRCVTIMEOUT = 32,  // Client receive timeout is valid only in reverse mode
     IESNDTIMEOUT = 33,      // Illegal message send timeout
+    IEMISSINGOPTARG = 34,   // A mandatory argument is missing for an option
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -462,6 +462,9 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "unable to set TCP USER_TIMEOUT");
             perr = 1;
             break;
+        case IEMISSINGOPTARG:
+	    snprintf(errstr, len, "a mandatory argument for an option is missing or is negativefor");
+            break;
 	default:
 	    snprintf(errstr, len, "int_errno=%d", int_errno);
 	    perr = 1;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
#1482

* Brief description of code changes (suitable for use as a commit message):

Suggested fix for preventing iperf3 from using an option as a missing argument for the previous option.  I.e. in `-i -u` the "-u" was used as the `-i` argument, and the default TCP was running instead of UDP test.

The suggested fix assumes that negative argument is not allowed for all numeric options, and that no string argument can start with "-" (e.g. for `title`, `extra-data`, `username`, `file`).  A more robust fix could be by checking that `optarg` is numeric in each case where `atoi()` is used.



