### PR TITLE
updated SPECS to use RELNOTES.md

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -130,7 +130,7 @@ The developers increment the:
 Release Engineering Checklist
 -----------------------------
 
-1. Update the ``README`` and ``RELEASE_NOTES`` files to be accurate. Make sure
+1. Update the ``README`` and ``RELNOTES.md`` files to be accurate. Make sure
    that the "Known Issues" section of the ``README`` file and in this document
    are up to date.
 
@@ -142,7 +142,7 @@ Release Engineering Checklist
    status`` emits no output), make the changes necessary to produce
    the new version, such as bumping version numbers::
 
-    vi RELEASE_NOTES   # update version number and release date
+    vi RELNOTES.md     # update version number and release date
     vi configure.ac    # update version parameter in AC_INIT
     vi src/iperf3.1    # update manpage revision date if needed
     vi src/libiperf.3  # update manpage revision date if needed

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -332,7 +332,7 @@ This maintenance release includes the following bug fixes:
 * Some portability fixes for OpenBSD and Solaris have been merged from
   the mainline.
 
-As always, more details can be found in the ``RELEASE_NOTES`` file in
+As always, more details can be found in the ``RELNOTES.md`` file in
 the source distribution.
 
 2014-06-16:  Project documentation on GitHub Pages
@@ -363,7 +363,7 @@ enhancements and bug fixes.  Highlights:
 * A number of bugs with ``--json`` output have been fixed.
 
 A more extensive list of changes can always be found in the
-``RELEASE_NOTES`` file in the source distribution.
+``RELNOTES.md`` file in the source distribution.
 
 Note:  An iperf-3.0.4 release was planned and tagged, but not
 officially released.
@@ -395,7 +395,7 @@ This is the second maintenance release of iperf 3.0, containing a few bug fixes 
 * A possible buffer overflow related to error output has been fixed.
   (This is not believed to be exploitable.)
 
-More information on changes can be found in the ``RELEASE_NOTES``
+More information on changes can be found in the ``RELNOTES.md``
 file in the source distribution.
 
 2014-03-10:  iperf-3.0.2 released
@@ -418,7 +418,7 @@ GitHub.  Of particular interest:
 * libiperf is now built as both a shared and static library; by
   default, the iperf3 binary links to the shared library.
 
-More information on changes can be found in the ``RELEASE_NOTES``
+More information on changes can be found in the ``RELNOTES.md``
 file in the source distribution.
 
 2014-02-28:  iperf migrated to GitHub

--- a/iperf3.spec.in
+++ b/iperf3.spec.in
@@ -44,7 +44,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
-%%doc README.md INSTALL LICENSE RELEASE_NOTES
+%%doc README.md INSTALL LICENSE RELNOTES.md
 %{_mandir}/man1/iperf3.1.gz
 %{_mandir}/man3/libiperf.3.gz
 %{_bindir}/iperf3


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
N/A

* Brief description of code changes (suitable for use as a commit message):
-- Fix to SPECS file to build using the RELNOTES.md
-- Changed strings from "RELEASE_NOTES" -> "RELNOTES.md"
