### PR TITLE
Verify success of BIO_new_file()

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1626,15 +1626,15 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 
         char *client_password = NULL;
         size_t s;
+        if (test_load_pubkey_from_file(client_rsa_public_key) < 0){
+            iperf_err(test, "%s\n", ERR_error_string(ERR_get_error(), NULL));
+            i_errno = IESETCLIENTAUTH;
+            return -1;
+        }
         /* Need to copy env var, so we can do a common free */
         if ((client_password = getenv("IPERF3_PASSWORD")) != NULL)
              client_password = strdup(client_password);
         else if (iperf_getpass(&client_password, &s, stdin) < 0){
-            i_errno = IESETCLIENTAUTH;
-            return -1;
-        }
-        if (test_load_pubkey_from_file(client_rsa_public_key) < 0){
-            iperf_err(test, "%s\n", ERR_error_string(ERR_get_error(), NULL));
             i_errno = IESETCLIENTAUTH;
             return -1;
         }

--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -162,9 +162,10 @@ EVP_PKEY *load_pubkey_from_file(const char *file) {
 
     if (file) {
       key = BIO_new_file(file, "r");
-      pkey = PEM_read_bio_PUBKEY(key, NULL, NULL, NULL);
-
-      BIO_free(key);
+      if (key != NULL) {
+          pkey = PEM_read_bio_PUBKEY(key, NULL, NULL, NULL);
+          BIO_free(key);
+      }
     }
     return (pkey);
 }
@@ -188,9 +189,10 @@ EVP_PKEY *load_privkey_from_file(const char *file) {
 
     if (file) {
       key = BIO_new_file(file, "r");
-      pkey = PEM_read_bio_PrivateKey(key, NULL, NULL, NULL);
-
-      BIO_free(key);
+      if (key != NULL) {
+          pkey = PEM_read_bio_PrivateKey(key, NULL, NULL, NULL);
+          BIO_free(key);
+      }
     }
     return (pkey);
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
* #1471

* Brief description of code changes (suitable for use as a commit message):

Suggested fix crash when public/private key file does not exist - may not be th full fix as the issue didn't happen on my PC.  However, the output of `BIO_new_file()` was not checked, which could lead to such crash in `PEM_read_bio_xxxxKey()` (depending on the library implementation).

In addition moved reading the private key file before prompting for the password, so the user will not have to enter password before the failure because file does not exist.
