### PR TITLE
Do not allow File transfer using UDP

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1676,6 +1676,13 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     }
 
 #endif //HAVE_SSL
+
+    // File cannot be transferred using UDP because of the UDP packets header (packet number, etc.)
+    if(test->role == 'c' && test->diskfile_name != (char*) 0 && test->protocol->id == Pudp) {
+        i_errno = IEUDPFILETRANSFER;
+        return -1;
+    }
+
     if (blksize == 0) {
 	if (test->protocol->id == Pudp)
 	    blksize = 0;	/* try to dynamically determine from MSS */

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -401,6 +401,7 @@ enum {
     IERCVTIMEOUT = 31,      // Illegal message receive timeout
     IERVRSONLYRCVTIMEOUT = 32,  // Client receive timeout is valid only in reverse mode
     IESNDTIMEOUT = 33,      // Illegal message send timeout
+    IEUDPFILETRANSFER = 34, // Cannot transfer file using UDP
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -350,6 +350,10 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "send timeout value is incorrect or not in range");
             perr = 1;
             break;
+        case IEUDPFILETRANSFER:
+            snprintf(errstr, len, "cannot transfer file using UDP");
+            perr = 1;
+            break;
         case IERVRSONLYRCVTIMEOUT:
             snprintf(errstr, len, "client receive timeout is valid only in receiving mode");
             perr = 1;

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -352,7 +352,6 @@ iperf_strerror(int int_errno)
             break;
         case IEUDPFILETRANSFER:
             snprintf(errstr, len, "cannot transfer file using UDP");
-            perr = 1;
             break;
         case IERVRSONLYRCVTIMEOUT:
             snprintf(errstr, len, "client receive timeout is valid only in receiving mode");


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
None

* Brief description of code changes (suitable for use as a commit message):

Found that iperf3 crashes when trying to transfer a file (`-F`) using UDP.  This is because UDP block size is fixed, but the last file block is usually smaller than the block size.   Also, the file transfer would fail anyway because of the UDP packet header.

Added an error when trying to transfer a file using UDP.
