### PR TITLE
Enhanced errors text for some control messages errors

### DIFF
--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -228,7 +228,7 @@ iperf_strerror(int int_errno)
             perr = 1;
             break;
         case IECONNECT:
-            snprintf(errstr, len, "unable to connect to server");
+            snprintf(errstr, len, "unable to connect to server - server may have stopped running or use a different port, firewall issue, etc.");
             perr = 1;
 	    herr = 1;
             break;
@@ -257,7 +257,7 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "control socket has closed unexpectedly");
             break;
         case IEMESSAGE:
-            snprintf(errstr, len, "received an unknown control message");
+            snprintf(errstr, len, "received an unknown control message (ensure other side is iperf3 and not iperf)");
             break;
         case IESENDMESSAGE:
             snprintf(errstr, len, "unable to send control message - port may not be available, the other side may have stopped running, etc.");


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
None

* Brief description of code changes (suitable for use as a commit message):
Based on [this comment](https://github.com/esnet/iperf/issues/1233#issuecomment-1509369780) I think it will help to enhance two errors messages regarding failure to connect to the server - especially for cases when iperf server is used by mistake (when forgetting the "3"), server and client does not the same port, or server is not running. (I am aware of the issue with long error messages, but I didn't find a shorter version.)

