### PR TITLE
Allow programmatic shutdown of iperf3 server

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -508,7 +508,7 @@ iperf_run_server(struct iperf_test *test)
 
         // Ensure select() will timeout to allow handling error cases that require server restart
         if (test->state == IPERF_START) {       // In idle mode server may need to restart
-            if (timeout == NULL && test->settings->idle_timeout > 0) {
+            if (timeout == NULL && test->settings->idle_timeout >= 0) {
                 used_timeout.tv_sec = test->settings->idle_timeout;
                 used_timeout.tv_usec = 0;
                 timeout = &used_timeout;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

master

* Issues fixed (if any):

none

* Brief description of code changes (suitable for use as a commit message):

when iperf3 is running on server mode, and it wait client connect, when `timeout>0`, the process is in a blocked state, so cannot close server programmatic.

when `timeout >= 0`, server side can close server by:

```
iperf_set_test_state(test, IPERF_DONE);
iperf_set_test_one_off(test, 1);
```

