### PR TITLE
Allow set iperf callback(on_new_stream/on_test_start/on_connect/on_test_finish)

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -593,6 +593,30 @@ iperf_set_mapped_v4(struct iperf_test *ipt, const int val)
     ipt->mapped_v4 = val;
 }
 
+void 
+iperf_set_on_new_stream_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_new_stream = callback;
+}
+
+void 
+iperf_set_on_test_start_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_test_start = callback;
+}
+
+void 
+iperf_set_on_test_connect_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_connect = callback;
+}
+
+void 
+iperf_set_on_test_finish_callback(struct iperf_test* ipt, void (*callback)())
+{
+        ipt->on_test_finish = callback;
+}
+
 static void
 check_sender_has_retransmits(struct iperf_test *ipt)
 {

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -200,6 +200,10 @@ void    iperf_set_dont_fragment( struct iperf_test* ipt, int dont_fragment );
 void    iperf_set_test_congestion_control(struct iperf_test* ipt, char* cc);
 void    iperf_set_test_mss(struct iperf_test* ipt, int mss);
 void    iperf_set_mapped_v4(struct iperf_test* ipt, const int val);
+void    iperf_set_on_new_stream_callback(struct iperf_test* ipt, void (*callback)());
+void    iperf_set_on_test_start_callback(struct iperf_test* ipt, void (*callback)());
+void    iperf_set_on_test_connect_callback(struct iperf_test* ipt, void (*callback)());
+void    iperf_set_on_test_finish_callback(struct iperf_test* ipt, void (*callback)());
 
 #if defined(HAVE_SSL)
 void    iperf_set_test_client_username(struct iperf_test *ipt, const char *client_username);


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

master

* Issues fixed (if any):

none

* Brief description of code changes (suitable for use as a commit message):

none
