### PR TITLE
Fix exit code when using json output

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4725,27 +4725,31 @@ iperf_json_start(struct iperf_test *test)
 int
 iperf_json_finish(struct iperf_test *test)
 {
-    if (test->title)
-	cJSON_AddStringToObject(test->json_top, "title", test->title);
-    if (test->extra_data)
-	cJSON_AddStringToObject(test->json_top, "extra_data", test->extra_data);
+    if (test->title) {
+        cJSON_AddStringToObject(test->json_top, "title", test->title);
+    }
+    if (test->extra_data) {
+        cJSON_AddStringToObject(test->json_top, "extra_data", test->extra_data);
+    }
     /* Include server output */
     if (test->json_server_output) {
-	cJSON_AddItemToObject(test->json_top, "server_output_json", test->json_server_output);
+        cJSON_AddItemToObject(test->json_top, "server_output_json", test->json_server_output);
     }
     if (test->server_output_text) {
-	cJSON_AddStringToObject(test->json_top, "server_output_text", test->server_output_text);
+        cJSON_AddStringToObject(test->json_top, "server_output_text", test->server_output_text);
     }
     // Get ASCII rendering of JSON structure.  Then make our
     // own copy of it and return the storage that cJSON allocated
     // on our behalf.  We keep our own copy around.
     char *str = cJSON_Print(test->json_top);
-    if (str == NULL)
-	return -1;
+    if (str == NULL) {
+        return -1;
+    }
     test->json_output_string = strdup(str);
     cJSON_free(str);
-    if (test->json_output_string == NULL)
+    if (test->json_output_string == NULL) {
         return -1;
+    }
     fprintf(test->outfile, "%s\n", test->json_output_string);
     iflush(test);
     cJSON_Delete(test->json_top);

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -708,10 +708,6 @@ iperf_run_client(struct iperf_test * test)
     if (test->json_output) {
         cJSON_AddStringToObject(test->json_top, "error", iperf_strerror(i_errno));
         iperf_json_finish(test);
-        iflush(test);
-        // Return 0 and not -1 since all terminating function were done here.
-        // Also prevents error message logging outside the already closed JSON output.
-        return 0;
     }
     iflush(test);
     return -1;

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -96,8 +96,10 @@ iperf_errexit(struct iperf_test *test, const char *format, ...)
 
     va_start(argp, format);
     vsnprintf(str, sizeof(str), format, argp);
-    if (test != NULL && test->json_output && test->json_top != NULL) {
-	cJSON_AddStringToObject(test->json_top, "error", str);
+    if (test != NULL && test->json_output) {
+        if (test->json_top != NULL) {
+	    cJSON_AddStringToObject(test->json_top, "error", str);
+        }
 	iperf_json_finish(test);
     } else
 	if (test && test->outfile && test->outfile != stdout) {


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
  * master

* Issues fixed (if any):
  * This PR attempts to address https://github.com/esnet/iperf/issues/1405 without breaking client API compatibility.

* Brief description of code changes (suitable for use as a commit message):
  * This PR cleans up the iperf_api::iperf_json_finish path to allow it to be called consistently on both the nominal and error case path. It contains the following 3 commits:
    * Make iperf_api::iperf_json_finish alignment self consistent
    * Make iperf_api::iperf_json_finish idempotent to simplify error path
    * Return client_api error codes, even with json output enabled

Sorry for the delay! I had a new job start up and didn't get back to this as quickly as I had hoped : ) Let me know what you think @bmah888 and @hajoha 
