### PR TITLE
doc: Don't (incorrectly) suggest the -S option can set the ECN bits.

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -363,8 +363,7 @@ i.e. 52, 064 and 0x34 all specify the same value.
 .TP
 .BR "--dscp " \fIdscp\fR
 set the IP DSCP bits.  Both numeric and symbolic values are accepted. Numeric
-values can be specified in decimal, octal and hex (see --tos above). To set
-both the DSCP bits and the ECN bits, use --tos.
+values can be specified in decimal, octal and hex (see --tos above).
 .TP
 .BR -L ", " --flowlabel " \fIn\fR"
 set the IPv6 flow label (currently only supported on Linux)


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

Don't (incorrectly) suggest the -S option can set the ECN bits.
