### PR TITLE
Prevent UDP packet count and operations overflow

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -85,13 +85,13 @@ struct iperf_interval_results
     float     interval_duration;
 
     /* for UDP */
-    int       interval_packet_count;
-    int       interval_outoforder_packets;
-    int       interval_cnt_error;
-    int       packet_count;
+    int64_t   interval_packet_count;
+    int64_t   interval_outoforder_packets;
+    int64_t   interval_cnt_error;
+    int64_t   packet_count;
     double    jitter;
-    int       outoforder_packets;
-    int       cnt_error;
+    int64_t   outoforder_packets;
+    int64_t   cnt_error;
 
     int omitted;
 #if (defined(linux) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)) && \
@@ -199,16 +199,16 @@ struct iperf_stream
      * for udp measurements - This can be a structure outside stream, and
      * stream can have a pointer to this
      */
-    int       packet_count;
-    int	      peer_packet_count;
-    int	      peer_omitted_packet_count;
-    int       omitted_packet_count;
+    int64_t   packet_count;
+    int64_t   peer_packet_count;
+    int64_t   peer_omitted_packet_count;
+    int64_t   omitted_packet_count;
     double    jitter;
     double    prev_transit;
-    int       outoforder_packets;
-    int       omitted_outoforder_packets;
-    int       cnt_error;
-    int       omitted_cnt_error;
+    int64_t   outoforder_packets;
+    int64_t   omitted_outoforder_packets;
+    int64_t   cnt_error;
+    int64_t   omitted_cnt_error;
     uint64_t  target;
 
     struct sockaddr_storage local_addr;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -81,6 +81,18 @@
 
 #include "version.h"
 
+#if defined(HAVE_INTTYPES_H)
+# include <inttypes.h>
+#else
+# ifndef PRIu64
+#  if sizeof(long) == 8
+#   define PRIu64		"lu"
+#  else
+#   define PRIu64		"llu"
+#  endif
+# endif
+#endif
+
 #ifdef __cplusplus
 extern    "C"
 {
@@ -382,13 +394,13 @@ const char report_bw_retrans_cwnd_format[] =
 "[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %3u   %ss       %s\n";
 
 const char report_bw_udp_format[] =
-"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %d/%d (%.2g%%)  %s\n";
+"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %" PRIu64 "/%" PRIu64 " (%.2g%%)  %s\n";
 
 const char report_bw_udp_format_no_omitted_error[] =
-"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  Unknown/%d  %s\n";
+"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  Unknown/%" PRIu64 "  %s\n";
 
 const char report_bw_udp_sender_format[] =
-"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %d  %s\n";
+"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %" PRIu64 "  %s\n";
 
 const char report_summary[] =
 "Test Complete. Summary Results:\n";
@@ -400,10 +412,10 @@ const char report_sum_bw_retrans_format[] =
 "[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %3d             %s\n";
 
 const char report_sum_bw_udp_format[] =
-"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %d/%d (%.2g%%)  %s\n";
+"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %" PRIu64 "/%" PRIu64 " (%.2g%%)  %s\n";
 
 const char report_sum_bw_udp_sender_format[] =
-"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %d  %s\n";
+"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %" PRIu64 "  %s\n";
 
 const char report_omitted[] = "(omitted)";
 

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -124,7 +124,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 	}
 
 	if (sp->test->debug_level >= DEBUG_LEVEL_DEBUG)
-	    fprintf(stderr, "pcount %" PRIu64 " packet_count %d\n", pcount, sp->packet_count);
+	    fprintf(stderr, "pcount %" PRIu64 " packet_count %" PRIu64 "\n", pcount, sp->packet_count);
 
 	/*
 	 * Try to handle out of order packets.  The way we do this
@@ -167,7 +167,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 
 	    /* Log the out-of-order packet */
 	    if (sp->test->debug)
-		fprintf(stderr, "OUT OF ORDER - incoming packet sequence %" PRIu64 " but expected sequence %d on stream %d", pcount, sp->packet_count + 1, sp->socket);
+		fprintf(stderr, "OUT OF ORDER - incoming packet sequence %" PRIu64 " but expected sequence %" PRIu64 " on stream %d", pcount, sp->packet_count + 1, sp->socket);
 	}
 
 	/*


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
* #1534

* Brief description of code changes (suitable for use as a commit message):

Make all variables related to UDP packets numbers and related calculations `int64_t`.  Although `--udp-counters-64bit` options allows UDP packet number to be larger than 2^32 bits, several of these related variables were defined as `int` which is 32 nits in several environments.  Note that `int64_t` is used and not `uint64_t` to keep sign compatibility with the replaced `int` (assuming that the 63 bits limit is large enough).

In addition, `report_bw_udp/report_sum_bw_udp...` definitions in `iperf_locale.c` were changed to use `%PRIu64` instead of `%d` when printing packets counts.   Note that the related `reportCSV_bw_udp_format` was **not** changed, as I am not sure how it is used.

