### PR TITLE
Support printing signed JSON Number

### DIFF
--- a/src/cjson.c
+++ b/src/cjson.c
@@ -99,6 +99,13 @@
 #  else
 #   define PRIu64		"llu"
 #  endif
+# ifndef PRId64
+#  if sizeof(long) == 8
+#   define PRId64		"ld"
+#  else
+#   define PRId64		"lld"
+#  endif
+# endif
 # endif
 #endif
 
@@ -588,7 +595,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     }
     else if(d == (double)item->valueint)
     {
-        length = sprintf((char*)number_buffer, "%" PRIu64, item->valueint);
+        length = sprintf((char*)number_buffer, "%" PRId64, item->valueint);
     }
     else
     {


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):
#1435

* Brief description of code changes (suitable for use as a commit message):
Changed `PRIu64` to `PRId64` in JSON `print_number()`, as the numbers in `struct cJSON` are signed.
