### PR TITLE
Retry server connection using other address type

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -995,6 +995,41 @@ iperf_on_test_finish(struct iperf_test *test)
 {
 }
 
+/*
+ * iperf_hostname_type  indicate whether a string formatted as "<addr>[%<device>]" is an
+ * IPv4 address, IPv6 address or other.  Return value:
+ *   4/6: hostname is IPv4/IPv6 addr.
+ *   0: other address type (probably FQDN)
+ *  -1: error
+ */
+int
+iperf_hostname_type(struct iperf_test *test, char *hostname) {
+    struct in6_addr ipv6_addr;
+    struct in_addr ipv4_addr;
+    char *phost = hostname;
+    int ret = 0;
+
+    // Format is <addr>[%<device>]
+    if ((phost = strdup(hostname)) == NULL) {
+        ret = -1;
+    } else {
+        strtok(phost, "%"); // remove "%" postfix part
+
+        // Determine address type
+        if (inet_pton(AF_INET6, phost, &ipv6_addr) == 1) {
+            ret = 6; // IPv6 address
+        } else if (inet_pton(AF_INET, phost, &ipv4_addr) == 1) {
+            ret = 4; // IPv4 address
+        }
+        
+        free(phost);
+    }
+
+    if (test->debug_level >= DEBUG_LEVEL_INFO) {
+        iperf_printf(test, "Hostname address type=%d\n", ret);
+    }
+    return ret;
+}
 
 /******************************************************************************/
 

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -332,6 +332,7 @@ int set_protocol(struct iperf_test *, int);
 void iperf_on_new_stream(struct iperf_stream *);
 void iperf_on_test_start(struct iperf_test *);
 void iperf_on_connect(struct iperf_test *);
+int iperf_hostname_type(struct iperf_test *test, char *hostname);
 void iperf_on_test_finish(struct iperf_test *);
 
 extern jmp_buf env;

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -364,6 +364,7 @@ iperf_connect(struct iperf_test *test)
 {
     int opt;
     socklen_t len;
+    int i;
 
     if (NULL == test)
     {
@@ -376,12 +377,32 @@ iperf_connect(struct iperf_test *test)
     make_cookie(test->cookie);
 
     /* Create and connect the control channel */
-    if (test->ctrl_sck < 0)
+    if (test->ctrl_sck < 0) {
 	// Create the control channel using an ephemeral port
 	test->ctrl_sck = netdial(test->settings->domain, Ptcp, test->bind_address, test->bind_dev, 0, test->server_hostname, test->server_port, test->settings->connect_timeout);
+    }
     if (test->ctrl_sck < 0) {
-        i_errno = IECONNECT;
-        return -1;
+        if (errno == ECONNREFUSED && test->settings->domain == AF_UNSPEC) {
+            // Retry connection using the other IPv6/IPv4 addr type if hostname is not specific IP address
+            if (iperf_hostname_type(test, test->server_hostname) == 0 &&
+               (test->ctrl_sck == -4 || test->ctrl_sck == -6))
+            {
+                if (test->verbose) {
+                    i = (test->ctrl_sck == -4) ? 6 : 4;
+                    iperf_printf(test, report_retry_after_connect_refused, i, -test->ctrl_sck);
+                }
+ 
+                if (test->ctrl_sck == -4)
+                    test->settings->domain = AF_INET6;
+                else
+                    test->settings->domain = AF_INET;
+                test->ctrl_sck = netdial(test->settings->domain, Ptcp, test->bind_address, test->bind_dev, 0, test->server_hostname, test->server_port, test->settings->connect_timeout);
+            }
+        }
+        if (test->ctrl_sck < 0) {
+            i_errno = IECONNECT;
+            return -1;
+        }
     }
 
     // set TCP_NODELAY for lower latency on control messages

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -461,6 +461,9 @@ const char report_sender_not_available_summary_format[] = "[%3s] (sender statist
 const char report_receiver_not_available_format[] = "[%3d] (receiver statistics not available)\n";
 const char report_receiver_not_available_summary_format[] = "[%3s] (receiver statistics not available)\n";
 
+const char report_retry_after_connect_refused[] =
+"Retry connecting to the server forcing IPv%d addr type, after connection refused with addr type IPv%d\n";
+
 #if defined(linux)
 const char report_tcpInfo[] =
 "event=TCP_Info CWND=%u SND_SSTHRESH=%u RCV_SSTHRESH=%u UNACKED=%u SACK=%u LOST=%u RETRANS=%u FACK=%u RTT=%u REORDERING=%u\n";

--- a/src/iperf_locale.h
+++ b/src/iperf_locale.h
@@ -110,6 +110,7 @@ extern const char report_receiver_not_available_summary_format[];
 extern const char report_tcpInfo[] ;
 extern const char report_tcpInfo[] ;
 
+extern const char report_retry_after_connect_refused[] ;
 
 extern const char warn_window_requested[] ;
 extern const char warn_window_small[] ;

--- a/src/net.c
+++ b/src/net.c
@@ -228,12 +228,17 @@ create_socket(int domain, int proto, const char *local, const char *bind_dev, in
     return s;
 }
 
-/* make connection to server */
+/* Make connection to server.
+ *
+ * Returns:
+ *   On success: socket number.
+ *   On failure: -4 / -6 if tried to connect useing IPv4 / IPv6 address, otherwise -1.
+*/
 int
 netdial(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, int timeout)
 {
     struct addrinfo *server_res = NULL;
-    int s, saved_errno;
+    int s, saved_errno, ret;
 
     s = create_socket(domain, proto, local, bind_dev, local_port, server, port, &server_res);
     if (s < 0) {
@@ -242,10 +247,19 @@ netdial(int domain, int proto, const char *local, const char *bind_dev, int loca
 
     if (timeout_connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen, timeout) < 0 && errno != EINPROGRESS) {
 	saved_errno = errno;
+
+        // Set failure return value per the addr-family that was tried.
+        if (server_res->ai_family == AF_INET)
+            ret = -4;
+        else if (server_res->ai_family == AF_INET6)
+            ret = -6;
+        else
+            ret = -1;
+
 	close(s);
 	freeaddrinfo(server_res);
 	errno = saved_errno;
-        return -1;
+        return ret;
     }
 
     freeaddrinfo(server_res);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #1558

* Brief description of code changes (suitable for use as a commit message):

Suggested enhancement per discussion #1558 - when connection to the server fails on "connection refused" while using IPv4/IPv6 address type, retry with the other address type (IPv6/IPv4).  This is done only when the server address is a hostname and `-4` or `-6` options are not used.  The first address used is per the address returned by `getaddrinfo()` (called by `netdial() -> create_socket()`).

Note that per the [getaddreinfo() man page](https://man7.org/linux/man-pages/man3/getaddrinfo.3.html): "AF_UNSPEC indicates that getaddrinfo() should return socket addresses for any address family (either IPv4 or IPv6, for example) that can be used with node and service".  At least in my WSL machine only the IPv4 address is returned.  This is why the retry in done in `iperf_connect()`.
