### PR TITLE
Add support to detect packet corruption

### DIFF
--- a/configure
+++ b/configure
@@ -15099,6 +15099,67 @@ then :
 fi
 
 
+# Check for phread support
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing pthread_create" >&5
+printf %s "checking for library containing pthread_create... " >&6; }
+if test ${ac_cv_search_pthread_create+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char pthread_create ();
+int
+main (void)
+{
+return pthread_create ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' pthread
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_pthread_create=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_pthread_create+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_pthread_create+y}
+then :
+
+else $as_nop
+  ac_cv_search_pthread_create=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_pthread_create" >&5
+printf "%s\n" "$ac_cv_search_pthread_create" >&6; }
+ac_res=$ac_cv_search_pthread_create
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+
 ac_config_files="$ac_config_files Makefile src/Makefile src/version.h examples/Makefile iperf3.spec"
 
 cat >confcache <<\_ACEOF

--- a/configure
+++ b/configure
@@ -15038,6 +15038,67 @@ then :
 fi
 
 
+# Check for shm_open support
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing shm_open" >&5
+printf %s "checking for library containing shm_open... " >&6; }
+if test ${ac_cv_search_shm_open+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char shm_open ();
+int
+main (void)
+{
+return shm_open ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' rt
+do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_search_shm_open=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext
+  if test ${ac_cv_search_shm_open+y}
+then :
+  break
+fi
+done
+if test ${ac_cv_search_shm_open+y}
+then :
+
+else $as_nop
+  ac_cv_search_shm_open=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_shm_open" >&5
+printf "%s\n" "$ac_cv_search_shm_open" >&6; }
+ac_res=$ac_cv_search_shm_open
+if test "$ac_res" != no
+then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+
 ac_config_files="$ac_config_files Makefile src/Makefile src/version.h examples/Makefile iperf3.spec"
 
 cat >confcache <<\_ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -322,5 +322,8 @@ AC_CHECK_FUNCS([clock_gettime])
 # Check for shm_open support
 AC_SEARCH_LIBS(shm_open, [rt])
 
+# Check for phread support
+AC_SEARCH_LIBS(pthread_create, [pthread])
+
 AC_CONFIG_FILES([Makefile src/Makefile src/version.h examples/Makefile iperf3.spec])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -319,5 +319,8 @@ AC_SEARCH_LIBS(clock_gettime, [rt posix4])
 # Check for clock_gettime support
 AC_CHECK_FUNCS([clock_gettime])
 
+# Check for shm_open support
+AC_SEARCH_LIBS(shm_open, [rt])
+
 AC_CONFIG_FILES([Makefile src/Makefile src/version.h examples/Makefile iperf3.spec])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,7 +43,9 @@ libiperf_la_SOURCES     = \
                         timer.h \
                         units.c \
                         units.h \
-                        version.h
+                        version.h \
+                        ring.c \
+                        ring.h
 
 # Specify the sources and various flags for the iperf binary
 iperf3_SOURCES          = main.c

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -150,7 +150,7 @@ am_libiperf_la_OBJECTS = cjson.lo iperf_api.lo iperf_error.lo \
 	iperf_auth.lo iperf_client_api.lo iperf_locale.lo \
 	iperf_server_api.lo iperf_tcp.lo iperf_udp.lo iperf_sctp.lo \
 	iperf_util.lo iperf_time.lo dscp.lo net.lo tcp_info.lo \
-	timer.lo units.lo
+	timer.lo units.lo ring.lo
 libiperf_la_OBJECTS = $(am_libiperf_la_OBJECTS)
 AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
@@ -169,7 +169,7 @@ am__iperf3_profile_SOURCES_DIST = main.c cjson.c cjson.h flowlabel.h \
 	iperf_udp.h iperf_sctp.c iperf_sctp.h iperf_util.c \
 	iperf_util.h iperf_time.c iperf_time.h dscp.c net.c net.h \
 	portable_endian.h queue.h tcp_info.c timer.c timer.h units.c \
-	units.h version.h
+	units.h version.h ring.c ring.h
 am__objects_1 = iperf3_profile-cjson.$(OBJEXT) \
 	iperf3_profile-iperf_api.$(OBJEXT) \
 	iperf3_profile-iperf_error.$(OBJEXT) \
@@ -184,7 +184,8 @@ am__objects_1 = iperf3_profile-cjson.$(OBJEXT) \
 	iperf3_profile-iperf_time.$(OBJEXT) \
 	iperf3_profile-dscp.$(OBJEXT) iperf3_profile-net.$(OBJEXT) \
 	iperf3_profile-tcp_info.$(OBJEXT) \
-	iperf3_profile-timer.$(OBJEXT) iperf3_profile-units.$(OBJEXT)
+	iperf3_profile-timer.$(OBJEXT) iperf3_profile-units.$(OBJEXT) \
+	iperf3_profile-ring.$(OBJEXT)
 @ENABLE_PROFILING_TRUE@am_iperf3_profile_OBJECTS =  \
 @ENABLE_PROFILING_TRUE@	iperf3_profile-main.$(OBJEXT) \
 @ENABLE_PROFILING_TRUE@	$(am__objects_1)
@@ -255,6 +256,7 @@ am__depfiles_remade = ./$(DEPDIR)/cjson.Plo ./$(DEPDIR)/dscp.Plo \
 	./$(DEPDIR)/iperf3_profile-iperf_util.Po \
 	./$(DEPDIR)/iperf3_profile-main.Po \
 	./$(DEPDIR)/iperf3_profile-net.Po \
+	./$(DEPDIR)/iperf3_profile-ring.Po \
 	./$(DEPDIR)/iperf3_profile-tcp_info.Po \
 	./$(DEPDIR)/iperf3_profile-timer.Po \
 	./$(DEPDIR)/iperf3_profile-units.Po ./$(DEPDIR)/iperf_api.Plo \
@@ -263,11 +265,11 @@ am__depfiles_remade = ./$(DEPDIR)/cjson.Plo ./$(DEPDIR)/dscp.Plo \
 	./$(DEPDIR)/iperf_sctp.Plo ./$(DEPDIR)/iperf_server_api.Plo \
 	./$(DEPDIR)/iperf_tcp.Plo ./$(DEPDIR)/iperf_time.Plo \
 	./$(DEPDIR)/iperf_udp.Plo ./$(DEPDIR)/iperf_util.Plo \
-	./$(DEPDIR)/net.Plo ./$(DEPDIR)/t_api-t_api.Po \
-	./$(DEPDIR)/t_auth-t_auth.Po ./$(DEPDIR)/t_timer-t_timer.Po \
-	./$(DEPDIR)/t_units-t_units.Po ./$(DEPDIR)/t_uuid-t_uuid.Po \
-	./$(DEPDIR)/tcp_info.Plo ./$(DEPDIR)/timer.Plo \
-	./$(DEPDIR)/units.Plo
+	./$(DEPDIR)/net.Plo ./$(DEPDIR)/ring.Plo \
+	./$(DEPDIR)/t_api-t_api.Po ./$(DEPDIR)/t_auth-t_auth.Po \
+	./$(DEPDIR)/t_timer-t_timer.Po ./$(DEPDIR)/t_units-t_units.Po \
+	./$(DEPDIR)/t_uuid-t_uuid.Po ./$(DEPDIR)/tcp_info.Plo \
+	./$(DEPDIR)/timer.Plo ./$(DEPDIR)/units.Plo
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -668,7 +670,9 @@ libiperf_la_SOURCES = \
                         timer.h \
                         units.c \
                         units.h \
-                        version.h
+                        version.h \
+                        ring.c \
+                        ring.h
 
 
 # Specify the sources and various flags for the iperf binary
@@ -909,6 +913,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-iperf_util.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-main.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-net.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-ring.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-tcp_info.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-timer.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf3_profile-units.Po@am__quote@ # am--include-marker
@@ -924,6 +929,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf_udp.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/iperf_util.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/net.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ring.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/t_api-t_api.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/t_auth-t_auth.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/t_timer-t_timer.Po@am__quote@ # am--include-marker
@@ -1225,6 +1231,20 @@ iperf3_profile-units.obj: units.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='units.c' object='iperf3_profile-units.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -c -o iperf3_profile-units.obj `if test -f 'units.c'; then $(CYGPATH_W) 'units.c'; else $(CYGPATH_W) '$(srcdir)/units.c'; fi`
+
+iperf3_profile-ring.o: ring.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -MT iperf3_profile-ring.o -MD -MP -MF $(DEPDIR)/iperf3_profile-ring.Tpo -c -o iperf3_profile-ring.o `test -f 'ring.c' || echo '$(srcdir)/'`ring.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/iperf3_profile-ring.Tpo $(DEPDIR)/iperf3_profile-ring.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='ring.c' object='iperf3_profile-ring.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -c -o iperf3_profile-ring.o `test -f 'ring.c' || echo '$(srcdir)/'`ring.c
+
+iperf3_profile-ring.obj: ring.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -MT iperf3_profile-ring.obj -MD -MP -MF $(DEPDIR)/iperf3_profile-ring.Tpo -c -o iperf3_profile-ring.obj `if test -f 'ring.c'; then $(CYGPATH_W) 'ring.c'; else $(CYGPATH_W) '$(srcdir)/ring.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/iperf3_profile-ring.Tpo $(DEPDIR)/iperf3_profile-ring.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='ring.c' object='iperf3_profile-ring.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(iperf3_profile_CFLAGS) $(CFLAGS) -c -o iperf3_profile-ring.obj `if test -f 'ring.c'; then $(CYGPATH_W) 'ring.c'; else $(CYGPATH_W) '$(srcdir)/ring.c'; fi`
 
 t_api-t_api.o: t_api.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(t_api_CFLAGS) $(CFLAGS) -MT t_api-t_api.o -MD -MP -MF $(DEPDIR)/t_api-t_api.Tpo -c -o t_api-t_api.o `test -f 't_api.c' || echo '$(srcdir)/'`t_api.c
@@ -1752,6 +1772,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_util.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-main.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-net.Po
+	-rm -f ./$(DEPDIR)/iperf3_profile-ring.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-tcp_info.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-timer.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-units.Po
@@ -1767,6 +1788,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/iperf_udp.Plo
 	-rm -f ./$(DEPDIR)/iperf_util.Plo
 	-rm -f ./$(DEPDIR)/net.Plo
+	-rm -f ./$(DEPDIR)/ring.Plo
 	-rm -f ./$(DEPDIR)/t_api-t_api.Po
 	-rm -f ./$(DEPDIR)/t_auth-t_auth.Po
 	-rm -f ./$(DEPDIR)/t_timer-t_timer.Po
@@ -1838,6 +1860,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/iperf3_profile-iperf_util.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-main.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-net.Po
+	-rm -f ./$(DEPDIR)/iperf3_profile-ring.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-tcp_info.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-timer.Po
 	-rm -f ./$(DEPDIR)/iperf3_profile-units.Po
@@ -1853,6 +1876,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/iperf_udp.Plo
 	-rm -f ./$(DEPDIR)/iperf_util.Plo
 	-rm -f ./$(DEPDIR)/net.Plo
+	-rm -f ./$(DEPDIR)/ring.Plo
 	-rm -f ./$(DEPDIR)/t_api-t_api.Po
 	-rm -f ./$(DEPDIR)/t_auth-t_auth.Po
 	-rm -f ./$(DEPDIR)/t_timer-t_timer.Po

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -338,6 +338,7 @@ struct iperf_test
 
     /* Interval related members */
     int       omitting;
+    int       corrupt_packets;
     double    stats_interval;
     double    reporter_interval;
     void      (*stats_callback) (struct iperf_test *);

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -328,6 +328,7 @@ struct iperf_test
     int	      multisend;
     int	      repeating_payload;                /* --repeating-payload */
     int       integrity_check;                  /* --integrity-check */
+    pthread_t worker_thread;                    /* worker thread for packet integrity check*/
     int       timestamps;			/* --timestamps */
     char     *timestamp_format;
 

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -327,6 +327,7 @@ struct iperf_test
     int       forceflush; /* --forceflush - flushing output at every interval */
     int	      multisend;
     int	      repeating_payload;                /* --repeating-payload */
+    int       integrity_check;                  /* --integrity-check */
     int       timestamps;			/* --timestamps */
     char     *timestamp_format;
 

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -296,6 +296,7 @@ struct iperf_test
 
     char     *logfile;				/* --logfile option */
     FILE     *outfile;
+    FILE     *corrupt_outfile;
 
     int       ctrl_sck;
     int       mapped_v4;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3141,6 +3141,7 @@ iperf_reset_test(struct iperf_test *test)
 	test->reporter_timer = NULL;
     }
     test->done = 0;
+    test->corrupt_packets = 0;
 
     SLIST_INIT(&test->streams);
 

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -294,6 +294,12 @@ iperf_get_test_bind_port(struct iperf_test *ipt)
 }
 
 int
+iperf_get_test_integrity_check(struct iperf_test *ipt)
+{
+    return ipt->integrity_check;
+}
+
+int
 iperf_get_test_server_port(struct iperf_test *ipt)
 {
     return ipt->server_port;
@@ -576,6 +582,12 @@ void
 iperf_set_test_repeating_payload(struct iperf_test *ipt, int repeating_payload)
 {
     ipt->repeating_payload = repeating_payload;
+}
+
+void
+iperf_set_test_integrity_check(struct iperf_test *ipt, int integrity_check)
+{
+    ipt->integrity_check = integrity_check;
 }
 
 void
@@ -1095,6 +1107,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         {"omit", required_argument, NULL, 'O'},
         {"file", required_argument, NULL, 'F'},
         {"repeating-payload", no_argument, NULL, OPT_REPEATING_PAYLOAD},
+        {"integrity-check", no_argument, NULL, OPT_INTEGRITY_CHECK},
         {"timestamps", optional_argument, NULL, OPT_TIMESTAMPS},
 #if defined(HAVE_CPU_AFFINITY)
         {"affinity", required_argument, NULL, 'A'},
@@ -1458,6 +1471,10 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
             case OPT_REPEATING_PAYLOAD:
                 test->repeating_payload = 1;
                 client_flag = 1;
+                break;
+            case OPT_INTEGRITY_CHECK:
+                test->integrity_check = 1;
+                server_flag = 1;
                 break;
             case OPT_TIMESTAMPS:
                 iperf_set_test_timestamps(test, 1);
@@ -2229,6 +2246,8 @@ send_parameters(struct iperf_test *test)
 	    cJSON_AddNumberToObject(j, "udp_counters_64bit", iperf_get_test_udp_counters_64bit(test));
 	if (test->repeating_payload)
 	    cJSON_AddNumberToObject(j, "repeating_payload", test->repeating_payload);
+	if (test->integrity_check)
+	    cJSON_AddNumberToObject(j, "integrity_check", test->integrity_check);
 	if (test->zerocopy)
 	    cJSON_AddNumberToObject(j, "zerocopy", test->zerocopy);
 #if defined(HAVE_DONT_FRAGMENT)
@@ -2345,6 +2364,8 @@ get_parameters(struct iperf_test *test)
 	    iperf_set_test_udp_counters_64bit(test, 1);
 	if ((j_p = cJSON_GetObjectItem(j, "repeating_payload")) != NULL)
 	    test->repeating_payload = 1;
+	if ((j_p = cJSON_GetObjectItem(j, "integrity_check")) != NULL)
+	    test->integrity_check = 1;
 	if ((j_p = cJSON_GetObjectItem(j, "zerocopy")) != NULL)
 	    test->zerocopy = j_p->valueint;
 #if defined(HAVE_DONT_FRAGMENT)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -479,6 +479,9 @@ extern uint8_t magic_word[4];
 
 /* Packet integrity check */
 int iperf_packet_integrity_check(struct iperf_test *test, uint8_t* payload, int len);
+void iperf_corrupt_err(struct iperf_test *test, const char *format, ...) __attribute__ ((format(printf,2,3)));
+void iperf_report_corrupt_stat(struct iperf_test *test, int corrupt_packets);
+void iperf_dump_payload(struct iperf_test *test, uint8_t* payload, int len);
 
 #ifdef __cplusplus
 } /* close extern "C" */

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -270,7 +270,7 @@ void      iperf_free_test(struct iperf_test * testp);
  * returns NULL on failure
  *
  */
-struct iperf_stream *iperf_new_stream(struct iperf_test *, int, int);
+struct iperf_stream *iperf_new_stream(struct iperf_test *, int, int, int);
 
 /**
  * iperf_add_stream -- add a stream to a test
@@ -471,6 +471,11 @@ enum {
     IEUPDATETIMER = 301,    // Unable to update timer (check perror)
 };
 
+extern uint8_t magic_word[4];
+// Magic word + the first 2 bytes
+#define INTEGRITY_PKT_FLOW_INDEX  4
+#define INTEGRITY_PKT_DATA_INDEX  5
+#define INTEGRITY_PKT_MIN_LEN     sizeof(magic_word) + 2
 
 #ifdef __cplusplus
 } /* close extern "C" */

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -90,6 +90,7 @@ typedef uint64_t iperf_size_t;
 #define OPT_DONT_FRAGMENT 26
 #define OPT_RCV_TIMEOUT 27
 #define OPT_SND_TIMEOUT 28
+#define OPT_INTEGRITY_CHECK 29
 
 /* states */
 #define TEST_START 1
@@ -131,6 +132,7 @@ double	iperf_get_test_reporter_interval( struct iperf_test* ipt );
 double	iperf_get_test_stats_interval( struct iperf_test* ipt );
 int	iperf_get_test_num_streams( struct iperf_test* ipt );
 int	iperf_get_test_repeating_payload( struct iperf_test* ipt );
+int	iperf_get_test_integrity_check( struct iperf_test* ipt );
 int	iperf_get_test_timestamps( struct iperf_test* ipt );
 const char* iperf_get_test_timestamp_format( struct iperf_test* ipt );
 int	iperf_get_test_bind_port( struct iperf_test* ipt );
@@ -177,6 +179,7 @@ void	iperf_set_test_server_port( struct iperf_test* ipt, int server_port );
 void	iperf_set_test_socket_bufsize( struct iperf_test* ipt, int socket_bufsize );
 void	iperf_set_test_num_streams( struct iperf_test* ipt, int num_streams );
 void	iperf_set_test_repeating_payload( struct iperf_test* ipt, int repeating_payload );
+void	iperf_set_test_integrity_check( struct iperf_test* ipt, int integrity_check );
 void	iperf_set_test_timestamps( struct iperf_test* ipt, int timestamps );
 void	iperf_set_test_timestamp_format( struct iperf_test*, const char *tf );
 void	iperf_set_test_role( struct iperf_test* ipt, char role );

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -477,6 +477,9 @@ extern uint8_t magic_word[4];
 #define INTEGRITY_PKT_DATA_INDEX  5
 #define INTEGRITY_PKT_MIN_LEN     sizeof(magic_word) + 2
 
+/* Packet integrity check */
+int iperf_packet_integrity_check(struct iperf_test *test, uint8_t* payload, int len);
+
 #ifdef __cplusplus
 } /* close extern "C" */
 #endif

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -121,7 +121,7 @@ iperf_create_streams(struct iperf_test *test, int sender)
 	    FD_SET(s, &test->read_set);
 	if (s > test->max_fd) test->max_fd = s;
 
-        sp = iperf_new_stream(test, s, sender);
+        sp = iperf_new_stream(test, s, sender, i);
         if (!sp)
             return -1;
 

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -148,6 +148,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 			   "                            (optional slash and number of secs interval for averaging\n"
 			   "                            total data rate.  Default is 5 seconds)\n"
                            "  --idle-timeout #          restart idle server after # seconds in case it\n"
+                           "  --integrity-check         turn on packet integrity check, in order to do this,\n"
+                           "                            client needs to use repeating pattern \n"
                            "                            got stuck (default - no timeout)\n"
 #if defined(HAVE_SSL)
                            "  --rsa-private-key-path    path to the RSA private key used to decrypt\n"

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -703,7 +703,7 @@ iperf_run_server(struct iperf_test *test)
                         }
 
                         if (flag != -1) {
-                            sp = iperf_new_stream(test, s, flag);
+                            sp = iperf_new_stream(test, s, flag, send_streams_accepted);
                             if (!sp) {
                                 cleanup_server(test);
                                 return -1;

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -43,6 +43,7 @@
 #include "iperf_tcp.h"
 #include "net.h"
 #include "cjson.h"
+#include "ring.h"
 
 #if defined(HAVE_FLOWLABEL)
 #include "flowlabel.h"
@@ -66,6 +67,9 @@ iperf_tcp_recv(struct iperf_stream *sp)
     if (sp->test->state == TEST_RUNNING) {
 	sp->result->bytes_received += r;
 	sp->result->bytes_received_this_interval += r;
+        if (sp->test->integrity_check) {
+		    enqueue_packet_ring(sp->buffer, r);
+        }
     }
     else {
 	if (sp->test->debug)

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -48,6 +48,7 @@
 #include "net.h"
 #include "cjson.h"
 #include "portable_endian.h"
+#include "ring.h"
 
 #if defined(HAVE_INTTYPES_H)
 # include <inttypes.h>
@@ -122,6 +123,10 @@ iperf_udp_recv(struct iperf_stream *sp)
 	    sent_time.secs = sec;
 	    sent_time.usecs = usec;
 	}
+
+    if (sp->test->integrity_check) {
+		enqueue_packet_ring(sp->buffer, r);
+    }
 
 	if (sp->test->debug_level >= DEBUG_LEVEL_DEBUG)
 	    fprintf(stderr, "pcount %" PRIu64 " packet_count %" PRIu64 "\n", pcount, sp->packet_count);

--- a/src/iperf_util.h
+++ b/src/iperf_util.h
@@ -34,7 +34,7 @@
 
 int readentropy(void *out, size_t outsize);
 
-void fill_with_repeating_pattern(void *out, size_t outsize);
+void fill_with_repeating_pattern(void *out, size_t outsize, int index, int offset);
 
 void make_cookie(char *);
 

--- a/src/ring.c
+++ b/src/ring.c
@@ -1,0 +1,91 @@
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include "ring.h"
+#include "iperf.h"
+#include "iperf_api.h"
+
+static PacketRing packetring;
+
+static bool is_ring_empty()
+{
+    int cur_rd_index = atomic_load(&packetring.rd_index);
+    int next_rd_index = (cur_rd_index + 1) % packetring.ring_size;
+
+    if (next_rd_index == atomic_load(&packetring.wt_index)) {
+        return true;
+    }
+
+    return false;
+}
+
+void init_packet_ring()
+{
+    packetring.ring_size = RING_SIZE;
+    atomic_init(&packetring.rd_index, 0);
+    atomic_init(&packetring.wt_index, 0);
+    sem_init(&packetring.doorbell, 0, 0);
+
+    for (int i = 1; i < RING_SIZE; i++) {
+        packetring.entries[i].cap = BUF_SIZE;
+        packetring.entries[i].size = 0;
+    }
+}
+
+void enqueue_packet_ring(void* data, size_t size)
+{
+    int remain = size;
+    int offset = 0;
+    int cur_wt_index;
+    int next_wt_index;
+    PacketEntry* wt_entry;
+
+    // If the ring was empty, ring the doorbell.
+    if (is_ring_empty()) {
+        sem_post(&packetring.doorbell);
+    }
+
+    while (remain > 0) {
+        do {
+            cur_wt_index = atomic_load(&packetring.wt_index);
+            next_wt_index = (cur_wt_index + 1) % packetring.ring_size;
+            if (next_wt_index == atomic_load(&packetring.rd_index))
+                // Ring is full, can't keep on processing, throw away the data
+                return;
+            } while (!atomic_compare_exchange_weak(&packetring.wt_index, &cur_wt_index, next_wt_index));
+
+            wt_entry = &packetring.entries[cur_wt_index];
+            wt_entry->size = remain > wt_entry->cap ? wt_entry->cap : remain;
+            memcpy(wt_entry->buf, data + offset, wt_entry->size);
+
+            remain -= wt_entry->size;
+            offset += wt_entry->size;
+    }
+}
+
+void dequeue_packet_ring(struct iperf_test* test, packet_ring_func func)
+{
+    int is_corrupted;
+    int cur_rd_index;
+    int next_rd_index;
+    PacketEntry* rd_entry;
+
+    do {
+        cur_rd_index = atomic_load(&packetring.rd_index);
+        next_rd_index = (cur_rd_index + 1) % packetring.ring_size;
+        if (next_rd_index == atomic_load(&packetring.wt_index)) {
+            // Ring is empty, wait for doorbell
+            sem_wait(&packetring.doorbell);	
+        }
+    } while (!atomic_compare_exchange_weak(&packetring.rd_index, &cur_rd_index, next_rd_index));
+
+    rd_entry = &packetring.entries[cur_rd_index];
+
+    is_corrupted = func(test, rd_entry->buf, rd_entry->size);
+    if (is_corrupted) {
+        test->corrupt_packets++;
+        iperf_report_corrupt_stat(test, test->corrupt_packets);
+        iperf_dump_payload(test, rd_entry->buf, rd_entry->size);
+    }
+}

--- a/src/ring.h
+++ b/src/ring.h
@@ -1,0 +1,44 @@
+#ifndef _RING_H_
+#define _RING_H_
+
+#include <sys/types.h>
+#include <inttypes.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdatomic.h>
+#include <semaphore.h>
+#include "queue.h"
+#include "iperf.h"
+
+#define BUF_SIZE 9001 /* Maximum size for a buffer */
+#define RING_SIZE 10000
+
+typedef struct Packet_Entry {
+	size_t size;
+	size_t cap;
+	uint8_t buf[BUF_SIZE];
+} PacketEntry;
+
+typedef struct Packet_Ring {
+	atomic_int rd_index;
+	atomic_int wt_index;
+	sem_t doorbell;
+	size_t ring_size;
+	PacketEntry entries[RING_SIZE];
+} PacketRing;
+
+struct iperf_test;
+
+typedef int (*packet_ring_func) (struct iperf_test *test, uint8_t* payload, int len);
+
+
+void init_packet_ring();
+void enqueue_packet_ring(void* data, size_t size);
+void dequeue_packet_ring(struct iperf_test *, packet_ring_func func);
+
+#endif


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

In this patch, add support to detect packet corruption during test. In order to enable this feature, the receiver has to enable the new option `--integrity-check`. 

The idea is to let the sender sends out known payload, which we use 1 byte to identify the flow, and the other byte to identify the data sequence.  Receiver check the payload pattern and report corruption when detects unexpected payload.

In order to not causing huge performance dip, receiver use a worker thread to check packet, worker thread and receiver thread uses a very simple lockless ring to transfer packet. 