### PR TITLE
Add --enable-openbsd-sandbox to use pledge and unveil

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -319,5 +319,11 @@ AC_SEARCH_LIBS(clock_gettime, [rt posix4])
 # Check for clock_gettime support
 AC_CHECK_FUNCS([clock_gettime])
 
+AC_ARG_ENABLE([openbsd-sandbox],
+    AS_HELP_STRING([--enable-openbsd-sandox], [Enable pledge and unveil support]))
+if test "x$enable_openbsd_sandbox" = "xyes"; then
+    AC_DEFINE(OPENBSD_SANDBOX, 1, [Define if openbsd sandboxing is enabled])
+fi
+
 AC_CONFIG_FILES([Makefile src/Makefile src/version.h examples/Makefile iperf3.spec])
 AC_OUTPUT

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -57,6 +57,9 @@
  */
 int readentropy(void *out, size_t outsize)
 {
+#ifdef OPENBSD_SANDBOX
+    arc4random_buf(out, outsize);
+#else
     static FILE *frandom;
     static const char rndfile[] = "/dev/urandom";
 
@@ -75,6 +78,7 @@ int readentropy(void *out, size_t outsize)
                       rndfile,
                       feof(frandom) ? "EOF" : strerror(errno));
     }
+#endif
     return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,15 @@ main(int argc, char **argv)
 {
     struct iperf_test *test;
 
+#ifdef OPENBSD_SANDBOX
+    int needfs = 0;
+
+    if (pledge("stdio tmppath rpath cpath wpath inet dns unveil", NULL) == -1) {
+	fprintf(stderr, "pledge: %s\n", strerror(errno));
+	exit(1);
+    }
+#endif
+
     // XXX: Setting the process affinity requires root on most systems.
     //      Is this a feature we really need?
 #ifdef TEST_PROC_AFFINITY
@@ -104,6 +113,45 @@ main(int argc, char **argv)
         usage();
         exit(1);
     }
+
+#ifdef OPENBSD_SANDBOX
+    /* Check for options which require filesystem access */
+    if (test->diskfile_name) {
+	if (unveil(test->diskfile_name, "crw") == -1) {
+	    /* XXX read for client, write for server */
+	    fprintf(stderr, "unveil diskfile: %s\n", strerror(errno));
+	    exit(1);
+	}
+	needfs = 1;
+    }
+
+    if (test->pidfile) {
+	if (unveil(test->pidfile, "cw") == -1) {
+	    fprintf(stderr, "unveil pidfile: %s\n", strerror(errno));
+	    exit(1);
+	}
+	needfs = 1;
+    }
+
+    if (test->logfile) {
+	if (unveil(test->logfile, "cwr") == -1) {
+	    fprintf(stderr, "unveil logfile: %s\n", strerror(errno));
+	    exit(1);
+	}
+	needfs = 1;
+    }
+
+    /* Drop filesystem access if we can, otherwise lock unveil */
+    if (needfs == 0) {
+	if (pledge("stdio tmppath inet dns", NULL) == -1) {
+	    fprintf(stderr, "pledge !needfs: %s\n", strerror(errno));
+	    exit(1);
+	}
+    } else if (pledge("stdio tmppath rpath cpath wpath inet dns", NULL) == -1) {
+	fprintf(stderr, "pledge needfs: %s\n", strerror(errno));
+	exit(1);
+    }
+#endif
 
     if (run(test) < 0)
         iperf_errexit(test, "error - %s", iperf_strerror(i_errno));


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

Iperf3 sometimes runs on publicly available unfirewalled servers, because clients use dynamic IPs. This patch introduces "--enable-openbsd-sandbox" configure option to use pledge and unveil. The calls are OpenBSD mechanism to limit syscalls and filesystem access, this is intended to raise security level of the system.

This is original patch with some additions from Stuart Henderson:
https://marc.info/?l=openbsd-ports&m=169766440629899&w=2

Regen of auto-stuff is required.