### PR TITLE
Disallow specifying both -b and --fq-rate together.

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -418,6 +418,7 @@ enum {
     IESNDTIMEOUT = 33,      // Illegal message send timeout
     IEUDPFILETRANSFER = 34, // Cannot transfer file using UDP
     IESERVERAUTHUSERS = 35,   // Cannot access authorized users file
+    IERATEFQRATE = 36,      // Cannot specify both -b and --fq-rate
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2022, The Regents of the University of
+ * iperf, Copyright (c) 2014-2023, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -197,6 +197,9 @@ iperf_strerror(int int_errno)
             break;
         case IESERVERAUTHUSERS:
              snprintf(errstr, len, "cannot access authorized users file");
+            break;
+        case IERATEFQRATE:
+             snprintf(errstr, len, "-b and --fq-rate cannot be specified together");
             break;
 	case IEBADFORMAT:
 	    snprintf(errstr, len, "bad format specifier (valid formats are in the set [kmgtKMGT])");


### PR DESCRIPTION
Closes #1597.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): #1597 

* Brief description of code changes (suitable for use as a commit message):

Don't allow both `--b` / `--bitrate` and `--fq-rate` to be specified in the same invocation of iperf3.
