### PR TITLE
Add `--json-immediate` option.

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -339,6 +339,7 @@ struct iperf_test
     int       bidirectional;                    /* --bidirectional */
     int	      verbose;                          /* -V option - verbose mode */
     int	      json_output;                      /* -J option - JSON output */
+    int       json_immediate;                   /* --json-immediate - output JSON every interval */
     int	      zerocopy;                         /* -Z option - use sendfile */
     int       debug;				/* -d option - enable debug */
     enum      debug_level debug_level;          /* -d option option - level of debug messages to show */

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -101,6 +101,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_DONT_FRAGMENT 26
 #define OPT_RCV_TIMEOUT 27
 #define OPT_SND_TIMEOUT 28
+#define OPT_JSON_IMMEDIATE 29
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -126,6 +126,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #endif /* HAVE_SO_BINDTODEVICE */
                            "  -V, --verbose             more detailed output\n"
                            "  -J, --json                output in JSON format\n"
+                           "  --json-immediate          output JSON every interval (implies -J)\n"
                            "  --logfile f               send output to a log file\n"
                            "  --forceflush              force flushing output at every interval\n"
                            "  --timestamps<=format>     emit a timestamp at the start of each output line\n"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): This addresses #444, though possibly not as the filer intended.

* Brief description of code changes (suitable for use as a commit message):

This change adds a new boolean flag, `--json-immediate`.  This flag has three effects:
* It implies `--json/-J` even if it is not also set.
* It causes the JSON output to be printed without whitespace formatting, so that a complete JSON structure appears on one output line.
* It causes the JSON structure for each interval to be printed out at the end of that interval.  The usual JSON output is still printed at the end of the test.

The motivation is, as requested in #444, to provide machine-readable output in real time.