### PR TITLE
Correct format specifier for printing int64_t

### DIFF
--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -84,11 +84,11 @@
 #if defined(HAVE_INTTYPES_H)
 # include <inttypes.h>
 #else
-# ifndef PRIu64
+# ifndef PRId64
 #  if sizeof(long) == 8
-#   define PRIu64		"lu"
+#   define PRId64		"ld"
 #  else
-#   define PRIu64		"llu"
+#   define PRId64		"lld"
 #  endif
 # endif
 #endif
@@ -394,13 +394,13 @@ const char report_bw_retrans_cwnd_format[] =
 "[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %3u   %ss       %s\n";
 
 const char report_bw_udp_format[] =
-"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %" PRIu64 "/%" PRIu64 " (%.2g%%)  %s\n";
+"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %" PRId64 "/%" PRId64 " (%.2g%%)  %s\n";
 
 const char report_bw_udp_format_no_omitted_error[] =
-"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  Unknown/%" PRIu64 "  %s\n";
+"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  Unknown/%" PRId64 "  %s\n";
 
 const char report_bw_udp_sender_format[] =
-"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %" PRIu64 "  %s\n";
+"[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %" PRId64 "  %s\n";
 
 const char report_summary[] =
 "Test Complete. Summary Results:\n";
@@ -412,10 +412,10 @@ const char report_sum_bw_retrans_format[] =
 "[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %3d             %s\n";
 
 const char report_sum_bw_udp_format[] =
-"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %" PRIu64 "/%" PRIu64 " (%.2g%%)  %s\n";
+"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec  %5.3f ms  %" PRId64 "/%" PRId64 " (%.2g%%)  %s\n";
 
 const char report_sum_bw_udp_sender_format[] =
-"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %" PRIu64 "  %s\n";
+"[SUM]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %" PRId64 "  %s\n";
 
 const char report_omitted[] = "(omitted)";
 


### PR DESCRIPTION
Version: iperf 3.16-beta1
OS: fedora 35

Negative packet loss (out of order packet) results in large positive packet loss count (percentage value is correct though).
The problem is unsigned format specifier when printing out UDP results.

```
-----------------------------------------------------------
Server listening on 5201 (test #2)
-----------------------------------------------------------
Accepted connection from 192.168.10.2, port 53474
[  5] local 192.168.10.1 port 5201 connected to 192.168.10.2 port 39361
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-5.00   sec   631 KBytes  1.03 Mbits/sec  25.143 ms  2/448 (0.45%)  
[  5]   5.00-10.00  sec   641 KBytes  1.05 Mbits/sec  22.475 ms  18446744073709551614/451 (-0.44%)  
[  5]  10.00-15.00  sec   642 KBytes  1.05 Mbits/sec  24.487 ms  1/455 (0.22%)  
[  5]  15.00-20.00  sec   639 KBytes  1.05 Mbits/sec  23.750 ms  0/452 (0%)  
[  5]  20.00-25.00  sec   641 KBytes  1.05 Mbits/sec  19.466 ms  18446744073709551615/452 (-0.22%)  
[  5]  25.00-30.00  sec   641 KBytes  1.05 Mbits/sec  30.371 ms  0/453 (0%)
```

Commands:
iperf3 -s -i 5
iperf3 -c 192.168.10.1 -u -i 5

Testing:
Simulated out of order packets with netem (high jitter). Fix seems to be working fine.

