### PR TITLE
Check and link libatomic if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,19 @@ CXX="$PTHREAD_CXX"
 ])
 
 # Atomics
-AC_CHECK_HEADERS([stdatomic.h])
+AC_CHECK_HEADERS([stdatomic.h],
+    [AC_MSG_CHECKING([whether libatomic is required])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdatomic.h>]], [[atomic_uint_fast64_t i; i++;]])],
+        [AC_MSG_RESULT([no])],
+        [save_LIBS="$LIBS"
+        LIBS="$LIBS -latomic"
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdatomic.h>]], [[atomic_uint_fast64_t i; i++;]])],
+            [AC_MSG_RESULT([yes])],
+            [AC_MSG_ERROR([failed to find working configuration with atomics])]
+        )]
+    )],
+    []
+)
 
 # Check for poll.h (it's in POSIX so everyone should have it?)
 AC_CHECK_HEADERS([poll.h])


### PR DESCRIPTION

* Version of iperf3 to which this pull request applies: `3.16`

* Issues fixed (if any): Fixes #1611

* Brief description of code changes (suitable for use as a commit message):

Some architectures without native support for 64-bit atomics need linking with libatomic.
