### PR TITLE
Fix --affinity help text

### DIFF
--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -115,7 +115,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -I, --pidfile file        write PID file\n"
                            "  -F, --file name           xmit/recv the specified file\n"
 #if defined(HAVE_CPU_AFFINITY)
-                           "  -A, --affinity n/n,m      set CPU affinity\n"
+                           "  -A, --affinity n[,m]      set CPU affinity core number to n (the core the process will use)\n"
+                          "                             (optional Client only m - the Server's core number for this test)\n"
 #endif /* HAVE_CPU_AFFINITY */
 #if defined(HAVE_SO_BINDTODEVICE)
                            "  -B, --bind <host>[%%<dev>] bind to the interface associated with the address <host>\n"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): Based on [this comment](https://github.com/esnet/iperf/issues/1588#issuecomment-1793403462).

* Brief description of code changes (suitable for use as a commit message):
Suggested change to the `--affinity` help text, as per the code the values it accepts is `n[,m]` and not `n/n,m`.

