### PR TITLE
Free descriptor when force exit from function 

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -129,6 +129,7 @@ iperf_tcp_accept(struct iperf_test * test)
 
     if (Nread(s, cookie, COOKIE_SIZE, Ptcp) < 0) {
         i_errno = IERECVCOOKIE;
+        close(s);
         return -1;
     }
 


### PR DESCRIPTION
* Development branch: master

* Issues fixed: free resource descriptor

* Brief description of code changes: free descriptor when force exit from function to avoid descriptor leak(CWE-403).