### PR TITLE
Fix descriptor leak in some return paths

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -309,6 +309,7 @@ iperf_tcp_listen(struct iperf_test *test)
 
         if (listen(s, INT_MAX) < 0) {
             i_errno = IESTREAMLISTEN;
+            close(s);
             return -1;
         }
 
@@ -329,6 +330,7 @@ iperf_tcp_listen(struct iperf_test *test)
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > sndbuf_actual) {
 	i_errno = IESETBUF2;
+    close(s);
 	return -1;
     }
 
@@ -346,6 +348,7 @@ iperf_tcp_listen(struct iperf_test *test)
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > rcvbuf_actual) {
 	i_errno = IESETBUF2;
+    close(s);
 	return -1;
     }
 


### PR DESCRIPTION
* Development branch: master

* Issues fixed: descriptor leak

* Brief description of code changes: close socket `s` in some cases when force return from function.