### PR TITLE
Define SIZE_OF_LONG_INT to replace sizeof(long) in #if

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,16 @@ else
     fi
 fi
 
+# Get the size of long int
+AC_CACHE_CHECK([Size of long int],
+[iperf3_cv_sizeof_long],
+AC_RUN_IFELSE(
+  [AC_LANG_PROGRAM([[#include <stdio.h>]],
+                   [[fprintf(stderr, "%d", sizeof(long)); return(0)]])],
+  [iperf3_cv_sizeof_long=`./conftest$EXEEXT 2>&1`],
+  [AC_MSG_ERROR(Failed to compile and run size of long test)]))
+AC_DEFINE_UNQUOTED([SIZE_OF_LONG_INT], $iperf3_cv_sizeof_long, [Size of long int.])
+
 # Check for TCP_CONGESTION sockopt (believed to be Linux and FreeBSD only)
 AC_CACHE_CHECK([TCP_CONGESTION socket option],
 [iperf3_cv_header_tcp_congestion],

--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ AC_CACHE_CHECK([Size of long int],
 [iperf3_cv_sizeof_long],
 AC_RUN_IFELSE(
   [AC_LANG_PROGRAM([[#include <stdio.h>]],
-                   [[fprintf(stderr, "%d", sizeof(long)); return(0)]])],
+                   [[fprintf(stderr, "%zd", sizeof(long)); return(0)]])],
   [iperf3_cv_sizeof_long=`./conftest$EXEEXT 2>&1`],
   [AC_MSG_ERROR(Failed to compile and run size of long test)]))
 AC_DEFINE_UNQUOTED([SIZE_OF_LONG_INT], $iperf3_cv_sizeof_long, [Size of long int.])

--- a/src/cjson.c
+++ b/src/cjson.c
@@ -94,13 +94,13 @@
 # include <inttypes.h>
 #else
 # ifndef PRIu64
-#  if sizeof(long) == 8
+#  if SIZE_OF_LONG_INT == 8
 #   define PRIu64		"lu"
 #  else
 #   define PRIu64		"llu"
 #  endif
 # ifndef PRId64
-#  if sizeof(long) == 8
+#  if SIZE_OF_LONG_INT == 8
 #   define PRId64		"ld"
 #  else
 #   define PRId64		"lld"

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -55,7 +55,7 @@
 # include <inttypes.h>
 #else
 # ifndef PRIu64
-#  if sizeof(long) == 8
+#  if SIZE_OF_LONG_INT == 8
 #   define PRIu64		"lu"
 #  else
 #   define PRIu64		"llu"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -85,7 +85,7 @@
 # include <inttypes.h>
 #else
 # ifndef PRId64
-#  if sizeof(long) == 8
+#  if SIZE_OF_LONG_INT == 8
 #   define PRId64		"ld"
 #  else
 #   define PRId64		"lld"

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -52,7 +52,7 @@
 # include <inttypes.h>
 #else
 # ifndef PRIu64
-#  if sizeof(long) == 8
+#  if SIZE_OF_LONG_INT == 8
 #   define PRIu64		"lu"
 #  else
 #   define PRIu64		"llu"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

Define SIZE_OF_LONG_INT by `./config.ac` with the value of `sizeof(long)` (required running  ./bootstrap; ./configuration).  This is to fix [the issue](https://github.com/esnet/iperf/commit/ff458b2e736ad301ae82624f08742165255671bd#r136874913) identified by @yumkam that `sizeof()` is not valid for the preprocessor in `#if`.

