### PR TITLE
Make use of arc4random_buf()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,9 @@ AC_CHECK_FUNCS([sendfile])
 # connections.
 AC_CHECK_FUNCS([getline])
 
+# Check for arc4random_buf().
+AC_CHECK_FUNCS([arc4random_buf])
+
 # Check for packet pacing socket option (Linux only for now).
 AC_CACHE_CHECK([SO_MAX_PACING_RATE socket option],
 [iperf3_cv_header_so_max_pacing_rate],

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -51,12 +51,15 @@
 #include "iperf_api.h"
 
 /*
- * Read entropy from /dev/urandom
+ * Read entropy using arc4random_buf() if exists, otherwise from /dev/urandom
  * Errors are fatal.
  * Returns 0 on success.
  */
 int readentropy(void *out, size_t outsize)
 {
+#ifdef HAVE_ARC4RANDOM_BUF
+    arc4random_buf(out, outsize);
+#else
     static FILE *frandom;
     static const char rndfile[] = "/dev/urandom";
 
@@ -75,6 +78,7 @@ int readentropy(void *out, size_t outsize)
                       rndfile,
                       feof(frandom) ? "EOF" : strerror(errno));
     }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
Make use of arc4random_buf() if it exists. Supported on
FreeBSD/NetBSD/OpenBSD/Solaris/Linux/Android.