### PR TITLE
Fix --rcv-timeout manual text

### DIFF
--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -194,7 +194,7 @@ the executable.
           --rcv-timeout #
                  set idle timeout for receiving data  during  active  tests.  The
                  receiver will halt a test if no data is received from the sender
-                 for this number of ms (default to 12000 ms, or 2 minutes).
+                 for this number of ms (default to 120000 ms, or 2 minutes).
    
           --snd-timeout #
                  set timeout for unacknowledged TCP data (on both test  and  con-

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -183,7 +183,7 @@ follow the \fB--timestamps\fR option with no whitespace intervening.
 .BR --rcv-timeout " \fI#\fR"
 set idle timeout for receiving data during active tests. The receiver
 will halt a test if no data is received from the sender for this
-number of ms (default to 12000 ms, or 2 minutes).
+number of ms (default to 120000 ms, or 2 minutes).
 .TP
 .BR --snd-timeout " \fI#\fR"
 set timeout for unacknowledged TCP data (on both test and control


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message): Correct the default value in ms from `12000` to `120000`. Source of truth: https://github.com/esnet/iperf/blob/master/src/iperf_api.h#L71
