### PR TITLE
late unlink file

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4428,12 +4428,6 @@ iperf_new_stream(struct iperf_test *test, int s, int sender)
         free(sp);
         return NULL;
     }
-    if (unlink(template) < 0) {
-        i_errno = IECREATESTREAM;
-        free(sp->result);
-        free(sp);
-        return NULL;
-    }
     if (ftruncate(sp->buffer_fd, test->settings->blksize) < 0) {
         i_errno = IECREATESTREAM;
         free(sp->result);
@@ -4448,6 +4442,13 @@ iperf_new_stream(struct iperf_test *test, int s, int sender)
         return NULL;
     }
     sp->pending_size = 0;
+
+    if (unlink(template) < 0) {
+        i_errno = IECREATESTREAM;
+        free(sp->result);
+        free(sp);
+        return NULL;
+    }
 
     /* Set socket */
     sp->socket = s;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):
https://github.com/esnet/iperf/issues/1644

* Brief description of code changes (suitable for use as a commit message):
unlink file after ftruncate to avoid “no such file or directory”
