### PR TITLE
minor error message correction for openssl includes

### DIFF
--- a/config/ax_check_openssl.m4
+++ b/config/ax_check_openssl.m4
@@ -75,7 +75,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
     if ! $found; then
         OPENSSL_INCLUDES=
         for ssldir in $ssldirs; do
-            AC_MSG_CHECKING([for openssl/ssl.h in $ssldir])
+            AC_MSG_CHECKING([for include/openssl/ssl.h in $ssldir])
             if test -f "$ssldir/include/openssl/ssl.h"; then
                 OPENSSL_INCLUDES="-I$ssldir/include"
                 OPENSSL_LDFLAGS="-L$ssldir/lib"

--- a/configure
+++ b/configure
@@ -15513,8 +15513,8 @@ fi
     if ! $found; then
         OPENSSL_INCLUDES=
         for ssldir in $ssldirs; do
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for openssl/ssl.h in $ssldir" >&5
-printf %s "checking for openssl/ssl.h in $ssldir... " >&6; }
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for include/openssl/ssl.h in $ssldir" >&5
+printf %s "checking for include/openssl/ssl.h in $ssldir... " >&6; }
             if test -f "$ssldir/include/openssl/ssl.h"; then
                 OPENSSL_INCLUDES="-I$ssldir/include"
                 OPENSSL_LDFLAGS="-L$ssldir/lib"

--- a/configure
+++ b/configure
@@ -15513,8 +15513,8 @@ fi
     if ! $found; then
         OPENSSL_INCLUDES=
         for ssldir in $ssldirs; do
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for include/openssl/ssl.h in $ssldir" >&5
-printf %s "checking for include/openssl/ssl.h in $ssldir... " >&6; }
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for openssl/ssl.h in $ssldir" >&5
+printf %s "checking for openssl/ssl.h in $ssldir... " >&6; }
             if test -f "$ssldir/include/openssl/ssl.h"; then
                 OPENSSL_INCLUDES="-I$ssldir/include"
                 OPENSSL_LDFLAGS="-L$ssldir/lib"


### PR DESCRIPTION
* Version of iperf3:
master

* Issues fixed (if any):
minor confusion during build debugging

* Brief description of code changes (suitable for use as a commit message):
Just matching the error message to what the test is actually doing.

