### PR TITLE
Add pthread missing functions in Android

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,6 +33,8 @@ libiperf_la_SOURCES     = \
                         iperf_util.h \
                         iperf_time.c \
                         iperf_time.h \
+                        iperf_pthread.c \
+                        iperf_pthread.h \
 			dscp.c \
                         net.c \
                         net.h \

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -74,9 +74,7 @@
 #include <openssl/evp.h>
 #endif // HAVE_SSL
 
-#ifdef HAVE_PTHREAD
-#include <pthread.h>
-#endif // HAVE_PTHREAD
+#include "iperf_pthread.h"
 
 /*
  * Atomic types highly desired, but if not, we approximate what we need

--- a/src/iperf_pthread.c
+++ b/src/iperf_pthread.c
@@ -1,0 +1,40 @@
+#include "iperf_config.h"
+
+#if defined(HAVE_PTHREAD) && defined(__ANDROID__)
+
+/* Workaround for `pthread_cancel()` in Android, using `pthread_kill()` instead,
+ * as Android NDK does not support `pthread_cancel()`.
+ */
+
+#include <signal.h>
+#include "iperf_pthread.h"
+
+int pthread_setcanceltype(int type, int *oldtype) { return 0; }
+int pthread_setcancelstate(int state, int *oldstate) { return 0; }
+int pthread_cancel(pthread_t thread_id) {
+    int status;
+    if ((status = iperf_set_thread_exit_handler()) == 0) {
+        status = pthread_kill(thread_id, SIGUSR1);
+    }
+    return status;
+}
+
+void iperf_thread_exit_handler(int sig)
+{ 
+    pthread_exit(0);
+}
+
+int iperf_set_thread_exit_handler() {
+    int rc;
+    struct sigaction actions;
+
+    memset(&actions, 0, sizeof(actions)); 
+    sigemptyset(&actions.sa_mask);
+    actions.sa_flags = 0; 
+    actions.sa_handler = iperf_thread_exit_handler;
+
+    rc = sigaction(SIGUSR1, &actions, NULL);
+    return rc;
+}
+
+#endif // defined(HAVE_PTHREAD) && defined(__ANDROID__)

--- a/src/iperf_pthread.h
+++ b/src/iperf_pthread.h
@@ -1,0 +1,21 @@
+#include "iperf_config.h"
+
+#if defined(HAVE_PTHREAD)
+
+#include <pthread.h>
+
+#if defined(__ANDROID__)
+
+/* Adding missing `pthread` related definitions in Android.
+ */
+
+#define PTHREAD_CANCEL_ASYNCHRONOUS 0
+#define PTHREAD_CANCEL_ENABLE NULL
+
+int pthread_setcanceltype(int type, int *oldtype);
+int pthread_setcancelstate(int state, int *oldstate);
+int pthread_cancel(pthread_t thread_id);
+
+#endif // defined(__ANDROID__)
+
+#endif // defined(HAVE_PTHREAD)


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1641

* Brief description of code changes (suitable for use as a commit message):

Add the related pthread functions that are missing in Android.  This is instead of the current practice to makes changes to the source files before building for Android  (see for example [here](https://github.com/davidBar-On/android-iperf3), which is the source for the changes).

The changes should not impact a build for any other OS, as the added/modified code in under `#ifdef __ANDROID__`.

Note that the PR includes two new files, so configure (and bootstrap?) is needed (this is why the automatic checks fail).

