### PR TITLE
Stop a test if one of the threads terminated because of an error

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -208,7 +208,6 @@ struct iperf_stream
     struct iperf_test* test;
 
     pthread_t thr;
-    int thread_created;
     int       done;
 
     /* configurable members */
@@ -216,6 +215,7 @@ struct iperf_stream
     int       remote_port;
     int       socket;
     int       id;
+    int       thread_number;
     int       sender;
 	/* XXX: is settings just a pointer to the same struct in iperf_test? if not,
 		should it be? */

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -5034,6 +5034,7 @@ iperf_new_stream(struct iperf_test *test, int s, int sender)
         goto err_exit_close_buffer;
     }
     sp->pending_size = 0;
+    sp->thread_number = 0;
 
     /* Set socket */
     sp->socket = s;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -508,6 +508,7 @@ enum {
     IESETCNTLKACOUNT = 158,    // Unable to set/get socket keepalive TCP number of retries (TCP_KEEPCNT) option
     IEPTHREADSIGMASK=159,      // Unable to initialize sub thread signal mask (check perror)
     IESERVERTESTDURATIONEXPIRED = 160, // Server test duration expired
+    IEPTHREADNOTRUNNING=161,    // A thread stopped running unexpectedly
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -52,6 +52,10 @@
 #endif /* TCP_CA_NAME_MAX */
 #endif /* HAVE_TCP_CONGESTION */
 
+// variable for number of active threads count (for checking if any failed)
+static volatile int running_threads = 0;
+static pthread_mutex_t running_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 void *
 iperf_client_worker_run(void *s) {
     struct iperf_stream *sp = (struct iperf_stream *) s;
@@ -93,6 +97,15 @@ iperf_client_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
+    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet by the main thread
+        pthread_mutex_lock(&running_mutex);
+        running_threads--;  // Indicate that the thread failed
+        pthread_mutex_unlock(&running_mutex);
+        // Error message is printed to NULL test to prevent adding JSON output context into the thread context
+        iperf_err(NULL, "Client Worker Thread %d FD %d failed - %s", sp->thread_number, sp->socket, iperf_strerror(i_errno));
+        if (test->ctrl_sck != -1) iflush(test);
+    }
+
     return NULL;
 }
 
@@ -609,6 +622,7 @@ iperf_run_client(struct iperf_test * test)
     int64_t timeout_us;
     int64_t rcv_timeout_us;
     int i_errno_save;
+    int total_num_streams = 0;
 
     if (NULL == test)
     {
@@ -742,14 +756,22 @@ iperf_run_client(struct iperf_test * test)
                     goto cleanup_and_fail;
                 }
 
+                pthread_mutex_lock(&running_mutex);
+                running_threads = 0;
+                total_num_streams = 0;
+                pthread_mutex_unlock(&running_mutex);
                 SLIST_FOREACH(sp, &test->streams, streams) {
                     if (pthread_create(&(sp->thr), &attr, &iperf_client_worker_run, sp) != 0) {
                         i_errno = IEPTHREADCREATE;
                         goto cleanup_and_fail;
                     }
-                    sp->thread_created = 1;
+                    pthread_mutex_lock(&running_mutex);
+                    running_threads++; // Count running threads
+                    sp->thread_number = running_threads;
+                    pthread_mutex_unlock(&running_mutex);
+                    total_num_streams++;
                     if (test->debug_level >= DEBUG_LEVEL_INFO) {
-                        iperf_printf(test, "Thread FD %d created\n", sp->socket);
+                        iperf_printf(test, "Thread number %d using FD %d created\n", sp->thread_number, sp->socket);
                     }
                 }
                 if (test->debug_level >= DEBUG_LEVEL_INFO) {
@@ -800,25 +822,28 @@ iperf_run_client(struct iperf_test * test)
                     if (sp->sender) {
                         int rc;
                         sp->done = 1;
-                        if (sp->thread_created == 1) {
+                        if (sp->thread_number > 0) { // if thread was created
                             rc = pthread_cancel(sp->thr);
                             if (rc != 0 && rc != ESRCH) {
                                 i_errno = IEPTHREADCANCEL;
                                 errno = rc;
-                                iperf_err(test, "sender cancel in pthread_cancel - %s", iperf_strerror(i_errno));
+                                iperf_err(test, "sender cancel in pthread_cancel of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
                                 goto cleanup_and_fail;
                             }
                             rc = pthread_join(sp->thr, NULL);
                             if (rc != 0 && rc != ESRCH) {
                                 i_errno = IEPTHREADJOIN;
                                 errno = rc;
-                                iperf_err(test, "sender cancel in pthread_join - %s", iperf_strerror(i_errno));
+                                iperf_err(test, "sender cancel in pthread_join of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
                                 goto cleanup_and_fail;
                             }
                             if (test->debug_level >= DEBUG_LEVEL_INFO) {
-                                iperf_printf(test, "Thread FD %d stopped\n", sp->socket);
+                                iperf_printf(test, "Thread number %d FD %d stopped\n", sp->thread_number, sp->socket);
                             }
-                            sp->thread_created = 0;
+                            sp->thread_number = 0;
+                        } else {
+                            if (test->debug_level >= DEBUG_LEVEL_INFO)
+                                iperf_printf(test, "Not stopping thread for FD %d as it was not created or failed\n", sp->socket);
                         }
                     }
                 }
@@ -833,6 +858,14 @@ iperf_run_client(struct iperf_test * test)
 		if (iperf_set_send_state(test, TEST_END) != 0)
                     goto cleanup_and_fail;
 	    }
+
+            /* Terminate if one of the threads failed */
+            if (running_threads != total_num_streams) {
+                i_errno = IEPTHREADNOTRUNNING;
+                iperf_err(test, "Number of running threads is %d but expected %d", running_threads, test->num_streams);
+                goto cleanup_and_fail;
+            }
+
 	}
     }
 
@@ -841,25 +874,28 @@ iperf_run_client(struct iperf_test * test)
         if (!sp->sender) {
             int rc;
             sp->done = 1;
-            if (sp->thread_created == 1) {
+            if (sp->thread_number > 0) { // if thread was created
                 rc = pthread_cancel(sp->thr);
                 if (rc != 0 && rc != ESRCH) {
                     i_errno = IEPTHREADCANCEL;
                     errno = rc;
-                    iperf_err(test, "receiver cancel in pthread_cancel - %s", iperf_strerror(i_errno));
+                    iperf_err(test, "receiver cancel in pthread_cancel of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
                     goto cleanup_and_fail;
                 }
                 rc = pthread_join(sp->thr, NULL);
                 if (rc != 0 && rc != ESRCH) {
                     i_errno = IEPTHREADJOIN;
                     errno = rc;
-                    iperf_err(test, "receiver cancel in pthread_join - %s", iperf_strerror(i_errno));
+                    iperf_err(test, "receiver cancel in pthread_join of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
                     goto cleanup_and_fail;
                 }
                 if (test->debug_level >= DEBUG_LEVEL_INFO) {
-                    iperf_printf(test, "Thread FD %d stopped\n", sp->socket);
+                    iperf_printf(test, "Thread number %d FD %d stopped\n", sp->thread_number, sp->socket);
                 }
-                sp->thread_created = 0;
+                sp->thread_number = 0;
+            } else {
+                if (test->debug_level >= DEBUG_LEVEL_INFO)
+                    iperf_printf(test, "Not stopping thread for FD %d as it was not created or failed\n", sp->socket);
             }
         }
     }
@@ -888,23 +924,26 @@ iperf_run_client(struct iperf_test * test)
         }
         sp->done = 1;
         int rc;
-        if (sp->thread_created == 1) {
+        if (sp->thread_number > 0) { // if thread was created
             rc = pthread_cancel(sp->thr);
             if (rc != 0 && rc != ESRCH) {
                 i_errno = IEPTHREADCANCEL;
                 errno = rc;
-                iperf_err(test, "cleanup_and_fail in pthread_cancel - %s", iperf_strerror(i_errno));
+                iperf_err(test, "cleanup_and_fail in pthread_cancel of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
             }
             rc = pthread_join(sp->thr, NULL); 
             if (rc != 0 && rc != ESRCH) {
                 i_errno = IEPTHREADJOIN;
                 errno = rc;
-                iperf_err(test, "cleanup_and_fail in pthread_join - %s", iperf_strerror(i_errno));
+                iperf_err(test, "cleanup_and_fail in pthread_join of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
             }
             if (test->debug_level >= DEBUG_LEVEL_INFO) {
-                iperf_printf(test, "Thread FD %d stopped\n", sp->socket);
+                iperf_printf(test, "Thread number %d FD %d stopped\n", sp->thread_number, sp->socket);
             }
-            sp->thread_created = 0;
+            sp->thread_number = 0;
+        } else {
+            if (test->debug_level >= DEBUG_LEVEL_INFO)
+                iperf_printf(test, "Not stopping thread for FD %d as it was not created or failed\n", sp->socket);
         }
     }
     if (test->debug_level >= DEBUG_LEVEL_INFO) {

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -569,6 +569,10 @@ iperf_strerror(int int_errno)
         case IERVRSONLYSKIPRXCOPY:
             snprintf(errstr, len, "this OS does not support --skip-rx-copy");
             break;
+	case IEPTHREADNOTRUNNING:
+            snprintf(errstr, len, "a thread stopped running unexpectedly");
+            perr = 1;
+            break;
 	default:
             snprintf(errstr, len, "int_errno=%d", int_errno);
             perr = 1;

--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -66,7 +66,7 @@ iperf_sctp_recv(struct iperf_stream *sp)
 	sp->result->bytes_received_this_interval += r;
     }
     else {
-	if (sp->test->debug)
+	if (sp->test->debug_level >= DEBUG_LEVEL_DEBUG)
 	    printf("Late receive, state = %d\n", sp->test->state);
     }
 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -65,6 +65,10 @@
 #endif /* TCP_CA_NAME_MAX */
 #endif /* HAVE_TCP_CONGESTION */
 
+// variable for number of active threads count
+static volatile int running_threads = 0;
+static pthread_mutex_t running_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 void *
 iperf_server_worker_run(void *s) {
     struct iperf_stream *sp = (struct iperf_stream *) s;
@@ -106,6 +110,15 @@ iperf_server_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
+    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet by the main thread
+        pthread_mutex_lock(&running_mutex);
+        running_threads--;  // Indicate that the thread failed
+        pthread_mutex_unlock(&running_mutex);
+        // Error message is printed to NULL test to prevent adding JSON output context into the thread context
+        iperf_err(NULL, "Server Worker Thread %d FD %d failed - %s", sp->thread_number, sp->socket, iperf_strerror(i_errno));
+        if (test->ctrl_sck != -1) iflush(test);
+    }
+
     return NULL;
 }
 
@@ -478,23 +491,26 @@ cleanup_server(struct iperf_test *test)
     SLIST_FOREACH(sp, &test->streams, streams) {
         int rc;
         sp->done = 1;
-        if (sp->thread_created == 1) {
+        if (sp->thread_number > 0) { // if thread was created
             rc = pthread_cancel(sp->thr);
             if (rc != 0 && rc != ESRCH) {
                 i_errno = IEPTHREADCANCEL;
                 errno = rc;
-                iperf_err(test, "cleanup_server in pthread_cancel - %s", iperf_strerror(i_errno));
+                iperf_err(test, "cleanup_server in pthread_cancel of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
             }
             rc = pthread_join(sp->thr, NULL);
             if (rc != 0 && rc != ESRCH) {
                 i_errno = IEPTHREADJOIN;
                 errno = rc;
-                iperf_err(test, "cleanup_server in pthread_join - %s", iperf_strerror(i_errno));
+                iperf_err(test, "cleanup_server in pthread_join of thread %d - %s", sp->thread_number, iperf_strerror(i_errno));
             }
             if (test->debug_level >= DEBUG_LEVEL_INFO) {
-                iperf_printf(test, "Thread FD %d stopped\n", sp->socket);
+                iperf_printf(test, "Thread number %d FD %d stopped\n", sp->thread_number, sp->socket);
             }
-            sp->thread_created = 0;
+            sp->thread_number = 0;
+        } else {
+            if (test->debug_level >= DEBUG_LEVEL_INFO)
+                iperf_printf(test, "Not stopping thread for FD %d as it was not created or failed\n", sp->socket);
         }
     }
     i_errno = i_errno_save;
@@ -574,6 +590,7 @@ iperf_run_server(struct iperf_test *test)
     int64_t timeout_us;
     int64_t rcv_timeout_us;
     int32_t err;
+    int total_num_streams = 0;
 
     if (test->logfile) {
         if (iperf_open_logfile(test) < 0)
@@ -957,15 +974,23 @@ iperf_run_server(struct iperf_test *test)
                         cleanup_server(test);
                     };
 
+                    pthread_mutex_lock(&running_mutex);
+                    running_threads = 0;
+                    total_num_streams = 0;
+                    pthread_mutex_unlock(&running_mutex);
                     SLIST_FOREACH(sp, &test->streams, streams) {
                         if (pthread_create(&(sp->thr), &attr, &iperf_server_worker_run, sp) != 0) {
                             i_errno = IEPTHREADCREATE;
                             cleanup_server(test);
                             return -1;
                         }
-                        sp->thread_created = 1;
+                        pthread_mutex_lock(&running_mutex);
+                        running_threads++; // Count running threads
+                        sp->thread_number = running_threads;
+                        pthread_mutex_unlock(&running_mutex);
+                        total_num_streams++;
                         if (test->debug_level >= DEBUG_LEVEL_INFO) {
-                            iperf_printf(test, "Thread FD %d created\n", sp->socket);
+                            iperf_printf(test, "Thread number %d FD %d created\n", sp->thread_number, sp->socket);
                         }
                     }
                     if (test->debug_level >= DEBUG_LEVEL_INFO) {
@@ -980,6 +1005,15 @@ iperf_run_server(struct iperf_test *test)
                     last_receive_blocks = test->blocks_received;
                     iperf_time_now(&last_receive_time);
                 }
+            }
+        }
+
+        /* Terminate if any thread failed */
+        if (test->state == TEST_RUNNING) {
+            if (running_threads != total_num_streams) {
+                i_errno = IEPTHREADNOTRUNNING;
+                iperf_err(test, "Number of running threads is %d but expected %d", running_threads, test->num_streams);
+                cleanup_server(test);
             }
         }
 

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -77,7 +77,7 @@ iperf_tcp_recv(struct iperf_stream *sp)
 	      sp->result->bytes_received_this_interval += r;
     }
     else {
-	      if (sp->test->debug)
+	      if (sp->test->debug_level >= DEBUG_LEVEL_DEBUG)
 	          printf("Late receive, state = %d-%s\n", sp->test->state, state_to_text(sp->test->state));
     }
 

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -232,8 +232,8 @@ iperf_udp_recv(struct iperf_stream *sp)
 	}
     }
     else {
-	if (test->debug_level >= DEBUG_LEVEL_INFO)
-	    printf("Late receive, state = %d\n", test->state);
+	if (sp->test->debug_level >= DEBUG_LEVEL_DEBUG)
+	    printf("Late receive, state = %d\n", sp->test->state);
     }
 
     return r;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1696

* Brief description of code changes (suitable for use as a commit message):

Suggested enhancement to terminate a test when one of the threads fail.  Currently, even with one thread that fails, iperf3 continues to run the test (and reports 0 bytes transferred).  The issue was detected while evaluating PR #1616.
UPDATE: Added  a fix for #1696 - try to cancel a stream's thread only if it was created.  This can happen if the client terminate before all threads for the streams where created. 

The suggest fix approach is that both the client and the server will keep a counter for the number of threads running, which is shared by all threads.  If a thread encounters an error, it subtract 1 from this counter before terminating.  The client/server main loop is checking whether the counter value equals the expected number of threads.

My initially approach was using `pthread_kill(thread, 0)` to check whether any of the streams threads terminated.  This is a more robust solution, since it also detects termination because of exceptions.  However, I thought the overhead of such check is too high.  I am not sure whether this is the case, since the check is done in the main thread.

