### PR TITLE
Assume we always have inttypes.h and stdint.h (both from C99)

### DIFF
--- a/examples/mic.c
+++ b/examples/mic.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 #include <iperf_api.h>
 

--- a/examples/mis.c
+++ b/examples/mis.c
@@ -4,9 +4,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 #include <iperf_api.h>
 

--- a/src/cjson.c
+++ b/src/cjson.c
@@ -45,9 +45,8 @@
 #include <limits.h>
 #include <ctype.h>
 #include <float.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
+#include <inttypes.h>
 #include <sys/types.h>
 
 #ifdef ENABLE_LOCALES
@@ -88,25 +87,6 @@
 #else
 #define NAN 0.0/0.0
 #endif
-#endif
-
-#if defined(HAVE_INTTYPES_H)
-# include <inttypes.h>
-#else
-# ifndef PRIu64
-#  if sizeof(long) == 8
-#   define PRIu64		"lu"
-#  else
-#   define PRIu64		"llu"
-#  endif
-# ifndef PRId64
-#  if sizeof(long) == 8
-#   define PRId64		"ld"
-#  else
-#   define PRId64		"lld"
-#  endif
-# endif
-# endif
 #endif
 
 typedef struct {

--- a/src/cjson.h
+++ b/src/cjson.h
@@ -23,9 +23,7 @@
 #ifndef cJSON__h
 #define cJSON__h
 
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 
 #ifdef __cplusplus
 extern "C"

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -31,9 +31,8 @@
 
 #include <sys/time.h>
 #include <sys/types.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
+#include <inttypes.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #ifndef _GNU_SOURCE
@@ -50,18 +49,6 @@
 #include <sys/param.h>
 #include <sys/cpuset.h>
 #endif /* HAVE_CPUSET_SETAFFINITY */
-
-#if defined(HAVE_INTTYPES_H)
-# include <inttypes.h>
-#else
-# ifndef PRIu64
-#  if sizeof(long) == 8
-#   define PRIu64		"lu"
-#  else
-#   define PRIu64		"llu"
-#  endif
-# endif
-#endif
 
 #include "timer.h"
 #include "queue.h"

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -46,9 +46,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/mman.h>

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -31,9 +31,7 @@
 #include <sys/time.h>
 #include <setjmp.h>
 #include <stdio.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #ifdef __cplusplus
 extern "C" { /* open extern "C" */
 #endif

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -81,17 +81,7 @@
 
 #include "version.h"
 
-#if defined(HAVE_INTTYPES_H)
-# include <inttypes.h>
-#else
-# ifndef PRId64
-#  if sizeof(long) == 8
-#   define PRId64		"ld"
-#  else
-#   define PRId64		"lld"
-#  endif
-# endif
-#endif
+#include <inttypes.h>
 
 #ifdef __cplusplus
 extern    "C"

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -40,9 +40,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sched.h>

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -34,9 +34,8 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <netinet/in.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
+#include <inttypes.h>
 #include <sys/time.h>
 #include <sys/select.h>
 
@@ -47,18 +46,6 @@
 #include "timer.h"
 #include "net.h"
 #include "cjson.h"
-
-#if defined(HAVE_INTTYPES_H)
-# include <inttypes.h>
-#else
-# ifndef PRIu64
-#  if sizeof(long) == 8
-#   define PRIu64		"lu"
-#  else
-#   define PRIu64		"llu"
-#  endif
-# endif
-#endif
 
 /* iperf_udp_recv
  *

--- a/src/main.c
+++ b/src/main.c
@@ -33,9 +33,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <unistd.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <netinet/in.h>

--- a/src/t_api.c
+++ b/src/t_api.c
@@ -27,9 +27,7 @@
 
 
 #include <assert.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <stdio.h>
 #include <string.h>
 

--- a/src/t_auth.c
+++ b/src/t_auth.c
@@ -27,9 +27,7 @@
 #include "iperf_config.h"
 
 #include <assert.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <stdio.h>
 #include <string.h>
 

--- a/src/t_timer.c
+++ b/src/t_timer.c
@@ -26,9 +26,7 @@
  */
 #include "iperf_config.h"
 
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/t_units.c
+++ b/src/t_units.c
@@ -25,9 +25,7 @@
  * file for complete information.
  */
 #include <assert.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <stdio.h>
 #include <string.h>
 

--- a/src/units.c
+++ b/src/units.c
@@ -54,9 +54,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <ctype.h>
-#ifdef HAVE_STDINT_H
 #include <stdint.h>
-#endif
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
This eliminates some compile-time tests that didn't really work as desired and aren't easy to fix. It also removes conditional compilation in a number of places.

Note that there were already instances of unconditionally including `<inttypes.h>` and `<stdint.h>` in the iperf3 source code, so in practice we had somehow already made this assumption.

Inspired by comments on PR #1636.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

