### PR TITLE
Add stat reporting interval to JSON .start.test_start

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -892,7 +892,7 @@ void
 iperf_on_test_start(struct iperf_test *test)
 {
     if (test->json_output) {
-	cJSON_AddItemToObject(test->json_start, "test_start", iperf_json_printf("protocol: %s  num_streams: %d  blksize: %d  omit: %d  duration: %d  bytes: %d  blocks: %d  reverse: %d  tos: %d  target_bitrate: %d bidir: %d fqrate: %d", test->protocol->name, (int64_t) test->num_streams, (int64_t) test->settings->blksize, (int64_t) test->omit, (int64_t) test->duration, (int64_t) test->settings->bytes, (int64_t) test->settings->blocks, test->reverse?(int64_t)1:(int64_t)0, (int64_t) test->settings->tos, (int64_t) test->settings->rate, (int64_t) test->bidirectional, (uint64_t) test->settings->fqrate));
+	cJSON_AddItemToObject(test->json_start, "test_start", iperf_json_printf("protocol: %s  num_streams: %d  blksize: %d  omit: %d  duration: %d  bytes: %d  blocks: %d  reverse: %d  tos: %d  target_bitrate: %d bidir: %d fqrate: %d interval: %f", test->protocol->name, (int64_t) test->num_streams, (int64_t) test->settings->blksize, (int64_t) test->omit, (int64_t) test->duration, (int64_t) test->settings->bytes, (int64_t) test->settings->blocks, test->reverse?(int64_t)1:(int64_t)0, (int64_t) test->settings->tos, (int64_t) test->settings->rate, (int64_t) test->bidirectional, (uint64_t) test->settings->fqrate, test->stats_interval));
     } else {
 	if (test->verbose) {
 	    if (test->settings->bytes)


### PR DESCRIPTION
* Version of iperf3: master

* Issues fixed (if any): Added `interval` to JSON output start.test_start as a floating point number

* Brief description of code changes (suitable for use as a commit message): Added `interval: %f` to JSON test_start printf with value `test->stats_interval`

Example output (master):
```
# iperf3 --client XXX --omit 0 --time 1 --json | jq .start.test_start
{
  "protocol": "TCP",
  "num_streams": 1,
  "blksize": 131072,
  "omit": 0,
  "duration": 1,
  "bytes": 0,
  "blocks": 0,
  "reverse": 0,
  "tos": 0,
  "target_bitrate": 0,
  "bidir": 0,
  "fqrate": 0
}
```

Example output (this PR):
```
# iperf3 --client XXX --omit 0 --time 1 --json | jq .start.test_start
{
  "protocol": "TCP",
  "num_streams": 1,
  "blksize": 131072,
  "omit": 0,
  "duration": 1,
  "bytes": 0,
  "blocks": 0,
  "reverse": 0,
  "tos": 0,
  "target_bitrate": 0,
  "bidir": 0,
  "fqrate": 0,
  "interval": 1
}