### PR TITLE
Not allow negative test duration

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1313,7 +1313,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 	        break;
             case 't':
                 test->duration = atoi(optarg);
-                if (test->duration > MAX_TIME) {
+                if (test->duration > MAX_TIME || test->duration < 0) {
                     i_errno = IEDURATION;
                     return -1;
                 }

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -166,7 +166,7 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "some option you are trying to set is client only");
             break;
         case IEDURATION:
-            snprintf(errstr, len, "test duration too long (maximum = %d seconds)", MAX_TIME);
+            snprintf(errstr, len, "test duration valid values are 0 to %d seconds", MAX_TIME);
             break;
         case IENUMSTREAMS:
             snprintf(errstr, len, "number of parallel streams too large (maximum = %d)", MAX_STREAMS);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master
* Issues fixed (if any): #1662

* Brief description of code changes (suitable for use as a commit message):

Make the test `duration` unsigned, to prevent the ability to set negative duration values.

Alternative, and maybe more standard, solution may be to change `duration` and the variables in `struct iperf_time` to `int64_t` (signed, instead of `uint32_t`), which is compatible with `struct timeval`.  I therefore added a check that the `period` option is not negative, although this is redundant when it is unsigned.

The issue itself was caused because of the following in `create_server_timers()`:
```c
    int max_rtt = 4; /* seconds */
    int state_transitions = 10; /* number of state transitions in iperf3 */
    .....
        test->timer = tmr_create(&now, server_timer_proc, cd, (test->duration + test->omit + grace_period) * SEC_TO_US, 0);
```
When period was -1 to -40, the `test->duration + test->omit + grace_period` calculation overflowed and caused the server to call `server_timer_proc()` within 0  to 39 seconds (depending on `duration`) and close all sockets to the client.

