### PR TITLE
Properly reset the --fq-rate parameter on the server between tests.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2022, The Regents of the University of
+ * iperf, Copyright (c) 2014-2024, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -3252,6 +3252,7 @@ iperf_reset_test(struct iperf_test *test)
     test->settings->socket_bufsize = 0;
     test->settings->blksize = DEFAULT_TCP_BLKSIZE;
     test->settings->rate = 0;
+    test->settings->fqrate = 0;
     test->settings->burst = 0;
     test->settings->mss = 0;
     test->settings->tos = 0;


### PR DESCRIPTION
Without this change, an --fq-rate setting would persist on the server, which could adversely slow down future --reverse tests. This bug was exposed by PR #1643, which allows --fq-rate to work on the server. One annoying side-effect of this bug was that GitHub Actions scripts were timing out and throwing errors.

Pet file copyright date while here.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): None

* Brief description of code changes (suitable for use as a commit message): See above.

