### PR TITLE
Don't chdir when becoming a daemon.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -154,7 +154,7 @@ run(struct iperf_test *test)
         case 's':
 	    if (test->daemon) {
 		int rc;
-		rc = daemon(0, 0);
+		rc = daemon(1, 0);
 		if (rc < 0) {
 		    i_errno = IEDAEMON;
 		    iperf_errexit(test, "error - %s", iperf_strerror(i_errno));


### PR DESCRIPTION
This fixes some non-intuitive behavior when using the iperf3 authentication feature, where iperf3 was able to use a relative path to locate the credentials file when being run "normally" but not if it was being run as a --daemon (the workaround was to use only absolute pathname arguments).

