### PR TITLE
Prevent server termination with JSON and remove redundant code with error

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4889,16 +4889,7 @@ iperf_json_finish(struct iperf_test *test)
         cJSON_Delete(test->json_top);
         test->json_top = NULL;
     }
-    // Get ASCII rendering of JSON structure.  Then make our
-    // own copy of it and return the storage that cJSON allocated
-    // on our behalf.  We keep our own copy around.
-    char *str = cJSON_Print(test->json_top);
-    if (str == NULL)
-	return -1;
-    test->json_output_string = strdup(str);
-    cJSON_free(str);
-    if (test->json_output_string == NULL)
-        return -1;
+
     if (test->json_stream) {
         cJSON *error = cJSON_GetObjectItem(test->json_top, "error");
         if (error) {

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -94,10 +94,6 @@ iperf_errexit(struct iperf_test *test, const char *format, ...)
     struct tm *ltm = NULL;
     char *ct = NULL;
 
-    if (pthread_mutex_lock(&(test->print_mutex)) != 0) {
-        perror("iperf_errexit: pthread_mutex_lock");
-    }
-
     /* Timestamp if requested */
     if (test != NULL && test->timestamps) {
 	time(&now);
@@ -113,7 +109,11 @@ iperf_errexit(struct iperf_test *test, const char *format, ...)
 	    cJSON_AddStringToObject(test->json_top, "error", str);
         }
 	iperf_json_finish(test);
-    } else
+    } else {
+        if (pthread_mutex_unlock(&(test->print_mutex)) != 0) {
+            perror("iperf_errexit: pthread_mutex_unlock");
+        }
+
 	if (test && test->outfile && test->outfile != stdout) {
 	    if (ct) {
 		fprintf(test->outfile, "%s", ct);
@@ -127,8 +127,9 @@ iperf_errexit(struct iperf_test *test, const char *format, ...)
 	    fprintf(stderr, "iperf3: %s\n", str);
 	}
 
-    if (pthread_mutex_unlock(&(test->print_mutex)) != 0) {
-        perror("iperf_errexit: pthread_mutex_unlock");
+        if (pthread_mutex_lock(&(test->print_mutex)) != 0) {
+            perror("iperf_errexit: pthread_mutex_lock");
+        }
     }
 
     va_end(argp);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1631

* Brief description of code changes (suitable for use as a commit message):

Fix to two issues when JSON is used, one of them caused **server termination**:

1. `iperf_errexit()` locked the mutex, but called `iperf_json_finish()` that also lock/unlock the mutex, so when the client terminated before the end of the test, the mutex unlock failed and the server terminated.
2. Removed a redundant code, which was probably forgotten after copying it some lines above.  The redundant code caused redundant client error when it terminated.
