### PR TITLE
Add Time Flag For The Iperf Server Process

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -312,6 +312,7 @@ struct iperf_test
     int       server_port;
     int       omit;                             /* duration of omit period (-O flag) */
     int       duration;                         /* total duration of test (-t flag) */
+    int       max_server_duration;               /* maximum possible duration of test as enforced by the server (--max-server-duration flag) */
     char     *diskfile_name;			/* -F option */
     int       affinity, server_affinity;	/* -A option */
 #if defined(HAVE_CPUSET_SETAFFINITY)

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -251,7 +251,7 @@ In one-off mode, this is the number of seconds the server will wait
 before exiting.
 .TP
 .BR --server-max-duration " "
-max time, in seconds, that an iperf client can run against the server.
+The maximum time, in seconds, that an iperf client can run against the server.
 When the sum of the client's time and omit values exceeds the max duration set by the server
 or the client's time value is 0, the measurement is rejected.
 .TP

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -250,6 +250,11 @@ Restart the server after \fIn\fR seconds in case it gets stuck.
 In one-off mode, this is the number of seconds the server will wait
 before exiting.
 .TP
+.BR --server-max-duration " "
+max time, in seconds, that an iperf client can run against the server.
+When the sum of the client's time and omit values exceeds the max duration set by the server
+or the client's time value is 0, the measurement is rejected.
+.TP
 .BR --server-bitrate-limit " \fIn\fR[KMGT][/\fCn\fR]"
 Set a limit on the server side, which will cause a test to abort if
 the client specifies a test of more than \fIn\fR bits per second, or

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2302,7 +2302,7 @@ iperf_exchange_parameters(struct iperf_test *test)
             if (iperf_set_send_state(test, SERVER_ERROR) != 0)
                 return -1;
 
-            i_errno = IEMAXSERVERDURATIONEXCEEDED;
+            i_errno = IEMAXSERVERTESTDURATIONEXCEEDED;
             err = htonl(i_errno);
             if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
                 i_errno = IECTRLWRITE;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2308,6 +2308,12 @@ iperf_exchange_parameters(struct iperf_test *test)
                 i_errno = IECTRLWRITE;
                 return -1;
             }
+            
+            err = htonl(errno);
+            if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+                i_errno = IECTRLWRITE;
+                return -1;
+            }
 
             return -1;
         }

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2297,7 +2297,7 @@ iperf_exchange_parameters(struct iperf_test *test)
             return -1;
         }
 
-        if (test->max_server_duration > 0 && ((test->duration + test->omit) > test->max_server_duration) || test->duration == 0) {
+        if ((test->max_server_duration > 0) && (((test->duration + test->omit) > test->max_server_duration) || (test->duration == 0))) {
             if (iperf_set_send_state(test, SERVER_ERROR) != 0)
                 return -1;
 

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2297,7 +2297,7 @@ iperf_exchange_parameters(struct iperf_test *test)
             return -1;
         }
 
-        if (test->max_server_duration > 0 && (test->duration + test->omit) > test->max_server_duration) {
+        if (test->max_server_duration > 0 && ((test->duration + test->omit) > test->max_server_duration) || test->duration == 0) {
             if (iperf_set_send_state(test, SERVER_ERROR) != 0)
                 return -1;
             

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2570,13 +2570,6 @@ get_parameters(struct iperf_test *test)
 	    test->repeating_payload = 1;
 	if ((j_p = iperf_cJSON_GetObjectItemType(j, "zerocopy", cJSON_Number)) != NULL)
 	    test->zerocopy = j_p->valueint;
-
-    /* Ensure that the client does not request to run longer than the server's configured max */
-    if ((test->max_server_duration > 0) && (((test->duration + test->omit) > test->max_server_duration) || (test->duration == 0))) {
-        i_errno = IEMAXSERVERTESTDURATIONEXCEEDED;
-        r = -1;
-    }
-
 #if defined(HAVE_DONT_FRAGMENT)
 	if ((j_p = iperf_cJSON_GetObjectItemType(j, "dont_fragment", cJSON_Number)) != NULL)
 	    test->settings->dont_fragment = j_p->valueint;
@@ -2592,6 +2585,13 @@ get_parameters(struct iperf_test *test)
 	if (test->settings->rate)
 	    cJSON_AddNumberToObject(test->json_start, "target_bitrate", test->settings->rate);
 	cJSON_Delete(j);
+
+    /* Ensure that the client does not request to run longer than the server's configured max */
+    if ((test->max_server_duration > 0) && (((test->duration + test->omit) > test->max_server_duration) || (test->duration == 0))) {
+        i_errno = IEMAXSERVERTESTDURATIONEXCEEDED;
+        r = -1;
+    }
+
     }
     return r;
 }

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2297,7 +2297,7 @@ iperf_exchange_parameters(struct iperf_test *test)
             return -1;
         }
 
-        if (test->max_server_duration > 0 && test->duration > test->max_server_duration) {
+        if (test->max_server_duration > 0 && (test->duration + test->omit) > test->max_server_duration) {
             if (iperf_set_send_state(test, SERVER_ERROR) != 0)
                 return -1;
             

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2300,7 +2300,7 @@ iperf_exchange_parameters(struct iperf_test *test)
         if (test->max_server_duration > 0 && ((test->duration + test->omit) > test->max_server_duration) || test->duration == 0) {
             if (iperf_set_send_state(test, SERVER_ERROR) != 0)
                 return -1;
-            
+
             i_errno = IEMAXSERVERDURATIONEXCEEDED;
             err = htonl(i_errno);
             if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1562,6 +1562,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                     i_errno = IEDURATION;
                     return -1;
                 }
+                server_flag = 1;
                 break;
             case OPT_RCV_TIMEOUT:
                 rcv_timeout_in = atoi(optarg);

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -105,6 +105,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_CNTL_KA 31
 #define OPT_SKIP_RX_COPY 32
 #define OPT_JSON_STREAM_FULL_OUTPUT 33
+#define OPT_SERVER_MAX_DURATION 33
 
 /* states */
 #define TEST_START 1
@@ -440,6 +441,7 @@ enum {
     IEUDPFILETRANSFER = 34, // Cannot transfer file using UDP
     IESERVERAUTHUSERS = 35,  // Cannot access authorized users file
     IECNTLKA = 36,          // Control connection Keepalive period should be larger than the full retry period (interval * count)
+    IEMAXSERVERDURATIONEXCEEDED = 37, // Client's duration exceeds server's maximum duration
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -105,7 +105,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_CNTL_KA 31
 #define OPT_SKIP_RX_COPY 32
 #define OPT_JSON_STREAM_FULL_OUTPUT 33
-#define OPT_SERVER_MAX_DURATION 33
+#define OPT_SERVER_MAX_DURATION 34
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -441,7 +441,7 @@ enum {
     IEUDPFILETRANSFER = 34, // Cannot transfer file using UDP
     IESERVERAUTHUSERS = 35,  // Cannot access authorized users file
     IECNTLKA = 36,          // Control connection Keepalive period should be larger than the full retry period (interval * count)
-    IEMAXSERVERDURATIONEXCEEDED = 37, // Client's duration exceeds server's maximum duration
+    IEMAXSERVERTESTDURATIONEXCEEDED = 37, // Client's duration exceeds server's maximum duration
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -334,7 +334,7 @@ iperf_handle_message_client(struct iperf_test *test)
     switch (test->state) {
         case PARAM_EXCHANGE:
             if (iperf_exchange_parameters(test) < 0)
-            return -1;
+                return -1;
             if (test->on_connect)
                 test->on_connect(test);
             break;

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -334,7 +334,7 @@ iperf_handle_message_client(struct iperf_test *test)
     switch (test->state) {
         case PARAM_EXCHANGE:
             if (iperf_exchange_parameters(test) < 0)
-                return -1;
+            return -1;
             if (test->on_connect)
                 test->on_connect(test);
             break;

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -551,6 +551,9 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "unable to set/get socket keepalive TCP number of retries (TCP_KEEPCNT) option");
             perr = 1;
             break;
+        case IEMAXSERVERDURATIONEXCEEDED:
+            snprintf(errstr, len, "client's max duration exceeds the server's maximum permitted duration");
+            break;
 	default:
 	    snprintf(errstr, len, "int_errno=%d", int_errno);
 	    perr = 1;

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -551,7 +551,7 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "unable to set/get socket keepalive TCP number of retries (TCP_KEEPCNT) option");
             perr = 1;
             break;
-        case IEMAXSERVERDURATIONEXCEEDED:
+        case IEMAXSERVERTESTDURATIONEXCEEDED:
             snprintf(errstr, len, "client's max duration exceeds the server's maximum permitted duration");
             break;
 	default:

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -552,7 +552,7 @@ iperf_strerror(int int_errno)
             perr = 1;
             break;
         case IEMAXSERVERTESTDURATIONEXCEEDED:
-            snprintf(errstr, len, "client's max duration exceeds the server's maximum permitted duration");
+            snprintf(errstr, len, "client's requested duration exceeds the server's maximum permitted limit");
             break;
 	default:
 	    snprintf(errstr, len, "int_errno=%d", int_errno);

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -149,6 +149,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 			   "                            total data rate.  Default is 5 seconds)\n"
                            "  --idle-timeout #          restart idle server after # seconds in case it\n"
                            "                            got stuck (default - no timeout)\n"
+                           "  --server-max-duration #   max time, in seconds, that an iperf test can run against the server\n"
 #if defined(HAVE_SSL)
                            "  --rsa-private-key-path    path to the RSA private key used to decrypt\n"
 			   "                            authentication credentials\n"


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #354, #615 

* Brief description of code changes (suitable for use as a commit message):
These changes add the functionality as requested by the linked issues. Specifically, this functionality allows the server to determine the maximum duration of an `iperf` measurement. The implementation is similar to the `--server-bitrate-limit` flag, where the measurement is forcibly stopped when an interval has exceeded the server's configured bitrate. In this case, the measurement is forcibly stopped when the duration exceeds the server's configured time, which is the value of `--server-time`.


### Example

From the dropdowns below, we can see that the server has enforced a measurement time of `3` seconds. The client attempts to run the measurement for `4` seconds. When the 3rd second is exceeded, the socket is forcibly closed.

<details>

<summary>server</summary>

```txt
./src/iperf3 -s --server-time 3
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
Accepted connection from 127.0.0.1, port 44938
[  6] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 44946
[ ID] Interval           Transfer     Bitrate
[  6]   0.00-1.00   sec  3.08 GBytes  26.5 Gbits/sec                  (omitted)
[  6]   1.00-2.00   sec  3.35 GBytes  28.8 Gbits/sec                  (omitted)
[  6]   2.00-3.00   sec  3.18 GBytes  27.3 Gbits/sec                  (omitted)
[  6]   0.00-1.00   sec  3.20 GBytes  27.5 Gbits/sec
[  6]   1.00-2.00   sec  3.34 GBytes  28.7 Gbits/sec
iperf3: error - select failed: Bad file descriptor
-----------------------------------------------------------
Server listening on 5201 (test #2)
-----------------------------------------------------------
```

</details>

<details>

<summary>client</summary>

```txt
./src/iperf3 --client 127.0.0.1 --port 5201 -t 4 --omit 3
Connecting to host 127.0.0.1, port 5201
[  5] local 127.0.0.1 port 44946 connected to 127.0.0.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  3.08 GBytes  26.5 Gbits/sec    0   1.06 MBytes       (omitted)
[  5]   1.00-2.00   sec  3.35 GBytes  28.8 Gbits/sec    0   1.06 MBytes       (omitted)
[  5]   2.00-3.00   sec  3.15 GBytes  27.1 Gbits/sec    0   1.06 MBytes       (omitted)
[  5]   0.00-1.00   sec  3.20 GBytes  27.5 Gbits/sec    0   1.12 MBytes
[  5]   1.00-2.00   sec  3.34 GBytes  28.7 Gbits/sec    0   1.25 MBytes
[  5]   1.00-2.00   sec  3.34 GBytes  28.7 Gbits/sec    0   1.25 MBytes
iperf3: error - control socket has closed unexpectedly
```

</details>

<details>

<summary>client_json</summary>

```json
{
        "start":        {
                "connected":    [{
                                "socket":       5,
                                "local_host":   "127.0.0.1",
                                "local_port":   53314,
                                "remote_host":  "127.0.0.1",
                                "remote_port":  5201
                        }],
                "version":      "iperf 3.16+",
                "system_info":  "Linux windows-nexus 5.15.146.1-microsoft-standard-WSL2 #1 SMP Thu Jan 11 04:09:03 UTC 2024 x86_64",
                "timestamp":    {
                        "time": "Thu, 18 Apr 2024 04:38:09 GMT",
                        "timesecs":     1713415089
                },
                "connecting_to":        {
                        "host": "127.0.0.1",
                        "port": 5201
                },
                "cookie":       "wtuhwwetnqayseccmqno6dutzjf3zly3op5p",
                "tcp_mss_default":      32768,
                "target_bitrate":       0,
                "fq_rate":      0,
                "sock_bufsize": 0,
                "sndbuf_actual":        16384,
                "rcvbuf_actual":        131072,
                "test_start":   {
                        "protocol":     "TCP",
                        "num_streams":  1,
                        "blksize":      131072,
                        "omit": 3,
                        "duration":     4,
                        "bytes":        0,
                        "blocks":       0,
                        "reverse":      0,
                        "tos":  0,
                        "target_bitrate":       0,
                        "bidir":        0,
                        "fqrate":       0,
                        "interval":     1
                }
        },
        "intervals":    [{
                        "streams":      [{
                                        "socket":       5,
                                        "start":        0,
                                        "end":  1.001066,
                                        "seconds":      1.0010659694671631,
                                        "bytes":        3578265600,
                                        "bits_per_second":      28595642717.968742,
                                        "retransmits":  0,
                                        "snd_cwnd":     2029973,
                                        "snd_wnd":      3145088,
                                        "rtt":  51,
                                        "rttvar":       5,
                                        "pmtu": 65535,
                                        "omitted":      true,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        0,
                                "end":  1.001066,
                                "seconds":      1.0010659694671631,
                                "bytes":        3578265600,
                                "bits_per_second":      28595642717.968742,
                                "retransmits":  0,
                                "omitted":      true,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        1.001066,
                                        "end":  2.001046,
                                        "seconds":      0.99997997283935547,
                                        "bytes":        3452698624,
                                        "bits_per_second":      27622142185.078888,
                                        "retransmits":  0,
                                        "snd_cwnd":     2029973,
                                        "snd_wnd":      3145088,
                                        "rtt":  88,
                                        "rttvar":       67,
                                        "pmtu": 65535,
                                        "omitted":      true,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        1.001066,
                                "end":  2.001046,
                                "seconds":      0.99997997283935547,
                                "bytes":        3452698624,
                                "bits_per_second":      27622142185.078888,
                                "retransmits":  0,
                                "omitted":      true,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        2.001046,
                                        "end":  3.001049,
                                        "seconds":      1.0000029802322388,
                                        "bytes":        3500015616,
                                        "bits_per_second":      28000041481.373692,
                                        "retransmits":  0,
                                        "snd_cwnd":     2029973,
                                        "snd_wnd":      3145088,
                                        "rtt":  63,
                                        "rttvar":       17,
                                        "pmtu": 65535,
                                        "omitted":      true,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        2.001046,
                                "end":  3.001049,
                                "seconds":      1.0000029802322388,
                                "bytes":        3500015616,
                                "bits_per_second":      28000041481.373692,
                                "retransmits":  0,
                                "omitted":      true,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        0.012641,
                                        "end":  0.988366,
                                        "seconds":      1.0010069608688354,
                                        "bytes":        3449421824,
                                        "bits_per_second":      27567615082.364941,
                                        "retransmits":  0,
                                        "snd_cwnd":     2029973,
                                        "snd_wnd":      3145088,
                                        "rtt":  58,
                                        "rttvar":       7,
                                        "pmtu": 65535,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        0.012641,
                                "end":  0.988366,
                                "seconds":      1.0010069608688354,
                                "bytes":        3449421824,
                                "bits_per_second":      27567615082.364941,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        0.988366,
                                        "end":  1.988398,
                                        "seconds":      1.0000319480895996,
                                        "bytes":        3414818816,
                                        "bits_per_second":      27317677780.382618,
                                        "retransmits":  0,
                                        "snd_cwnd":     2029973,
                                        "snd_wnd":      3145088,
                                        "rtt":  61,
                                        "rttvar":       9,
                                        "pmtu": 65535,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        0.988366,
                                "end":  1.988398,
                                "seconds":      1.0000319480895996,
                                "bytes":        3414818816,
                                "bits_per_second":      27317677780.382618,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        0.988366,
                                        "end":  1.988398,
                                        "seconds":      1.0000319480895996,
                                        "bytes":        3414818816,
                                        "bits_per_second":      27317677780.382618,
                                        "retransmits":  0,
                                        "snd_cwnd":     2029973,
                                        "snd_wnd":      3145088,
                                        "rtt":  61,
                                        "rttvar":       9,
                                        "pmtu": 65535,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        0.988366,
                                "end":  1.988398,
                                "seconds":      1.0000319480895996,
                                "bytes":        3414818816,
                                "bits_per_second":      27317677780.382618,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }],
        "end":  {
        },
        "error":        "control socket has closed unexpectedly"
}
```

</details>

### Implementation Details

With this implementation, the server overrides the value of `test->duration` with the value that was passed in via the `--server-time` flag. We can see from the drop downs that the client's experience is similar to when the bitrate limit is exceeded with the error: `iperf3: error - control socket has closed unexpectedly`. However, the server side is less friendly, with an error of `iperf3: error - select failed: Bad file descriptor`. I can already envision myself encountering this error and not knowing why I am getting it, as well as forgetting that I had set the `--server-time` flag to begin with.

Another thing to note is that nothing is stopping the user from setting a high value for `--omit`. Given that this feature is meant to protect the server, is it reasonable to include a `--server-omit` option to enforce a maximum value?


### Update (04/18/2024)

Since the first commit, I've introduced a solution for the error `iperf3: error - select failed: Bad file descriptor` which provides a more friendly experience. Let's consider the scenario where the `--server-time` flag has been set on the server to a value of `3`:

1. The client connects to the server
2. The server accepts the connection, receives the client's cookie, and sends the client that value of `3` for the server time
3. When the client's timers are created, it compares its duration to the server's duration of `3`. If the client's duration is greater than the server's, then the server's value is selected for the timer.
4. The same process occurs when the server's timers are created.

The JSON output also has a new field which specifies the server's value for duration: `server_duration`


<details>

<summary>client_json</summary>

```json
{
        "start":        {
                "connected":    [{
                                "socket":       5,
                                "local_host":   "127.0.0.1",
                                "local_port":   36906,
                                "remote_host":  "127.0.0.1",
                                "remote_port":  5201
                        }],
                "version":      "iperf 3.16+",
                "system_info":  "Linux windows-nexus 5.15.146.1-microsoft-standard-WSL2 #1 SMP Thu Jan 11 04:09:03 UTC 2024 x86_64",
                "timestamp":    {
                        "time": "Mon, 22 Apr 2024 02:23:53 GMT",
                        "timesecs":     1713752633
                },
                "connecting_to":        {
                        "host": "127.0.0.1",
                        "port": 5201
                },
                "cookie":       "m4n5p26auofjvyda2x2ba56kexzsly7mz5k7",
                "tcp_mss_default":      32768,
                "target_bitrate":       5000000,
                "fq_rate":      0,
                "sock_bufsize": 0,
                "sndbuf_actual":        16384,
                "rcvbuf_actual":        131072,
                "test_start":   {
                        "protocol":     "TCP",
                        "num_streams":  1,
                        "blksize":      131072,
                        "omit": 0,
                        "duration":     6,
                        "server_duration":      3,
                        "bytes":        0,
                        "blocks":       0,
                        "reverse":      0,
                        "tos":  0,
                        "target_bitrate":       5000000,
                        "bidir":        0,
                        "fqrate":       0,
                        "interval":     1
                }
        },
        "intervals":    [{
                        "streams":      [{
                                        "socket":       5,
                                        "start":        0,
                                        "end":  1.000087,
                                        "seconds":      1.0000870227813721,
                                        "bytes":        655360,
                                        "bits_per_second":      5242423.78970069,
                                        "retransmits":  0,
                                        "snd_cwnd":     654830,
                                        "snd_wnd":      1375232,
                                        "rtt":  38,
                                        "rttvar":       24,
                                        "pmtu": 65535,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        0,
                                "end":  1.000087,
                                "seconds":      1.0000870227813721,
                                "bytes":        655360,
                                "bits_per_second":      5242423.78970069,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        1.000087,
                                        "end":  2.000084,
                                        "seconds":      0.99999701976776123,
                                        "bytes":        655360,
                                        "bits_per_second":      5242895.6250465661,
                                        "retransmits":  0,
                                        "snd_cwnd":     654830,
                                        "snd_wnd":      2684928,
                                        "rtt":  45,
                                        "rttvar":       22,
                                        "pmtu": 65535,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        1.000087,
                                "end":  2.000084,
                                "seconds":      0.99999701976776123,
                                "bytes":        655360,
                                "bits_per_second":      5242895.6250465661,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        2.000084,
                                        "end":  3.000148,
                                        "seconds":      1.0000640153884888,
                                        "bytes":        655360,
                                        "bits_per_second":      5242544.39648379,
                                        "retransmits":  0,
                                        "snd_cwnd":     654830,
                                        "snd_wnd":      3112448,
                                        "rtt":  62,
                                        "rttvar":       44,
                                        "pmtu": 65535,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        2.000084,
                                "end":  3.000148,
                                "seconds":      1.0000640153884888,
                                "bytes":        655360,
                                "bits_per_second":      5242544.39648379,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }],
        "end":  {
                "streams":      [{
                                "sender":       {
                                        "socket":       5,
                                        "start":        0,
                                        "end":  3.000148,
                                        "seconds":      3.000148,
                                        "bytes":        1966080,
                                        "bits_per_second":      5242621.36401271,
                                        "retransmits":  0,
                                        "max_snd_cwnd": 654830,
                                        "max_snd_wnd":  3112448,
                                        "max_rtt":      62,
                                        "min_rtt":      38,
                                        "mean_rtt":     48,
                                        "sender":       true
                                },
                                "receiver":     {
                                        "socket":       5,
                                        "start":        0,
                                        "end":  3.000258,
                                        "seconds":      3.000148,
                                        "bytes":        1966080,
                                        "bits_per_second":      5242429.1510930061,
                                        "sender":       true
                                }
                        }],
                "sum_sent":     {
                        "start":        0,
                        "end":  3.000148,
                        "seconds":      3.000148,
                        "bytes":        1966080,
                        "bits_per_second":      5242621.36401271,
                        "retransmits":  0,
                        "sender":       true
                },
                "sum_received": {
                        "start":        0,
                        "end":  3.000258,
                        "seconds":      3.000258,
                        "bytes":        1966080,
                        "bits_per_second":      5242429.1510930061,
                        "sender":       true
                },
                "cpu_utilization_percent":      {
                        "host_total":   100.87966904530634,
                        "host_user":    100.8797023673657,
                        "host_system":  0,
                        "remote_total": 0.037496475331318856,
                        "remote_user":  0.037496475331318856,
                        "remote_system":        0
                },
                "sender_tcp_congestion":        "cubic",
                "receiver_tcp_congestion":      "cubic"
        }
}
```

</details>

### Update (06/05/2024)

A valid question was brought up by @TheRealDJ: `What happens when the server has this feature but the client doesn't?`. With the current implementation, there is no backwards compatability. Further discussions will need to be had in order to handle this case properly.

### Update (05/17/2025)

A new implementation has been made to address the backwards compatibility issue mentioned above.

#### Implementation Details

The server has a new flag, `--server-max-duration`, represents the maximum permitted duration for an `iperf3` test in seconds. When the client initiates a test, it sends its desired duration to the server. The server then compares the client's requested duration with its own maximum duration. If the client's requested duration exceeds the server's maximum, the server rejects the test and sends an error message back to the client. Since older client's do not have the newly added `IEMAXSERVERDURATIONEXCEEDED` error, the handler for `int_errno` falls into the default case. The output for the server and both outputs for the client are shown below.

<details>

<summary>server</summary>

```txt
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
iperf3: error - client's max duration exceeds the server's maximum permitted duration
```


</details>

<details>

<summary>client (new)</summary>

```txt
Connecting to host 127.0.0.1, port 5201
iperf3: error - client's max duration exceeds the server's maximum permitted duration
```

</details>

<details>

<summary>client (old)</summary>

```txt
Connecting to host 127.0.0.1, port 5201
iperf3: error - int_errno=37: No locks available
```

</details>

#### Questions

Is this output acceptable? The error message is not very user friendly, but I'm not sure of a way to relay more information when the error message is based on the `int_errno` value. Ideally, the server and the client should exchange information on their respective versions, but since that functionality does not currently exist, I am uncertain of the best way to handle this.

### Update (05/19/2025)

@TheRealDJ mentioned that the sum of the client's duration and omits must not exceed the server's maximum duration. This change has been implemented.
