### PR TITLE
Fix clang compilation failure on Android

### DIFF
--- a/src/iperf_pthread.c
+++ b/src/iperf_pthread.c
@@ -6,8 +6,27 @@
  * as Android NDK does not support `pthread_cancel()`.
  */
 
+#include <string.h>
 #include <signal.h>
 #include "iperf_pthread.h"
+
+void iperf_thread_exit_handler(int sig)
+{
+    pthread_exit(0);
+}
+
+int iperf_set_thread_exit_handler() {
+    int rc;
+    struct sigaction actions;
+
+    memset(&actions, 0, sizeof(actions));
+    sigemptyset(&actions.sa_mask);
+    actions.sa_flags = 0;
+    actions.sa_handler = iperf_thread_exit_handler;
+
+    rc = sigaction(SIGUSR1, &actions, NULL);
+    return rc;
+}
 
 int pthread_setcanceltype(int type, int *oldtype) { return 0; }
 int pthread_setcancelstate(int state, int *oldstate) { return 0; }
@@ -17,24 +36,6 @@ int pthread_cancel(pthread_t thread_id) {
         status = pthread_kill(thread_id, SIGUSR1);
     }
     return status;
-}
-
-void iperf_thread_exit_handler(int sig)
-{ 
-    pthread_exit(0);
-}
-
-int iperf_set_thread_exit_handler() {
-    int rc;
-    struct sigaction actions;
-
-    memset(&actions, 0, sizeof(actions)); 
-    sigemptyset(&actions.sa_mask);
-    actions.sa_flags = 0; 
-    actions.sa_handler = iperf_thread_exit_handler;
-
-    rc = sigaction(SIGUSR1, &actions, NULL);
-    return rc;
 }
 
 #endif // defined(HAVE_PTHREAD) && defined(__ANDROID__)

--- a/src/iperf_pthread.h
+++ b/src/iperf_pthread.h
@@ -10,7 +10,7 @@
  */
 
 #define PTHREAD_CANCEL_ASYNCHRONOUS 0
-#define PTHREAD_CANCEL_ENABLE NULL
+#define PTHREAD_CANCEL_ENABLE 0
 
 int pthread_setcanceltype(int type, int *oldtype);
 int pthread_setcancelstate(int state, int *oldstate);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

Fix aarch64-linux-android-clang compilation failure due to patch d80b914141582dc0c0cf3f71cc5799061074be66 #1651 
