### PR TITLE
Initialize cookie buffer

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -117,7 +117,7 @@ iperf_tcp_accept(struct iperf_test * test)
 {
     int     s;
     signed char rbuf = ACCESS_DENIED;
-    char    cookie[COOKIE_SIZE];
+    char    cookie[COOKIE_SIZE] = {0};
     socklen_t len;
     struct sockaddr_storage addr;
 
@@ -149,7 +149,7 @@ iperf_tcp_accept(struct iperf_test * test)
         return -1;
     }
 
-    if (strcmp(test->cookie, cookie) != 0) {
+    if (strncmp(test->cookie, cookie, COOKIE_SIZE) != 0) {
         if (Nwrite(s, (char*) &rbuf, sizeof(rbuf), Ptcp) < 0) {
             iperf_err(test, "failed to send access denied from busy server to new connecting client, errno = %d\n", errno);
         }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: 3.16

* Issues fixed (if any): uninitialized buffer

* Brief description of code changes (suitable for use as a commit message):

`Nread` reads up *to* N bytes from the socket. Since we only check that we read more than 0 bytes, it's possible for the cookie buffer only be partially initialized (and may not contain a valid null terminated string). Initializing the buffer to 0 fixes this.

Also swap `strcmp` with `strncmp` since we know know exactly how long a cookie should be. This will help prevent any buffer overflows if the length of the cookie ever changes for some reason.

