### PR TITLE
Fix Compiler Error Android pthread

### DIFF
--- a/src/iperf_pthread.c
+++ b/src/iperf_pthread.c
@@ -7,34 +7,33 @@
  */
 
 #include <signal.h>
+#include <string.h>
 #include "iperf_pthread.h"
 
 int pthread_setcanceltype(int type, int *oldtype) { return 0; }
 int pthread_setcancelstate(int state, int *oldstate) { return 0; }
+void iperf_thread_exit_handler(int sig)
+{
+    pthread_exit(0);
+}
+int iperf_set_thread_exit_handler() {
+    int rc;
+    struct sigaction actions;
+
+    memset(&actions, 0, sizeof(actions));
+    sigemptyset(&actions.sa_mask);
+    actions.sa_flags = 0;
+    actions.sa_handler = iperf_thread_exit_handler;
+
+    rc = sigaction(SIGUSR1, &actions, NULL);
+    return rc;
+}
 int pthread_cancel(pthread_t thread_id) {
     int status;
     if ((status = iperf_set_thread_exit_handler()) == 0) {
         status = pthread_kill(thread_id, SIGUSR1);
     }
     return status;
-}
-
-void iperf_thread_exit_handler(int sig)
-{ 
-    pthread_exit(0);
-}
-
-int iperf_set_thread_exit_handler() {
-    int rc;
-    struct sigaction actions;
-
-    memset(&actions, 0, sizeof(actions)); 
-    sigemptyset(&actions.sa_mask);
-    actions.sa_flags = 0; 
-    actions.sa_handler = iperf_thread_exit_handler;
-
-    rc = sigaction(SIGUSR1, &actions, NULL);
-    return rc;
 }
 
 #endif // defined(HAVE_PTHREAD) && defined(__ANDROID__)

--- a/src/iperf_pthread.h
+++ b/src/iperf_pthread.h
@@ -10,7 +10,7 @@
  */
 
 #define PTHREAD_CANCEL_ASYNCHRONOUS 0
-#define PTHREAD_CANCEL_ENABLE NULL
+#define PTHREAD_CANCEL_ENABLE 0
 
 int pthread_setcanceltype(int type, int *oldtype);
 int pthread_setcancelstate(int state, int *oldstate);


### PR DESCRIPTION
Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
- 3.16 and following

Issues fixed (if any):
- Following Compiler Errors
```
1.725 /tmp/iperf/src/iperf_client_api.c:61:28: error: incompatible pointer to integer conversion passing 'void *' to parameter of type 'int' [-Wint-conversion]
1.725     pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
1.725                            ^~~~~~~~~~~~~~~~~~~~~
1.725 /tmp/iperf/src/iperf_pthread.h:13:31: note: expanded from macro 'PTHREAD_CANCEL_ENABLE'
1.725 #define PTHREAD_CANCEL_ENABLE NULL
1.725                               ^~~~
1.725 /opt/android-ndk/android-ndk-r26b/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/17/include/stddef.h:89:16: note: expanded from macro 'NULL'
1.725 #  define NULL ((void*)0)
1.725                ^~~~~~~~~~
1.725 /tmp/iperf/src/iperf_pthread.h:16:32: note: passing argument to parameter 'state' here
1.725 int pthread_setcancelstate(int state, int *oldstate);
1.725                                ^
1.727 1 error generated.
1.730 make: *** [/opt/android-ndk/android-ndk-r26b/build/core/build-binary.mk:413: /tmp/obj/local/arm64-v8a/objs/iperf3.16/src/iperf_client_api.o] Error 1
------
``` 
```
1.615 /tmp/iperf/src/iperf_pthread.c:16:19: error: call to undeclared function 'iperf_set_thread_exit_handler'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
1.615     if ((status = iperf_set_thread_exit_handler()) == 0) {
1.615                   ^
1.616 /tmp/iperf/src/iperf_pthread.c:31:5: error: call to undeclared library function 'memset' with type 'void *(void *, int, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
1.616     memset(&actions, 0, sizeof(actions)); 
1.616     ^
1.616 /tmp/iperf/src/iperf_pthread.c:31:5: note: include the header <string.h> or explicitly provide a declaration for 'memset'
1.617 2 errors generated.
1.619 make: *** [/opt/android-ndk/android-ndk-r26b/build/core/build-binary.mk:413: /tmp/obj/local/arm64-v8a/objs/iperf3.16/src/iperf_pthread.o] Error 1
------
```
If I apply the changes, it compiles without a problem.

Brief description of code changes (suitable for use as a commit message):
- Reordering of functions, so that functions are declared before their usage

If you want to try it out yourself, [here](https://github.com/omnt/iperf/tree/v3.17.1).
Building ENV:
```
ARG API_VERSION=31
ARG SDK_VERSION=4333796
ARG NDK_VERSION=r26b
ARG IPERF_VERSION=iperf-3.17.1
```
Feel free to close this PR if I made a mistake or missing something.