### PR TITLE
Do not listen to old UDP prot_listener

### DIFF
--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -446,6 +446,7 @@ iperf_udp_accept(struct iperf_test *test)
     /*
      * Create a new "listening" socket to replace the one we were using before.
      */
+    FD_CLR(test->prot_listener, &test->read_set); // No control messages from old listener
     test->prot_listener = netannounce(test->settings->domain, Pudp, test->bind_address, test->bind_dev, test->server_port);
     if (test->prot_listener < 0) {
         i_errno = IESTREAMLISTEN;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

Clear old UDP `prot_listener` from `read_set`, as currently the server's `select()` always return when data (that is relevant only to the worker thread) is received.  This makes the main thread consume a lot of unnecessary CPU, which reduces the total throughput - especially when only one stream is used.

In my single machine environment, with the this fix the throughput is increased by about 40% for one stream test.

