### PR TITLE
Json read check json size

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -436,6 +436,8 @@ struct iperf_test
 
 #define UDP_BUFFER_EXTRA 1024
 
+#define MAX_PARAMS_JSON_STRING 8 * 1024
+
 /* constants for command line arg sanity checks */
 #define MB (1024 * 1024)
 #define MAX_TCP_BUFFER (512 * MB)

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2820,7 +2820,7 @@ JSON_read(int fd)
                             json = cJSON_Parse(str);
                         }
                         else {
-                            printf("WARNING:  JSON size of data read does not correspond to offered length\n");
+                            warning("JSON size of data read does not correspond to offered length");
                         }
 	            }
 	            free(str);
@@ -2828,11 +2828,11 @@ JSON_read(int fd)
             }
 	}
 	else {
-	    printf("WARNING:  JSON data length overflow\n");
+	    warning("JSON data length overflow");
 	}
     }
     else {
-        printf("WARNING:  Failed to read JSN data size\n");
+        warning("Failed to read JSON data size");
     }
     return json;
 }

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2799,8 +2799,9 @@ JSON_read(int fd)
      * Then read the JSON into a buffer and parse it.  Return a parsed JSON
      * structure, NULL if there was an error.
      */
-    if (Nread(fd, (char*) &nsize, sizeof(nsize), Ptcp) >= 0) {
-	hsize = ntohl(nsize);
+    rc = Nread(fd, (char*) &nsize, sizeof(nsize), Ptcp);
+    hsize = ntohl(nsize);
+    if (rc == sizeof(nsize) && hsize <= MAX_PARAMS_JSON_STRING) {
 	/* Allocate a buffer to hold the JSON */
 	strsize = hsize + 1;              /* +1 for trailing NULL */
 	if (strsize) {

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2801,7 +2801,7 @@ JSON_read(int fd)
      */
     rc = Nread(fd, (char*) &nsize, sizeof(nsize), Ptcp);
     hsize = ntohl(nsize);
-    if (rc == sizeof(nsize) && hsize <= MAX_PARAMS_JSON_STRING) {
+    if (rc == sizeof(nsize) && hsize > 0 && hsize <= MAX_PARAMS_JSON_STRING) {
 	/* Allocate a buffer to hold the JSON */
 	strsize = hsize + 1;              /* +1 for trailing NULL */
 	if (strsize) {

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2800,34 +2800,39 @@ JSON_read(int fd)
      * structure, NULL if there was an error.
      */
     rc = Nread(fd, (char*) &nsize, sizeof(nsize), Ptcp);
-    hsize = ntohl(nsize);
-    if (rc == sizeof(nsize) && hsize > 0 && hsize <= MAX_PARAMS_JSON_STRING) {
-	/* Allocate a buffer to hold the JSON */
-	strsize = hsize + 1;              /* +1 for trailing NULL */
-	if (strsize) {
-	str = (char *) calloc(sizeof(char), strsize);
-	if (str != NULL) {
-	    rc = Nread(fd, str, hsize, Ptcp);
-	    if (rc >= 0) {
-		/*
-		 * We should be reading in the number of bytes corresponding to the
-		 * length in that 4-byte integer.  If we don't the socket might have
-		 * prematurely closed.  Only do the JSON parsing if we got the
-		 * correct number of bytes.
-		 */
-		if (rc == hsize) {
-		    json = cJSON_Parse(str);
-		}
-		else {
-		    printf("WARNING:  Size of data read does not correspond to offered length\n");
-		}
-	    }
-	}
-	free(str);
+    if (rc == sizeof(nsize)) {
+        hsize = ntohl(nsize);
+        if (hsize > 0 && hsize <= MAX_PARAMS_JSON_STRING) {
+	    /* Allocate a buffer to hold the JSON */
+	    strsize = hsize + 1;              /* +1 for trailing NULL */
+	    if (strsize) {
+	        str = (char *) calloc(sizeof(char), strsize);
+	        if (str != NULL) {
+	            rc = Nread(fd, str, hsize, Ptcp);
+	            if (rc >= 0) {
+                        /*
+                        * We should be reading in the number of bytes corresponding to the
+                        * length in that 4-byte integer.  If we don't the socket might have
+                        * prematurely closed.  Only do the JSON parsing if we got the
+                        * correct number of bytes.
+                        */
+                        if (rc == hsize) {
+                            json = cJSON_Parse(str);
+                        }
+                        else {
+                            printf("WARNING:  JSON size of data read does not correspond to offered length\n");
+                        }
+	            }
+	            free(str);
+                }
+            }
 	}
 	else {
-	    printf("WARNING:  Data length overflow\n");
+	    printf("WARNING:  JSON data length overflow\n");
 	}
+    }
+    else {
+        printf("WARNING:  Failed to read JSN data size\n");
     }
     return json;
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
latest

* Issues fixed (if any): None

* Brief description of code changes (suitable for use as a commit message):

When receiving Params JSON size, verify that received exactly the `sizeof(<size variable>)` bytes.

In addition, added a check that the size received is reasonable - positive and is less than 8KB (which probably is much more that needed and may be reduced).
