### PR TITLE
Fix memory leak for parallel tests

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4200,6 +4200,7 @@ iperf_print_results(struct iperf_test *test)
                 }
                 if (test->server_output_text) {
                     iperf_printf(test, "\nServer output:\n%s\n", test->server_output_text);
+	            free(test->server_output_text);
                     test->server_output_text = NULL;
                 }
             }

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -130,6 +130,11 @@ iperf_create_streams(struct iperf_test *test, int sender)
 		    i_errno = IESETCONGESTION;
 		    return -1;
 		}
+	        if (test->congestion_used) {
+	          if (test->debug)
+	            printf("Overriding existing congestion algorithm: %s\n", test->congestion_used);
+	          free(test->congestion_used);
+	        }
                 // Set actual used congestion alg, or set to unknown if could not get it
                 if (rc < 0)
                     test->congestion_used = strdup("unknown");


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):
`congestion_used` is set each iteration of the loop. For tests running parallel streams, the previous malloc-ed string (from `strdup`) is leaked.

* Brief description of code changes (suitable for use as a commit message):
If `congestion_used` is not NULL, free the existing string.
