### PR TITLE
fix -Wformat-y2k error

### DIFF
--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -99,7 +99,7 @@ iperf_errexit(struct iperf_test *test, const char *format, ...)
     if (test != NULL && test->timestamps) {
 	time(&now);
 	ltm = localtime(&now);
-	strftime(iperf_timestrerr, sizeof(iperf_timestrerr), "%Y-%m-%d %H:%M:%S", ltm);
+	strftime(iperf_timestrerr, sizeof(iperf_timestrerr), iperf_get_test_timestamp_format(test), ltm);
 	ct = iperf_timestrerr;
     }
 

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -99,7 +99,7 @@ iperf_errexit(struct iperf_test *test, const char *format, ...)
     if (test != NULL && test->timestamps) {
 	time(&now);
 	ltm = localtime(&now);
-	strftime(iperf_timestrerr, sizeof(iperf_timestrerr), "%c ", ltm);
+	strftime(iperf_timestrerr, sizeof(iperf_timestrerr), "%Y-%m-%d %H:%M:%S", ltm);
 	ct = iperf_timestrerr;
     }
 


### PR DESCRIPTION
%c potentially prints a 2 digit year. Just use a normal format.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
all

* Issues fixed (if any):
* -Wformat-y2k error

* Brief description of code changes (suitable for use as a commit message):
%c potentially prints a 2 digit year. Just use a normal format.

