### PR TITLE
Add SO_ZEROCOPY and MSG_ZEROCOPY support for UDP and TCP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -337,6 +337,20 @@ if test "x$iperf3_cv_header_tcp_info_snd_wnd" = "xyes"; then
   AC_DEFINE([HAVE_TCP_INFO_SND_WND], [1], [Have tcpi_snd_wnd field in tcp_info.])
 fi
 
+# Check for MSG_ZEROCOPY (mostly on Linux)
+AC_CACHE_CHECK([MSG_ZEROCOPY send option],
+[iperf3_cv_header_msg_zerocopy],
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <sys/types.h>
+                     #include <sys/socket.h>
+                     #include <netinet/in.h>]],
+                   [[int foo = MSG_ZEROCOPY;]])],
+  iperf3_cv_header_msg_zerocopy=yes,
+  iperf3_cv_header_msg_zerocopy=no))
+if test "x$iperf3_cv_header_msg_zerocopy" = "xyes"; then
+    AC_DEFINE([HAVE_MSG_ZEROCOPY], [1], [Have MSG_ZEROCOPY send option.])
+fi
+
 # Check if we need -lrt for clock_gettime
 AC_SEARCH_LIBS(clock_gettime, [rt posix4])
 # Check for clock_gettime support

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -420,6 +420,7 @@ enum {
     IESNDTIMEOUT = 33,      // Illegal message send timeout
     IEUDPFILETRANSFER = 34, // Cannot transfer file using UDP
     IESERVERAUTHUSERS = 35,   // Cannot access authorized users file
+    IEDISKFILEZEROCOPY = 36, // Sending disk file using MSG_ZEROCOPY is not supported 
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -210,7 +210,14 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "TCP MSS too large (maximum = %d bytes)", MAX_MSS);
             break;
         case IENOSENDFILE:
+#if defined(SUPPORTED_MSG_ZEROCOPY)
+            snprintf(errstr, len, "invalid zerocopy option value or this OS does not support sendfile");
+#else
             snprintf(errstr, len, "this OS does not support sendfile");
+#endif /* SUPPORTED_MSG_ZEROCOPY */
+            break;
+        case IEDISKFILEZEROCOPY:
+            snprintf(errstr, len, "Sending disk file using MSG_ZEROCOPY is not supported");
             break;
         case IEOMIT:
             snprintf(errstr, len, "bogus value for --omit");

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -198,7 +198,12 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #if defined(HAVE_FLOWLABEL)
                            "  -L, --flowlabel N         set the IPv6 flow label (only supported on Linux)\n"
 #endif /* HAVE_FLOWLABEL */
-                           "  -Z, --zerocopy            use a 'zero copy' method of sending data\n"
+#if defined(HAVE_MSG_ZEROCOPY) && defined(HAVE_POLL_H)
+                           "  -Z, --zerocopy[=z]        for UDP use MSG_ZEROCOPY 'zero copy' method for sending data;\n"
+                           "                            for TCP, use sendfile() uless '=z' is set for using MSG_ZEROCOPY\n"
+#else
+                           "  -Z, --zerocopy            use `sendfile()` for 'zero copy' send of TCP data\n"
+#endif /* SUPPORTED_MSG_ZEROCOPY */
                            "  -O, --omit N              perform pre-test for N seconds and omit the pre-test statistics\n"
                            "  -T, --title str           prefix every output line with this string\n"
                            "  --extra-data str          data string to include in client and server JSON\n"

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -420,6 +420,11 @@ cleanup_server(struct iperf_test *test)
     int i_errno_save = i_errno;
     SLIST_FOREACH(sp, &test->streams, streams) {
         int rc;
+#if defined(SUPPORTED_MSG_ZEROCOPY)
+        if (sp->sender && sp->test->zerocopy == ZEROCOPY_MSG_ZEROCOPY) {
+            wait_zerocopy_buffer_available(sp); /* Wait until last message is sent */
+        }
+#endif /* SUPPORTED_MSG_ZEROCOPY */
         sp->done = 1;
         rc = pthread_cancel(sp->thr);
         if (rc != 0 && rc != ESRCH) {

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -88,6 +88,18 @@ iperf_tcp_send(struct iperf_stream *sp)
     if (!sp->pending_size)
 	sp->pending_size = sp->settings->blksize;
 
+#if defined(SUPPORTED_MSG_ZEROCOPY)
+    if (sp->test->zerocopy == ZEROCOPY_MSG_ZEROCOPY) {
+        /* Wait until it is safe to rewite the sending buffer */
+        r = wait_zerocopy_buffer_available(sp);
+        if (r < 0) {
+            if (sp->test->debug_level >= DEBUG_LEVEL_INFO)
+                printf("Waining for TCP MSG_ZEROCOPY buffer to become available failed, errno=%s\n", strerror(errno));
+            return r;
+        }
+        r = Nsend_sp(sp, sp->buffer, sp->pending_size, Ptcp, MSG_ZEROCOPY);
+    } else
+#endif /* SUPPORTED_MSG_ZEROCOPY */
     if (sp->test->zerocopy)
 	r = Nsendfile(sp->buffer_fd, sp->socket, sp->buffer, sp->pending_size);
     else
@@ -120,12 +132,27 @@ iperf_tcp_accept(struct iperf_test * test)
     char    cookie[COOKIE_SIZE] = {0};
     socklen_t len;
     struct sockaddr_storage addr;
+#if defined(SUPPORTED_MSG_ZEROCOPY)
+    int opt;
+#endif /* SUPPORTED_MSG_ZEROCOPY */
 
     len = sizeof(addr);
     if ((s = accept(test->listener, (struct sockaddr *) &addr, &len)) < 0) {
         i_errno = IESTREAMCONNECT;
         return -1;
     }
+
+#if defined(SUPPORTED_MSG_ZEROCOPY)
+    /* Setting should be done before the socket is conected */
+    if (test->zerocopy == ZEROCOPY_MSG_ZEROCOPY) {
+        opt = 1;
+        if (setsockopt(s, SOL_SOCKET, SO_ZEROCOPY, &opt, sizeof(opt)) < 0) {
+            i_errno = IESTREAMACCEPT;
+            return -1;
+        }
+    }
+#endif /* SUPPORTED_MSG_ZEROCOPY */
+
 #if defined(HAVE_SO_MAX_PACING_RATE)
     /* If fq socket pacing is specified, enable it. */
 
@@ -380,7 +407,7 @@ iperf_tcp_connect(struct iperf_test *test)
     int saved_errno;
     int rcvbuf_actual, sndbuf_actual;
 
-    s = create_socket(test->settings->domain, SOCK_STREAM, test->bind_address, test->bind_dev, test->bind_port, test->server_hostname, test->server_port, &server_res);
+    s = create_socket(test->settings->domain, SOCK_STREAM, test->bind_address, test->bind_dev, test->bind_port, test->server_hostname, test->server_port, &server_res, test->zerocopy);
     if (s < 0) {
 	i_errno = IESTREAMCONNECT;
 	return -1;

--- a/src/iperf_time.c
+++ b/src/iperf_time.c
@@ -86,6 +86,16 @@ iperf_time_in_usecs(struct iperf_time *time)
     return time->secs * 1000000LL + time->usecs;
 }
 
+uint64_t
+iperf_time_now_in_usecs()
+{
+    struct iperf_time time;
+
+    iperf_time_now(&time);
+    return iperf_time_in_usecs(&time);
+}
+
+
 double
 iperf_time_in_secs(struct iperf_time *time)
 {

--- a/src/iperf_time.h
+++ b/src/iperf_time.h
@@ -36,6 +36,8 @@ struct iperf_time {
 
 int iperf_time_now(struct iperf_time *time1);
 
+uint64_t iperf_time_now_in_usecs();
+
 void iperf_time_add_usecs(struct iperf_time *time1, uint64_t usecs);
 
 int iperf_time_compare(struct iperf_time *time1, struct iperf_time *time2);

--- a/src/net.h
+++ b/src/net.h
@@ -28,16 +28,22 @@
 #define __NET_H
 
 int timeout_connect(int s, const struct sockaddr *name, socklen_t namelen, int timeout);
-int create_socket(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, struct addrinfo **server_res_out);
-int netdial(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, int timeout);
+int create_socket(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, struct addrinfo **server_res_out, int zerocopy);
+int netdial(int domain, int proto, const char *local, const char *bind_dev, int local_port, const char *server, int port, int timeout, int zerocopy);
 int netannounce(int domain, int proto, const char *local, const char *bind_dev, int port);
 int Nread(int fd, char *buf, size_t count, int prot);
 int Nwrite(int fd, const char *buf, size_t count, int prot) /* __attribute__((hot)) */;
+int Nsend(int fd, const char *buf, size_t count, int prot, int sock_opt) /* __attribute__((hot)) */;
 int has_sendfile(void);
 int Nsendfile(int fromfd, int tofd, const char *buf, size_t count) /* __attribute__((hot)) */;
 int setnonblocking(int fd, int nonblocking);
 int getsockdomain(int sock);
 int parse_qos(const char *tos);
+
+#if defined(SUPPORTED_MSG_ZEROCOPY)
+int Nsend_sp(struct iperf_stream *sp, const char *buf, size_t count, int prot, int sock_opt);
+int wait_zerocopy_buffer_available(struct iperf_stream *sp);
+#endif /* SUPPORTED_MSG_ZEROCOPY */
 
 #define NET_SOFTERROR -1
 #define NET_HARDERROR -2


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1678

* Brief description of code changes (suitable for use as a commit message):

Add support for zero-copy for both UDP and TCP, using SO_ZEROCOPY/MSG_ZEROCOPY.  Although it is not clear when and in what environments the added functionality improve performance, support was added to allow testing this functionality.  The assumption is that different environments may have different levels of support for this functionality.
(Note that running `bootstrap.sh; configure` is required before `make` to support the new features.)

The added support is for `MSG_ZEROCOPY`. When used, socket option `SO_ZEROCOPY` is set and `send(...., MSG_ZEROCOPY)` is used instead of `write()`.  `MSG_ZEROCOPY` is used in the following cases:
- UDP: when `-Z/--zerocopy` option is set.
- TCP: when `--zerocopy=z` is set.  Otherwise, `sendfile()` continue to be used for TCP zero copy.

This PR is a rework of the original suggested support in #1690, as it was too naive and did not include support for notifications.

The main implementation is based on the [msg_zerocopy.c example](https://github.com/torvalds/linux/blob/master/tools/testing/selftests/net/msg_zerocopy.c) for supporting `MSG_ZEROCOPY`.

Note that per the [Zero-copy networking discussion](https://lwn.net/Articles/726917/) about the [patch that added MSG_ZEROCOPY support](https://lwn.net/Articles/726353/), the expected performance improvement is expected to be less than 10% and only for large packets.  Therefor, it would be helpful if this PR will be tested on different environments to see whether and when it improves performance.
