### PR TITLE
Add debug messges when State changes

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -288,6 +288,11 @@ iperf_handle_message_client(struct iperf_test *test)
 	i_errno = IEINITTEST;
         return -1;
     }
+
+    if (test->debug_level >= DEBUG_LEVEL_INFO) {
+        iperf_printf(test, "Reading new State from the Server - current state is %d-%s\n", test->state, state_to_text(test->state));
+    }
+
     /*!!! Why is this read() and not Nread()? */
     if ((rval = read(test->ctrl_sck, (char*) &test->state, sizeof(signed char))) <= 0) {
         if (rval == 0) {
@@ -297,6 +302,10 @@ iperf_handle_message_client(struct iperf_test *test)
             i_errno = IERECVMESSAGE;
             return -1;
         }
+    }
+
+    if (test->debug_level >= DEBUG_LEVEL_INFO) {
+        iperf_printf(test, "State change: client received and changed State to %d-%s\n", test->state, state_to_text(test->state));
     }
 
     switch (test->state) {

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -41,6 +41,7 @@
 #include "iperf.h"
 #include "iperf_api.h"
 #include "iperf_tcp.h"
+#include "iperf_util.h"
 #include "net.h"
 #include "cjson.h"
 
@@ -69,7 +70,7 @@ iperf_tcp_recv(struct iperf_stream *sp)
     }
     else {
 	if (sp->test->debug)
-	    printf("Late receive, state = %d\n", sp->test->state);
+	    printf("Late receive, state = %d-%s\n", sp->test->state, state_to_text(sp->test->state));
     }
 
     return r;

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -595,3 +595,30 @@ getline(char **buf, size_t *bufsiz, FILE *fp)
 }
 
 #endif
+
+/* Translate numeric State to text - for debugging pupposes */
+char *
+state_to_text(signed char state)
+{
+    char *txt;
+
+    switch (state) {
+        case 0: txt = "Test reset"; break;
+        case TEST_START: txt = "TEST_START - starting a new test"; break;
+        case TEST_RUNNING: txt = "TEST_RUNNING"; break;
+        case TEST_END: txt = "TEST_END"; break;
+        case PARAM_EXCHANGE: txt = "PARAM_EXCHANGE - Client to Server Parameters Exchange"; break;
+        case CREATE_STREAMS: txt = "CREATE_STREAMS"; break;
+        case SERVER_TERMINATE: txt = "SERVER_TERMINATE"; break;
+        case CLIENT_TERMINATE: txt = "CLIENT_TERMINATE"; break;
+        case EXCHANGE_RESULTS: txt = "EXCHANGE_RESULTS"; break;
+        case DISPLAY_RESULTS: txt = "DISPLAY_RESULTS"; break;
+        case IPERF_START: txt = "IPERF_START - waiting for a new test"; break;
+        case IPERF_DONE: txt = "IPERF_DONE"; break;
+        case ACCESS_DENIED: txt = "ACCESS_DENIED - Server is busy"; break;
+        case SERVER_ERROR: txt = "SERVER_ERROR"; break;
+        default: txt = "Unknown State";
+    }
+
+    return txt;
+}

--- a/src/iperf_util.h
+++ b/src/iperf_util.h
@@ -64,4 +64,6 @@ extern int daemon(int nochdir, int noclose);
 ssize_t getline(char **buf, size_t *bufsiz, FILE *fp);
 #endif /* HAVE_GETLINE */
 
+char * state_to_text(signed char state);
+
 #endif


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
Master

* Issues fixed (if any): None

* Brief description of code changes (suitable for use as a commit message):
Added DEBUG_LEVEL_INFO debug messages when state changes.  I found these debug messages useful in different error cases, especially when there is a problem with the client/server interface.

