### PR TITLE
iperf_time_add() optimization

### DIFF
--- a/src/iperf_time.c
+++ b/src/iperf_time.c
@@ -72,12 +72,11 @@ iperf_time_now(struct iperf_time *time1)
 void
 iperf_time_add_usecs(struct iperf_time *time1, uint64_t usecs)
 {
-    time1->secs += usecs / 1000000L;
-    time1->usecs += usecs % 1000000L;
-    if ( time1->usecs >= 1000000L ) {
-        time1->secs += time1->usecs / 1000000L;
-        time1->usecs %= 1000000L;
-    }
+    uint64_t total_usecs;
+
+    total_usecs = time1->usecs + usecs;
+    time1->secs += total_usecs / 1000000L;
+    time1->usecs = total_usecs % 1000000L;
 }
 
 uint64_t


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): None

* Brief description of code changes (suitable for use as a commit message):
Optimizing `iperf_time_add()` by reducing operations using pointers and division/modulus calculations.  Impact is mainly to short periodic timers, although I am not sure it will practically enhance the iperf3 performance in these cases.
