### PR TITLE
Reduce CPU usage when test baud rate is limited

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,5 +342,14 @@ AC_SEARCH_LIBS(clock_gettime, [rt posix4])
 # Check for clock_gettime support
 AC_CHECK_FUNCS([clock_gettime])
 
+# Check if we need -lrt for nanosleep
+AC_SEARCH_LIBS(nanosleep, [rt posix4])
+# Check for nanosleep support
+AC_CHECK_FUNCS([nanosleep])
+# Check if we need -lrt for clock_nanosleep
+AC_SEARCH_LIBS(clock_nanosleep, [rt posix4])
+# Check for clock_nanosleep support
+AC_CHECK_FUNCS([clock_nanosleep])
+
 AC_CONFIG_FILES([Makefile src/Makefile src/version.h examples/Makefile iperf3.spec])
 AC_OUTPUT

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1639,12 +1639,10 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 	    test->use_pkcs1_padding = 1;
 	    break;
 #endif /* HAVE_SSL */
-#if !defined(HAVE_CLOCK_NANOSLEEP) && !defined(HAVE_NANOSLEEP)
 	    case OPT_PACING_TIMER:
 		test->settings->pacing_timer = unit_atoi(optarg);
 		client_flag = 1;
 		break;
-#endif /* !HAVE_CLOCK_NANOSLEEP && !HAVE_NANOSLEEP */
 	    case OPT_CONNECT_TIMEOUT:
 		test->settings->connect_timeout = unit_atoi(optarg);
 		client_flag = 1;
@@ -1888,7 +1886,7 @@ iperf_check_throttle(struct iperf_stream *sp, struct iperf_time *nowP)
     
 #if defined(HAVE_CLOCK_NANOSLEEP) || defined(HAVE_NANOSLEEP)
     struct timespec nanosleep_time;
-    int64_t time_to_green_ligh, delta_bits;
+    int64_t time_to_green_light, delta_bits;
     int ret;
 #endif /* HAVE_CLOCK_NANOSLEEP || HAVE_NANOSLEEP) */
 #if defined(HAVE_CLOCK_NANOSLEEP)
@@ -1914,13 +1912,13 @@ iperf_check_throttle(struct iperf_stream *sp, struct iperf_time *nowP)
     if (missing_rate < 0) {
         delta_bits = bits_sent - (seconds * sp->test->settings->rate);
         // Calclate time until next data send is required
-        time_to_green_ligh = (SEC_TO_NS * delta_bits / sp->test->settings->rate);
+        time_to_green_light = (SEC_TO_NS * delta_bits / sp->test->settings->rate);
         // Whether shouuld wait before next send
-        if (time_to_green_ligh >= 0) {
+        if (time_to_green_light >= 0) {
 #if defined(HAVE_CLOCK_NANOSLEEP)
             if (clock_gettime(CLOCK_MONOTONIC, &nanosleep_time) == 0) {
                 // Calculate absolute end of sleep time
-                ns = nanosleep_time.tv_nsec + time_to_green_ligh;
+                ns = nanosleep_time.tv_nsec + time_to_green_light;
                 if (ns < SEC_TO_NS) {
                     nanosleep_time.tv_nsec = ns;
                 } else {
@@ -1939,10 +1937,10 @@ iperf_check_throttle(struct iperf_stream *sp, struct iperf_time *nowP)
             // Sleep until average baud rate reaches the target value or intrupt / error
             do {
                 // nansleep() time should be less than 1 sec
-                nanosleep_time.tv_nsec = (time_to_green_ligh >= SEC_TO_NS) ? SEC_TO_NS - 1 : time_to_green_ligh;
-                time_to_green_ligh -= nanosleep_time.tv_nsec;
+                nanosleep_time.tv_nsec = (time_to_green_light >= SEC_TO_NS) ? SEC_TO_NS - 1 : time_to_green_light;
+                time_to_green_light -= nanosleep_time.tv_nsec;
                 ret = nanosleep(&nanosleep_time, NULL);
-            } while (ret == 0 && time_to_green_ligh > 0);
+            } while (ret == 0 && time_to_green_light > 0);
             if (ret == 0) {
                 sp->green_light = 1;
             }

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -163,7 +163,9 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -b, --bitrate #[KMG][/#]  target bitrate in bits/sec (0 for unlimited)\n"
                            "                            (default %d Mbit/sec for UDP, unlimited for TCP)\n"
                            "                            (optional slash and packet count for burst mode)\n"
+#if !defined(HAVE_CLOCK_NANOSLEEP) && !defined(HAVE_NANOSLEEP)
 			   "  --pacing-timer #[KMG]     set the timing for pacing, in microseconds (default %d)\n"
+#endif /* !HAVE_CLOCK_NANOSLEEP && !HAVE_NANOSLEEP */
 #if defined(HAVE_SO_MAX_PACING_RATE)
                            "  --fq-rate #[KMG]          enable fair-queuing based socket pacing in\n"
 			   "                            bits/sec (Linux only)\n"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -165,6 +165,9 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "                            (optional slash and packet count for burst mode)\n"
 #if !defined(HAVE_CLOCK_NANOSLEEP) && !defined(HAVE_NANOSLEEP)
 			   "  --pacing-timer #[KMG]     set the timing for pacing, in microseconds (default %d)\n"
+#else
+			   "  --pacing-timer #[KMG]     set the Server timing for pacing, in microseconds (default %d)\n"
+                           "                            (used by the server only if this option is in its help message)\n"
 #endif /* !HAVE_CLOCK_NANOSLEEP && !HAVE_NANOSLEEP */
 #if defined(HAVE_SO_MAX_PACING_RATE)
                            "  --fq-rate #[KMG]          enable fair-queuing based socket pacing in\n"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1741

* Brief description of code changes (suitable for use as a commit message):

Suggested fix to #1741 for (significantly) reduce iperf3 send CPU usage when `--baud` limits the sending baud rate.  The suggested change uses `nanosleep()` or `clock_nanosleep()` to seep between sends instead of using the pacing timer.  This change seem to work fine because of the current usage of threads and since the `select()` is used only in the main thread.

`clock_nanosleep()` has a cleaner implementation, so its use is preferred.  However, since it seem to be newer than `nanosleep()`, `nanosleep()` is used if `clock_nanosleep()` is not supported.  Both give similar results.  If both functions are not supported, then the legacy behavior is used.

The `--pacing-timer` option is removed.  However the related variables/functions are not removed in case they are used as part of the library.

(By the way, it seems that `iperf_send_mt()` can be simplified.  E.g. the `if (sp->sender)` is probably redundant.  In addition, the use of burst/multisend is also probably redundant, since the sending threads do not use `select()`.)