### PR TITLE
Fix rcv-timeout issue because of Nread timeout

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2000,8 +2000,14 @@ iperf_recv_mt(struct iperf_stream *sp)
 		i_errno = IESTREAMREAD;
 		return r;
 	    }
-	    test->bytes_received += r;
-	    ++test->blocks_received;
+            
+            /* Collect statistics only if receive did not timeout (e.g. `Nread()` may timeout).
+             * This is also important for `--rcv-timeout` to work properly.
+             */
+            if (r > 0) {
+	        test->bytes_received += r;
+	        ++test->blocks_received;
+            }
 
     return 0;
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): None

* Brief description of code changes (suitable for use as a commit message):

Fix an issue with `--rcv-timeout` - did not work with value over 10 seconds (my first PR for a problem I found at work as iperf3 user :smile:).  This is because `Nread()` timeout after 10 seconds, but `iperf_recv_mt()` collected statistics even when receiving 0 bytes.  Therefore, it was assumed that data blocks where received and so receive did not timeout.

