### PR TITLE
Avoid subthread signal handling

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -474,8 +474,8 @@ enum {
     IEPTHREADCANCEL=151,        // Unable to cancel thread (check perror)
     IEPTHREADJOIN=152,		// Unable to join thread (check perror)
     IEPTHREADATTRINIT=153,      // Unable to initialize thread attribute (check perror)
-    IEPTHREADSIGMASK=154,      // Unable to initialize sub thread signal mask (check perror)
-    IEPTHREADATTRDESTROY=155,      // Unable to destroy thread attribute (check perror)
+    IEPTHREADATTRDESTROY=154,      // Unable to destroy thread attribute (check perror)
+    IEPTHREADSIGMASK=155,      // Unable to initialize sub thread signal mask (check perror)
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -474,7 +474,8 @@ enum {
     IEPTHREADCANCEL=151,        // Unable to cancel thread (check perror)
     IEPTHREADJOIN=152,		// Unable to join thread (check perror)
     IEPTHREADATTRINIT=153,      // Unable to initialize thread attribute (check perror)
-    IEPTHREADATTRDESTROY=154,      // Unable to destroy thread attribute (check perror)
+    IEPTHREADSIGMASK=154,      // Unable to initialize sub thread signal mask (check perror)
+    IEPTHREADATTRDESTROY=155,      // Unable to destroy thread attribute (check perror)
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -60,9 +60,15 @@ iperf_client_worker_run(void *s) {
     /* Blocking signal to make sure that signal will be handled by main thread */
     sigset_t set;
     sigemptyset(&set);
+#ifdef SIGTERM
     sigaddset(&set, SIGTERM);
+#endif
+#ifdef SIGHUP
     sigaddset(&set, SIGHUP);
+#endif
+#ifdef SIGINT
     sigaddset(&set, SIGINT);
+#endif
     if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {
 	    i_errno = IEPTHREADSIGMASK;
 	    goto cleanup_and_fail;

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -505,6 +505,9 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "unable to create thread attributes");
             perr = 1;
             break;
+	case IEPTHREADSIGMASK:
+	    snprintf(errstr, len, "unable to change mask of blocked signals");
+	    break;
 	case IEPTHREADATTRDESTROY:
             snprintf(errstr, len, "unable to destroy thread attributes");
             perr = 1;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -73,9 +73,15 @@ iperf_server_worker_run(void *s) {
     /* Blocking signal to make sure that signal will be handled by main thread */
     sigset_t set;
     sigemptyset(&set);
+#ifdef SIGTERM
     sigaddset(&set, SIGTERM);
+#endif
+#ifdef SIGHUP
     sigaddset(&set, SIGHUP);
+#endif
+#ifdef SIGINT
     sigaddset(&set, SIGINT);
+#endif
     if (pthread_sigmask(SIG_BLOCK, &set, NULL) != 0) {
 	    i_errno = IEPTHREADSIGMASK;
 	    goto cleanup_and_fail;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3:  master

* Issues fixed (if any): #1750

* Brief description of code changes:
The main and sub-threads responding to the signal processing function at the same time will cause the sub-thread to access the test instance that has been released by the main thread, vice versa.
