### PR TITLE
fix incorrect freeaddrinfo call

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -145,7 +145,6 @@ create_socket(int domain, int proto, const char *local, const char *bind_dev, in
     if ((gerror = getaddrinfo(server, portstr, &hints, &server_res)) != 0) {
 	if (local)
 	    freeaddrinfo(local_res);
-        freeaddrinfo(server_res);
         return -1;
     }
 


### PR DESCRIPTION
`freeaddrinfo` call introduced with https://github.com/esnet/iperf/commit/111212bca2eaab948cff11fafddcb097e7615f52 is incorrect, because if `getaddrinfo` failed, there is nothing in there to free.

We encountered segfault there on Solaris, but I can reproduce that on Linux the pointer remains `NULL` as well when `getaddrinfo` fails.
