### PR TITLE
Avoid duplicate thread recycling.

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -807,6 +807,9 @@ iperf_run_client(struct iperf_test * test)
     /* Cancel all outstanding threads */
     i_errno_save = i_errno;
     SLIST_FOREACH(sp, &test->streams, streams) {
+        if (sp->done) {
+            continue;
+        }
         sp->done = 1;
         int rc;
         rc = pthread_cancel(sp->thr);


### PR DESCRIPTION
At the end of the test, the traffic thread has been reclaimed. If there is an exception in the control connection, it will cause the thread to be reclaimed repeatedly. Use sp->done to avoid repeated thread recycling.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any): https://github.com/esnet/iperf/issues/1760

* Brief description of code changes (suitable for use as a commit message):

