### PR TITLE
No Server error when connection closed while waiting for IPERF_DONE

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -251,7 +251,7 @@ iperf_handle_message_server(struct iperf_test *test)
                 iperf_err(test, "the client has unexpectedly closed the connection");
                 i_errno = IECTRLCLOSE;
             } else {
-                printf("WARNING:  client connection was closed when waiting for IPERF_DONE\n");
+                warning("client connection was closed when waiting for IPERF_DONE");
             }
             iperf_set_test_state(test, IPERF_DONE);
             return 0;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1756

* Brief description of code changes (suitable for use as a commit message):

It seems that the problem in #1756 is that the server "received" the client's close of the control channel, before the `IPERF_DONE` arrived to the server.  Since this is not really an error, the change is that in this case the server just print a warning message , instead of issuing an error.