### PR TITLE
Remove the usage of pacing_timer and simplify iperf_mt_send

### DIFF
--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -163,12 +163,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -b, --bitrate #[KMG][/#]  target bitrate in bits/sec (0 for unlimited)\n"
                            "                            (default %d Mbit/sec for UDP, unlimited for TCP)\n"
                            "                            (optional slash and packet count for burst mode)\n"
-#if !defined(HAVE_CLOCK_NANOSLEEP) && !defined(HAVE_NANOSLEEP)
-			   "  --pacing-timer #[KMG]     set the timing for pacing, in microseconds (default %d)\n"
-#else
 			   "  --pacing-timer #[KMG]     set the Server timing for pacing, in microseconds (default %d)\n"
-                           "                            (used by the server only if this option is in its help message)\n"
-#endif /* !HAVE_CLOCK_NANOSLEEP && !HAVE_NANOSLEEP */
+                           "                            (deprecated - for servers using older versions ackward compatibility)\n"
 #if defined(HAVE_SO_MAX_PACING_RATE)
                            "  --fq-rate #[KMG]          enable fair-queuing based socket pacing in\n"
 			   "                            bits/sec (Linux only)\n"


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): discussion #1736

* Brief description of code changes (suitable for use as a commit message):

**Removed the usage of `pacing_timer`**, and keep it as a parameter for backward compatibility for servers running older versions of iperf3.

In addition, **simplified `iperf_send_mt()`**, since it contained some leftovers of the multi-streams support (including some variables renaming).

Tested with and without nanosleep support.