### PR TITLE
No limit to omit time period

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -447,6 +447,7 @@ struct iperf_test
 #define MIN_INTERVAL 0.1
 #define MAX_INTERVAL 60.0
 #define MAX_TIME 86400
+#define MAX_OMIT_TIME 600
 #define MAX_BURST 1000
 #define MAX_MSS (9 * 1024)
 #define MAX_STREAMS 128

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1493,7 +1493,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 break;
             case 'O':
                 test->omit = atoi(optarg);
-                if (test->omit < 0 || test->omit > 60) {
+                if (test->omit < 0 || test->omit > MAX_TIME) {
                     i_errno = IEOMIT;
                     return -1;
                 }

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1493,7 +1493,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 break;
             case 'O':
                 test->omit = atoi(optarg);
-                if (test->omit < 0 || test->omit > MAX_TIME) {
+                if (test->omit < 0 || test->omit > MAX_OMIT_TIME) {
                     i_errno = IEOMIT;
                     return -1;
                 }

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -213,7 +213,7 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "this OS does not support sendfile");
             break;
         case IEOMIT:
-            snprintf(errstr, len, "bogus value for --omit");
+            snprintf(errstr, len, "bogus value for --omit (maximum = %d seconds)", MAX_OMIT_TIME);
             break;
         case IEUNIMP:
             snprintf(errstr, len, "an option you are trying to set is not implemented yet");


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1770

* Brief description of code changes (suitable for use as a commit message):
Change the `--omit` time period limit from 60 to the same limit as `--time` (86,400 seconds = one day).
My assumption is that the 60 seconds was just to be more user friendly, assuming that the omit period is only to omit possible performance fluctuations at the first few seconds of the tests.  Per #1770 there are other use cases that requires larger omit time period. 

