### PR TITLE
End test immediately when all number of blocks/bytes sent/received

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -288,6 +288,7 @@ enum debug_level {
 struct iperf_test
 {
     pthread_mutex_t print_mutex;
+    pthread_mutex_t pipe_mutex;
 
     char      role;                             /* 'c' lient or 's' erver */
     enum iperf_mode mode;
@@ -325,6 +326,9 @@ struct iperf_test
     int       prot_listener;
 
     int	      ctrl_sck_mss;			/* MSS for the control channel */
+
+    int       pipe_end_of_test_fds[2];          /* fot select() terminating when -n/-k flags are set */
+    int       pipe_end_of_test_created;
 
 #if defined(HAVE_SSL)
     char      *server_authorized_users;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -336,6 +336,8 @@ int iperf_create_send_timers(struct iperf_test *);
 int iperf_parse_arguments(struct iperf_test *, int, char **);
 int iperf_open_logfile(struct iperf_test *);
 void iperf_close_logfile(struct iperf_test *);
+void iperf_open_pipe_end_of_test(struct iperf_test *);
+void iperf_close_pipe_end_of_test(struct iperf_test *);
 void iperf_reset_test(struct iperf_test *);
 void iperf_reset_stats(struct iperf_test * test);
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1768

* Brief description of code changes (suitable for use as a commit message):

Currently, after the change to multi-thread, when limiting the test by number of bytes (`-n`) or number of blocks (`-k`), the test ends only when the current interval (`-i`) ends and not when all the data was sent/received.  This is because the `select()` no longer monitor the steams data.  Therefore the throughput statistics are not properly calculated.  I.e. for 1 second interval, if sending was done in 2.5 seconds, the statistics will be as if sending was done in 3 seconds.  This is much worse if the interval period is larger.

This suggested fix is using the [self-pipe trick](https://cr.yp.to/docs/selfpipe.html), based on [this example](https://www.michaelkerrisk.com/tlpi/code/online/dist/altio/self_pipe.c.html).  When `-n` or `-k` are set, a self-pipe is added to the Client's select.  When the limit is reached, one byte is written to the pipe to wake-up the `select()` in the main thread.