### PR TITLE
Add Bounceback test

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -71,6 +71,10 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 
 #define WARN_STR_LEN 128
 
+#define DEFAULT_BOUNCEBACK_MSG_SIZE 100 /* default Bounceback message size */
+#define DEFAULT_BOUNCEBACK_BURST    10  /* default burst size of baounceback messages */
+#define DEFAULT_BOUNCEBACK_INUM     1   /* default number of baounceback burst per report interval */
+
 /* short option equivalents, used to support options that only have long form */
 #define OPT_SCTP 1
 #define OPT_LOGFILE 2
@@ -101,6 +105,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_JSON_STREAM 28
 #define OPT_SND_TIMEOUT 29
 #define OPT_USE_PKCS1_PADDING 30
+#define OPT_BOUNCEBACK 31
 
 /* states */
 #define TEST_START 1
@@ -168,6 +173,10 @@ int	iperf_get_dont_fragment( struct iperf_test* ipt );
 char*   iperf_get_test_congestion_control(struct iperf_test* ipt);
 int iperf_get_test_mss(struct iperf_test* ipt);
 int     iperf_get_mapped_v4(struct iperf_test* ipt);
+int     iperf_get_test_bounceback_burst(struct iperf_test *ipt);
+double  iperf_get_test_bounceback_period(struct iperf_test *ipt);
+int     iperf_get_test_bounceback_size(struct iperf_test *ipt);
+int     iperf_get_test_bounceback_response_size(struct iperf_test *ipt);
 
 /* Setter routines for some fields inside iperf_test. */
 void	iperf_set_verbose( struct iperf_test* ipt, int verbose );
@@ -217,6 +226,10 @@ void    iperf_set_on_new_stream_callback(struct iperf_test* ipt, void (*callback
 void    iperf_set_on_test_start_callback(struct iperf_test* ipt, void (*callback)());
 void    iperf_set_on_test_connect_callback(struct iperf_test* ipt, void (*callback)());
 void    iperf_set_on_test_finish_callback(struct iperf_test* ipt, void (*callback)());
+void    iperf_set_test_bounceback_burst(struct iperf_test *ipt, int burst);
+void    iperf_set_test_bounceback_period(struct iperf_test *ipt, double period);
+void    iperf_set_test_bounceback_size(struct iperf_test *ipt, int size);
+void    iperf_set_test_bounceback_response_size(struct iperf_test *ipt, int size);
 
 #if defined(HAVE_SSL)
 void    iperf_set_test_client_username(struct iperf_test *ipt, const char *client_username);
@@ -420,6 +433,7 @@ enum {
     IESNDTIMEOUT = 33,      // Illegal message send timeout
     IEUDPFILETRANSFER = 34, // Cannot transfer file using UDP
     IESERVERAUTHUSERS = 35,   // Cannot access authorized users file
+    IEBOUNCEBACK = 36,      // Invalid value specified in bounceback
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -200,6 +200,9 @@ iperf_strerror(int int_errno)
         case IESERVERAUTHUSERS:
              snprintf(errstr, len, "cannot access authorized users file");
             break;
+        case IEBOUNCEBACK:
+             snprintf(errstr, len, "invalid value specified in bounceback");
+            break;
 	case IEBADFORMAT:
 	    snprintf(errstr, len, "bad format specifier (valid formats are in the set [kmgtKMGT])");
 	    break;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -214,6 +214,13 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #if defined(HAVE_DONT_FRAGMENT)
                            "  --dont-fragment           set IPv4 Don't Fragment flag\n"
 #endif /* HAVE_DONT_FRAGMENT */
+                           "  --bounceback[=[burst][/[inum][/[len][/replen]]]]  Bounceback - send `inum` (default %d)\n"
+                           "                            bursts of `burst` (default %d) messages of `len` (default %d)\n"
+                           "                            bytes per report interval. Server reply is `replen`\n"
+                           "                            (default `len`) bytes (TCP uses TCP_NODELAY).\n"
+#if !defined(HAVE_CLOCK_NANOSLEEP) && !defined(HAVE_NANOSLEEP)
+                           "                            (NOTE: `period` is rounded to nearest second, with minimum 1 sec.\n"
+#endif      /* !HAVE_CLOCK_NANOSLEEP and !HAVE_NANOSLEEP */
 #if defined(HAVE_SSL)
                            "  --username                username for authentication\n"
                            "  --rsa-public-key-path     path to the RSA public key used to encrypt\n"
@@ -301,6 +308,9 @@ const char test_start_bytes[] =
 
 const char test_start_blocks[] =
 "Starting Test: protocol: %s, %d streams, %d byte blocks, omitting %d seconds, %"PRIuFAST64" bytes to send, tos %d\n";
+
+const char test_start_bounceback[] =
+"Bounceback Test: burst-size: %d, %d bursts-in-interval, %d byte send, %d byte response\n";
 
 
 /* -------------------------------------------------------------------
@@ -399,6 +409,9 @@ const char report_bw_udp_format_no_omitted_error[] =
 
 const char report_bw_udp_sender_format[] =
 "[%3d]%s %6.2f-%-6.2f sec  %ss  %ss/sec %s %" PRId64 "  %s\n";
+
+const char report_bounceback_format[] =
+"[BBK]%s %6.2f-%-6.2f sec  count: %ld, avarage: %.3fms  min: %.3fms  max: %.3fms  stdev: %.3fms\n";
 
 const char report_summary[] =
 "Test Complete. Summary Results:\n";

--- a/src/iperf_locale.h
+++ b/src/iperf_locale.h
@@ -48,6 +48,7 @@ extern const char wait_server_threads[] ;
 extern const char test_start_time[];
 extern const char test_start_bytes[];
 extern const char test_start_blocks[];
+extern const char test_start_bounceback[];
 
 extern const char report_time[] ;
 extern const char report_connecting[] ;
@@ -80,6 +81,7 @@ extern const char report_bw_retrans_cwnd_format[] ;
 extern const char report_bw_udp_format[] ;
 extern const char report_bw_udp_format_no_omitted_error[] ;
 extern const char report_bw_udp_sender_format[] ;
+extern const char report_bounceback_format[] ;
 extern const char report_summary[] ;
 extern const char report_sum_bw_format[] ;
 extern const char report_sum_bw_retrans_format[] ;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1725

* Brief description of code changes (suitable for use as a commit message):

Suggested solution for adding Bounceback test to iperf3, using a new `--bounceback` option.  The implementation options are based on subset of the iperf2 options, but there are some differences in the approach to simplify iperf3 code changes (assuming I understood iperf2 implementation well enough ...).  Following are the main approach considerations:
- Instead of supporting `--bounceback-period` option, the bounceback test **period is the Report Interval (`-i`)**.  That allows using the interval reporting mechanism, instead of adding a separate one.  During the interval period, several bursts of bounceback messages may be sent, but the statistics are reported once per interval.
- The **protocol** used for the bounceback messages is the **same protocol used for the throughput test** (i.e., default TCP, UDP with `-u`).  This is to allow creating the bounceback stream as part of the test streams creation.  Practically, it may be that only TCP (and SCTP) are reliable.
- Instead of supporting `--working-load`, the **normal iperf3 throughput tests are used** as the workload.  That makes all the iperf3 tests options available to the bounceback workload (`-P`, `-R`, `--bidir`, `-b`, etc.).  For running only bounceback test, `-P 0` should be used.
- **Report is about the bounceback round-trip time**.  The bounceback RTT is calculated at the client by subtracting the server's processing time from the total RTT.  With this approach, the clock in the client and server does not have to be in sync.  Of course, not all the client/server overheads are eliminated from the RTT, but I am not sure how much and how important this is.
- **Only client to server** bounceback test is supported.  I am not sure if this is different from iperf2, but it seems that this should be sufficient, as the report is about the round-trip time.
- TCP bounceback streams is always using `TCP_NODELAY` (not an option) and there is no option to set `TCP_QUICKACK`.

The **`--bounceback` option** receives the following 4 parameters (all are optional):
1. **Number of messages in a burst** (default is 10)
2. **Number of bursts per Report Interval** (default is 1)
3. **Client to server request message size** (default is 100 bytes)
4. **Server reply message size** (default is request message size)

**Some open questions:**
1. **Should `-P 0` be the default** when `--bounceback` is specified?  I.e. should the default be no workload, and if needed workload should be added using the `-P` option?
2. **For TCP bounceback tests**, is it important to support options to disable `TCP_NODELAY` or to support `TCP_QUICKACK`?
3. **How important are the iperf2 options** `--bounceback-hold ` and `--bounceback-txdelay`?  Is it important that any of them will be added to iperf3?

