### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   cppcheck-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install dependencies
       run: |
         sudo apt-get -y update && sudo apt-get install -y cppcheck && \
@@ -12,7 +12,7 @@ jobs:
   build-test-latest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install dependencies
       run: |
         sudo apt-get -y update && sudo apt-get install -y build-essential
@@ -24,7 +24,7 @@ jobs:
   build-test-ubuntu-20_04:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install dependencies
       run: |
         sudo apt-get -y update && sudo apt-get install -y build-essential 


### PR DESCRIPTION
* Version of iperf3
`master` 

* Issues fixed (if any):
GitHub Actions deprecation warnings: `The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3.`

* Brief description of code changes (suitable for use as a commit message):
Bump actions/checkout to v4
