### PR TITLE
Improved iperf_udp_recv() debug messages

### DIFF
--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -187,7 +187,7 @@ iperf_udp_recv(struct iperf_stream *sp)
     }
     else {
 	if (test->debug_level >= DEBUG_LEVEL_INFO)
-	    printf("Late receive, state = %d\n", sp->test->state);
+	    printf("Late receive, state = %d\n", test->state);
     }
 
     return r;

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -61,6 +61,7 @@ iperf_udp_recv(struct iperf_stream *sp)
     int       first_packet = 0;
     double    transit = 0, d = 0;
     struct iperf_time sent_time, arrival_time, temp_time;
+    struct iperf_test *test = sp->test;
 
     r = Nread_no_select(sp->socket, sp->buffer, size, Pudp);
 
@@ -73,7 +74,7 @@ iperf_udp_recv(struct iperf_stream *sp)
         return r;
 
     /* Only count bytes received while we're in the correct state. */
-    if (sp->test->state == TEST_RUNNING) {
+    if (test->state == TEST_RUNNING) {
 
 	/*
 	 * For jitter computation below, it's important to know if this
@@ -87,7 +88,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 	sp->result->bytes_received_this_interval += r;
 
 	/* Dig the various counters out of the incoming UDP packet */
-	if (sp->test->udp_counters_64bit) {
+	if (test->udp_counters_64bit) {
 	    memcpy(&sec, sp->buffer, sizeof(sec));
 	    memcpy(&usec, sp->buffer+4, sizeof(usec));
 	    memcpy(&pcount, sp->buffer+8, sizeof(pcount));
@@ -109,7 +110,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 	    sent_time.usecs = usec;
 	}
 
-	if (sp->test->debug_level >= DEBUG_LEVEL_DEBUG)
+	if (test->debug_level >= DEBUG_LEVEL_DEBUG)
 	    fprintf(stderr, "pcount %" PRIu64 " packet_count %" PRIu64 "\n", pcount, sp->packet_count);
 
 	/*
@@ -131,6 +132,8 @@ iperf_udp_recv(struct iperf_stream *sp)
 	    if (pcount > sp->packet_count + 1) {
 		/* There's a gap so count that as a loss. */
 		sp->cnt_error += (pcount - 1) - sp->packet_count;
+                if (test->debug_level >= DEBUG_LEVEL_INFO)
+		    fprintf(stderr, "LOST %" PRIu64 " PACKETS - received packet %" PRIu64 " but expected sequence %" PRIu64 " on stream %d\n", (pcount - sp->packet_count + 1), pcount, sp->packet_count + 1, sp->socket);
 	    }
 	    /* Update the highest sequence number seen so far. */
 	    sp->packet_count = pcount;
@@ -152,8 +155,8 @@ iperf_udp_recv(struct iperf_stream *sp)
 		sp->cnt_error--;
 
 	    /* Log the out-of-order packet */
-	    if (sp->test->debug)
-		fprintf(stderr, "OUT OF ORDER - incoming packet sequence %" PRIu64 " but expected sequence %" PRIu64 " on stream %d", pcount, sp->packet_count + 1, sp->socket);
+	    if (test->debug_level >= DEBUG_LEVEL_INFO)
+		fprintf(stderr, "OUT OF ORDER - received packet %" PRIu64 " but expected sequence %" PRIu64 " on stream %d\n", pcount, sp->packet_count + 1, sp->socket);
 	}
 
 	/*
@@ -183,7 +186,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 	sp->jitter += (d - sp->jitter) / 16.0;
     }
     else {
-	if (sp->test->debug)
+	if (test->debug_level >= DEBUG_LEVEL_INFO)
 	    printf("Late receive, state = %d\n", sp->test->state);
     }
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):
* While trying to help with issue #1793, I made the changes here in `iperf_udp_recv()` and I submit them as they may be useful in other cases.  The main changes are changing the debug level of the LOST and REORDER messages to INFO (3) and adding debug message.

