### PR TITLE
Do not try to cancel NULL thread (causing Segmentation fault)

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -193,6 +193,7 @@ struct iperf_stream
     struct iperf_test* test;
 
     pthread_t thr;
+    int thread_created;
     int       done;
 
     /* configurable members */

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4498,6 +4498,7 @@ iperf_new_stream(struct iperf_test *test, int s, int sender)
 
     memset(sp, 0, sizeof(struct iperf_stream));
 
+    sp->thread_created = 0;
     sp->sender = sender;
     sp->test = test;
     sp->settings = test->settings;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4498,7 +4498,6 @@ iperf_new_stream(struct iperf_test *test, int s, int sender)
 
     memset(sp, 0, sizeof(struct iperf_stream));
 
-    sp->thread_created = 0;
     sp->sender = sender;
     sp->test = test;
     sp->settings = test->settings;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

Suggested Bug fix: thread id 0 is not regarded as illegal id (at least in Ubuntu Linux), and `pthread_cancel()` **crashes** (Segmentation fault) when trying to cancel a thread with id 0.  That happens if streams creation was successful, but there was a failure before all threads are created.  The problem happened to me at work and I can reproduce it in my private PC.

The suggested fix is to add an indication `thread_created` per stream to indicate if the thread was created for the stream, and try to cancel the stream's thread **only if it was created**.

