### PR TITLE
Reset the congestion protocol on the server between tests

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3262,6 +3262,9 @@ iperf_reset_test(struct iperf_test *test)
 
     SLIST_INIT(&test->streams);
 
+    if (test->congestion)
+        free(test->congestion);
+    test->congestion = NULL;
     if (test->remote_congestion_used)
         free(test->remote_congestion_used);
     test->remote_congestion_used = NULL;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
  master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):
Reset the congestion protocol between tests. Otherwise, the server keeps the last congestion protocol asked by a client (-C option), applying it to the following clients not asking for a specific protocol.
