### PR TITLE
Remove (by design) memory-leak by from the Intervals Results linked-list

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2844,6 +2844,14 @@ add_to_interval_list(struct iperf_stream_result * rp, struct iperf_interval_resu
 {
     struct iperf_interval_results *irp;
 
+    /* Only the last interval result is needed, so removing last old entry to reduce memory consupmtion */
+    if (!TAILQ_EMPTY(&rp->interval_results) &&
+        (irp = TAILQ_LAST(&rp->interval_results, irlisthead)) != NULL
+    ) {
+        TAILQ_REMOVE(&rp->interval_results, irp, irlistentries);
+	free(irp);
+    }
+
     irp = (struct iperf_interval_results *) malloc(sizeof(struct iperf_interval_results));
     memcpy(irp, new, sizeof(struct iperf_interval_results));
     TAILQ_INSERT_TAIL(&rp->interval_results, irp, irlistentries);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): may fix #1806

* Brief description of code changes (suitable for use as a commit message):

Intervals Results history is saved in a linked list, but is seems that this history is not used (history is used only as JSON or printed output).  Therefore, keeping this linked list cause unnecessary memory usage and practically this is a **memory leak**.  As each entry i the list is about 400 bytes, with 0.1 sec interval, about 15MB are allocated per one stream per hour, which is about 350MB for one day test per stream.

I suspect that #1806 [problem after running for 3 hours ](https://github.com/esnet/iperf/issues/1806#issuecomment-2533562802)with 24 streams was caused by this memory leak (although this is not confirmed yet).

**This PR suggest the removal of the Interval Results history**, by removing the last entry when allocating a new one.  Practically making 1 the maximum list length.

The suggested change is not optimal, as it removes the old entry and then insert the new one.  A better approach may be to replace the last entry, just reuse the last entry, or even don't use a linked list at all.  However, since the operation is relatively not frequent, the chosen approach seems to be good enough with lower risk.
