### PR TITLE
Increase MAX_MSS to 32K

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -452,7 +452,7 @@ struct iperf_test
 #define MAX_TIME 86400
 #define MAX_OMIT_TIME 600
 #define MAX_BURST 1000
-#define MAX_MSS (9 * 1024)
+#define MAX_MSS (32 * 1024 - 1)
 #define MAX_STREAMS 128
 
 #define TIMESTAMP_FORMAT "%c "


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Brief description of code changes (suitable for use as a commit message):

Today hardware capable 16K MTU already, this raise MAX_MSS to 32K which can be set via -M option. 

I would increased to max allowed for ipv4 datagram size 65536 - 20 - 20, but its not possible to set value above 32767 manually as it return error. 
`setsockopt(3, SOL_TCP, TCP_MAXSEG, [32768], 4) = -1 EINVAL (Invalid argument)`

