### PR TITLE
JSON_Read() warning messages enhancements

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2789,12 +2789,12 @@ JSON_read(int fd, int max_size)
                             json = cJSON_Parse(str);
                         }
                         else {
-                            sprintf(msg_buf, "JSON size of data read does not correspond to offered length - expected %d bytes but received %d; errno=%d", hsize, rc, errno);
+                            snprintf(msg_buf, sizeof(msg_buf), "JSON size of data read does not correspond to offered length - expected %d bytes but received %d; errno=%d", hsize, rc, errno);
                             warning(msg_buf);
                         }
 	            }
                     else {
-                        sprintf(msg_buf, "JSON data read failed; errno=%d", errno);
+                        snprintf(msg_buf, sizeof(msg_buf), "JSON data read failed; errno=%d", errno);
                         warning(msg_buf);
                     }
 	            free(str);
@@ -2802,13 +2802,13 @@ JSON_read(int fd, int max_size)
             }
 	}
 	else {
-            sprintf(msg_buf, "JSON data length overflow - %d bytes JSON size is not allowed", hsize);
+            snprintf(msg_buf, sizeof(msg_buf), "JSON data length overflow - %d bytes JSON size is not allowed", hsize);
 	    warning(msg_buf);
 	}
     }
     else {
         warning("Failed to read JSON data size");
-        sprintf(msg_buf, "Failed to read JSON data size - read returned %d; errno=%d", rc, errno);
+        snprintf(msg_buf, sizeof(msg_buf), "Failed to read JSON data size - read returned %d; errno=%d", rc, errno);
         warning(msg_buf);
     }
     return json;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2761,6 +2761,7 @@ JSON_read(int fd, int max_size)
     char *str;
     cJSON *json = NULL;
     int rc;
+    char msg_buf[WARN_STR_LEN * 2];
 
     /*
      * Read a four-byte integer, which is the length of the JSON to follow.
@@ -2788,19 +2789,27 @@ JSON_read(int fd, int max_size)
                             json = cJSON_Parse(str);
                         }
                         else {
-                            warning("JSON size of data read does not correspond to offered length");
+                            sprintf(msg_buf, "JSON size of data read does not correspond to offered length - expected %d bytes but received %d; errno=%d", hsize, rc, errno);
+                            warning(msg_buf);
                         }
 	            }
+                    else {
+                        sprintf(msg_buf, "JSON data read failed; errno=%d", errno);
+                        warning(msg_buf);
+                    }
 	            free(str);
                 }
             }
 	}
 	else {
-	    warning("JSON data length overflow");
+            sprintf(msg_buf, "JSON data length overflow - %d bytes JSON size is not allowed", hsize);
+	    warning(msg_buf);
 	}
     }
     else {
         warning("Failed to read JSON data size");
+        sprintf(msg_buf, "Failed to read JSON data size - read returned %d; errno=%d", rc, errno);
+        warning(msg_buf);
     }
     return json;
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):
Enhancement to the `JSON_Read()` `warning()` messages done while evaluating issue #1808.  I believe that they can help in other situations.

