### PR TITLE
iperf_api: fix potential descriptor leak

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4884,6 +4884,7 @@ iperf_create_pidfile(struct iperf_test *test)
 		    }
 		}
 	    }
+        (void)close(fd);
 	}
 
 	/*


### PR DESCRIPTION
* Development branch: master

* Issues fixed: descriptor leak

* Brief description of code changes: If the pid file remains, but the process has been killed, the handle will be rewritten without closing.
