### PR TITLE
iperf_tcp: Fix two potential memory leaks in iperf_tcp_connect()

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -454,6 +454,8 @@ iperf_tcp_connect(struct iperf_test *test)
 	printf("SNDBUF is %u, expecting %u\n", sndbuf_actual, test->settings->socket_bufsize);
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > sndbuf_actual) {
+    close(s);
+	freeaddrinfo(server_res);
 	i_errno = IESETBUF2;
 	return -1;
     }


### PR DESCRIPTION
* Development branch: master

* Issues fixed: descriptor and memory leaks

* Brief description of code changes: The descriptor `s` and pointer `server_res` are lost without close and free.

