### PR TITLE
docs: Fix wrong URL in news entry for iperf-3.18

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,7 +4,7 @@ iperf3 Project News
 2024-12-13:  iperf-3.18 released
 --------------------------------
 
-| URL:  https://downloads.es.net/pub/iperf/iperf-3.8.1.tar.gz
+| URL:  https://downloads.es.net/pub/iperf/iperf-3.18.tar.gz
 | SHA256: ``c0618175514331e766522500e20c94bfb293b4424eb27d7207fb427b88d20bab``
 
 iperf-3.18 includes fixes for several bugs, including one that could


### PR DESCRIPTION
Pointed out by @victorlupuseli in #1826.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

