### PR TITLE
Add missing code for SERVER_ERRROR handling under HAVE_SSL

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2201,12 +2201,17 @@ iperf_exchange_parameters(struct iperf_test *test)
                 i_errno = IECTRLWRITE;
                 return -1;
             }
+            err = htonl(errno);
+            if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+                i_errno = IECTRLWRITE;
+                return -1;
+            }
             return -1;
         }
 #endif //HAVE_SSL
 
         if ((s = test->protocol->listen(test)) < 0) {
-	        if (iperf_set_send_state(test, SERVER_ERROR) != 0)
+	    if (iperf_set_send_state(test, SERVER_ERROR) != 0)
                 return -1;
             err = htonl(i_errno);
             if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

When `test_is_authorized(test)` fails (under `HAVE_SSL`) and `SERVER_ERROR` state is set, the code for sending `errno` to the client is missing.

