### PR TITLE
json: add UNIX timestamp in milliseconds

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -72,8 +72,9 @@
 #include "net.h"
 #include "iperf.h"
 #include "iperf_api.h"
-#include "iperf_udp.h"
 #include "iperf_tcp.h"
+#include "iperf_time.h"
+#include "iperf_udp.h"
 #if defined(HAVE_SCTP_H)
 #include "iperf_sctp.h"
 #endif /* HAVE_SCTP_H */
@@ -944,7 +945,6 @@ mapped_v4_to_regular_v4(char *str)
 void
 iperf_on_connect(struct iperf_test *test)
 {
-    time_t now_secs;
     const char* rfc1123_fmt = "%a, %d %b %Y %H:%M:%S %Z";
     char now_str[100];
     char ipr[INET6_ADDRSTRLEN];
@@ -953,11 +953,17 @@ iperf_on_connect(struct iperf_test *test)
     struct sockaddr_in *sa_inP;
     struct sockaddr_in6 *sa_in6P;
     socklen_t len;
+    struct iperf_time now;
+    time_t now_secs;
+    unsigned long long now_millisecs;
 
-    now_secs = time((time_t*) 0);
+    iperf_time_now_wallclock(&now);
+    now_millisecs = (time_t) iperf_time_in_usecs(&now) / 1000;
+    now_secs = (time_t) (now_millisecs / 1000);
+
     (void) strftime(now_str, sizeof(now_str), rfc1123_fmt, gmtime(&now_secs));
     if (test->json_output)
-	cJSON_AddItemToObject(test->json_start, "timestamp", iperf_json_printf("time: %s  timesecs: %d", now_str, (int64_t) now_secs));
+	cJSON_AddItemToObject(test->json_start, "timestamp", iperf_json_printf("time: %s  timesecs: %d  timemillisecs: %d", now_str, (int64_t) now_secs, now_millisecs));
     else if (test->verbose)
 	iperf_printf(test, report_time, now_str);
 

--- a/src/iperf_time.h
+++ b/src/iperf_time.h
@@ -34,6 +34,24 @@ struct iperf_time {
     uint32_t usecs;
 };
 
+/**
+ * Retrieves the current wallclock time.
+ *
+ * When during operation the system-wide clock changes, users will see
+ * this and results might become inconsistent.
+ */
+int iperf_time_now_wallclock(struct iperf_time *time1);
+
+/**
+ * Retrieves the current time using a monotonic clock.
+ *
+ * When during operation the system-wide clock changes, users still will see
+ * a strictly monotonic increasing clock.
+ *
+ * Please note that a monotonic clock is only available on systems that have the
+ * `clock_gettime()` system call. On other systems, this falls back to
+ * `iperf_time_now_wallclock()`.
+ */
 int iperf_time_now(struct iperf_time *time1);
 
 void iperf_time_add_usecs(struct iperf_time *time1, uint64_t usecs);
@@ -44,6 +62,9 @@ int iperf_time_diff(struct iperf_time *time1, struct iperf_time *time2, struct i
 
 uint64_t iperf_time_in_usecs(struct iperf_time *time);
 
+/**
+ * Returns the time in seconds as double type with a microsecond granularity.
+ */
 double iperf_time_in_secs(struct iperf_time *time);
 
 #endif


### PR DESCRIPTION
json: add UNIX timestamp in milliseconds

This extends the "timestamp" field with a UNIX timestamp in milliseconds
representing the current local wall clock time.

The "timestamp" field now has a new subkey:

    "timestamp": {
      "time": "Tue, 25 Feb 2025 11:49:59 GMT",
      "timesecs": 1740484199,
      // new
      "timemillisecs": 1740484199926
    },

This is helpful when one does fine-grained network tests with iperf,
where iperf events need to be aligned with events coming from other
resources. A time resolution based on seconds is too coarse-grained
for that.

It is enough to use milliseconds here, as networking always comes
with small timing offsets and delays. Using microseconds wouldn't 
add a benefit. 

It is sufficient to only change the code at this place, as the rel time
offset for all further events already includes milliseconds. Currently,
iperf3 prints this time offset in seconds encoded as a double with
a microsecond granularity.

Signed-off-by: Philipp Schuster <philipp.schuster@cyberus-technology.de>

---

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

