### PR TITLE
Extending PR #1821 fix to PR #1773 for sending when bitrate is set

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2065,7 +2065,7 @@ iperf_send_mt(struct iperf_stream *sp)
     }
 #if defined(HAVE_CLOCK_NANOSLEEP) || defined(HAVE_NANOSLEEP)
      /* Should check if green light can be set, as pacing timer is not supported in this case */
-    if (throttle_check && !throttle_check_per_message) {
+    if (throttle_check && (!throttle_check_per_message || message_sent == 0)) {
 #else /* !HAVE_CLOCK_NANOSLEEP && !HAVE_NANOSLEEP */
     if (!throttle_check_per_message || message_sent == 0) {   /* Throttle check if was not checked for each send */
 #endif /* HAVE_CLOCK_NANOSLEEP, HAVE_NANOSLEEP */


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1847

* Brief description of code changes (suitable for use as a commit message):

Further fix to #1773 that was partially fixed by #1821.  This fix here is making sure that after sending, the conditions for green light will be evaluated if no message was send.  The issue was actually caused by wrong copy/paste (did not copy the `|| message_sent == 0`) 😞...

@bmah888, not that this seems to be a **quite urgent issue**.  It happens with **short packets much more frequently** (this is why I didn't find it in my tests).  My understanding is that this is because the long enough delays between packets, the micro-sleep mechanism resolution is good enough, and the delays between packets are bigger for large packets.



