### PR TITLE
Secure iperf3 systemd service

### DIFF
--- a/contrib/iperf3.service
+++ b/contrib/iperf3.service
@@ -5,6 +5,23 @@ Requires=network.target
 [Service]
 ExecStart=/usr/bin/iperf3 -s
 Restart=on-failure
+User=nobody
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

## Issues fixed (if any):

This pull request improves the security posture of the iperf3 systemd service by introducing additional systemd hardening options. These changes restrict privileges, isolate resources, and mitigate potential attack vectors.

## Brief description of code changes (suitable for use as a commit message):

- Added **`User=nobody`** to run `iperf3` with minimal privileges.
- Enabled **systemd sandboxing features**:
  - `NoNewPrivileges=yes` – Prevents privilege escalation.
  - `PrivateTmp=yes` – Isolates `/tmp` and `/var/tmp` to prevent interference.
  - `PrivateDevices=yes` and `DevicePolicy=closed` – Restricts access to device files.
  - `ProtectSystem=strict` – Makes the filesystem read-only except for essential directories.
  - `ProtectHome=read-only` – Prevents modification of user home directories.
  - `ProtectControlGroups=yes`, `ProtectKernelModules=yes`, `ProtectKernelTunables=yes` – Restricts access to kernel-related settings.
  - `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK` – Limits allowed network families.
  - `RestrictNamespaces=yes` – Disables namespace usage to prevent container escape vulnerabilities.
  - `RestrictRealtime=yes` and `RestrictSUIDSGID=yes` – Prevents real-time scheduling abuse and SUID/SGID privilege escalation.
  - `MemoryDenyWriteExecute=yes` – Blocks execution of writable memory.
  - `LockPersonality=yes` – Prevents personality changes to avoid exploits.

