### PR TITLE
Print an error message when a Send/Receive Worker Thread fail

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -93,7 +93,10 @@ iperf_client_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
-    iperf_err(test, "Client Worker Thread failed - %s", iperf_strerror(i_errno));
+    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet but the main thread
+        iperf_err(test, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
+        if (test->ctrl_sck != -1) iflush(test);
+    }
     return NULL;
 }
 

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -93,7 +93,7 @@ iperf_client_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
-    iperf_err(test, "Client Worker Thread failed - %s, with errno %s (%d)", iperf_strerror(i_errno), strerror(errno), errno);
+    iperf_err(test, "Client Worker Thread failed - %s", iperf_strerror(i_errno));
     return NULL;
 }
 

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -93,6 +93,7 @@ iperf_client_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
+    iperf_err(test, "Client Worker Thread failed - %s, with errno %s (%d)", iperf_strerror(i_errno), strerror(errno), errno);
     return NULL;
 }
 

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -93,8 +93,9 @@ iperf_client_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
-    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet but the main thread
-        iperf_err(test, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
+    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet by the main thread
+        // Error message is printed to NULL test to prevent adding JSON output context into the thread context
+        iperf_err(NULL, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
         if (test->ctrl_sck != -1) iflush(test);
     }
     return NULL;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -106,6 +106,7 @@ iperf_server_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
+    iperf_err(test, "Server Worker Thread failed - %s, with errno %s (%d)", iperf_strerror(i_errno), strerror(errno), errno);
     return NULL;
 }
 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -106,7 +106,7 @@ iperf_server_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
-    iperf_err(test, "Server Worker Thread failed - %s, with errno %s (%d)", iperf_strerror(i_errno), strerror(errno), errno);
+    iperf_err(test, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
     return NULL;
 }
 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -106,7 +106,10 @@ iperf_server_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
-    iperf_err(test, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
+    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet but the main thread
+        iperf_err(test, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
+        if (test->ctrl_sck != -1) iflush(test);
+    }
     return NULL;
 }
 

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -106,8 +106,9 @@ iperf_server_worker_run(void *s) {
     return NULL;
 
   cleanup_and_fail:
-    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet but the main thread
-        iperf_err(test, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
+    if (test->ctrl_sck != -1) { // Make sure test was not cleared yet by the main thread
+        // Error message is printed to NULL test to prevent adding JSON output context into the thread context
+        iperf_err(NULL, "Server Worker Thread failed - %s", iperf_strerror(i_errno));
         if (test->ctrl_sck != -1) iflush(test);
     }
     return NULL;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):
Add error message if a Send/Receive Worker Thread fail.  Currently such failure is "silent".

