### PR TITLE
replace strncat (unsafe) with strlcat (safe)

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2555,8 +2555,7 @@ send_results(struct iperf_test *test)
 		/* Allocate and build it up from the component lines */
 		char *output = calloc(buflen + 1, 1);
 		TAILQ_FOREACH(t, &(test->server_output_list), textlineentries) {
-		    strncat(output, t->line, buflen);
-		    buflen -= strlen(t->line);
+		    strlcat(output, t->line, buflen+1);		    
 		}
 
 		cJSON_AddStringToObject(j, "server_output_text", output);

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -556,11 +556,11 @@ iperf_strerror(int int_errno)
 
     /* Append the result of strerror() or gai_strerror() if appropriate */
     if (herr || perr)
-        strncat(errstr, ": ", len - strlen(errstr) - 1);
+        strlcat(errstr, ": ", len);
     if (errno && perr)
-        strncat(errstr, strerror(errno), len - strlen(errstr) - 1);
+        strlcat(errstr, strerror(errno), len);
     else if (herr && gerror) {
-        strncat(errstr, gai_strerror(gerror), len - strlen(errstr) - 1);
+        strlcat(errstr, gai_strerror(gerror), len);
 	gerror = 0;
     }
 

--- a/src/iperf_util.c
+++ b/src/iperf_util.c
@@ -249,107 +249,86 @@ get_optional_features(void)
 
 #if defined(HAVE_CPU_AFFINITY)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+	strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "CPU affinity setting",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "CPU affinity setting", sizeof(features));
     numfeatures++;
 #endif /* HAVE_CPU_AFFINITY */
 
 #if defined(HAVE_FLOWLABEL)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+	strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "IPv6 flow label",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "IPv6 flow label", sizeof(features));
     numfeatures++;
 #endif /* HAVE_FLOWLABEL */
 
 #if defined(HAVE_SCTP_H)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "SCTP",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "SCTP", sizeof(features));	
     numfeatures++;
 #endif /* HAVE_SCTP_H */
 
 #if defined(HAVE_TCP_CONGESTION)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "TCP congestion algorithm setting",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "TCP congestion algorithm setting", sizeof(features));
     numfeatures++;
 #endif /* HAVE_TCP_CONGESTION */
 
 #if defined(HAVE_SENDFILE)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "sendfile / zerocopy",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "sendfile / zerocopy",  sizeof(features));	
     numfeatures++;
 #endif /* HAVE_SENDFILE */
 
 #if defined(HAVE_SO_MAX_PACING_RATE)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "socket pacing",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "socket pacing", sizeof(features));	
     numfeatures++;
 #endif /* HAVE_SO_MAX_PACING_RATE */
 
 #if defined(HAVE_SSL)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "authentication",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "authentication", sizeof(features));	
     numfeatures++;
 #endif /* HAVE_SSL */
 
 #if defined(HAVE_SO_BINDTODEVICE)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "bind to device",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "bind to device", sizeof(features));	
     numfeatures++;
 #endif /* HAVE_SO_BINDTODEVICE */
 
 #if defined(HAVE_DONT_FRAGMENT)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "support IPv4 don't fragment",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "support IPv4 don't fragment", sizeof(features));	
     numfeatures++;
 #endif /* HAVE_DONT_FRAGMENT */
 
 #if defined(HAVE_PTHREAD)
     if (numfeatures > 0) {
-	strncat(features, ", ",
-		sizeof(features) - strlen(features) - 1);
+    strlcat(features, ", ", sizeof(features));
     }
-    strncat(features, "POSIX threads",
-	sizeof(features) - strlen(features) - 1);
+    strlcat(features, "POSIX threads", sizeof(features));	
     numfeatures++;
 #endif /* HAVE_PTHREAD */
 
     if (numfeatures == 0) {
-	strncat(features, "None",
-		sizeof(features) - strlen(features) - 1);
+	strlcat(features, "None",  sizeof(features));		
     }
 
     return features;


### PR DESCRIPTION
Some code bases will not allow strncat anymore for safety concerns. Replace with strlcat, note when using strlcat you simply pass the full size of the buffer (you do not account for the NULL terminator, this is handled for you).

I tested this by forcing inclusion of features using ...

CFLAGS='-DHAVE_CPU_AFFINITY -DHAVE_FLOWLABEL  -DHAVE_TCP_CONGESTION -DHAVE_SENDFILE -DHAVE_SO_MAX_PACING_RATE -DHAVE_SO_BINDTODEVICE -DHAVE_DONT_FRAGMENT -DHAVE_PTHREAD' ./configure

NOTE: I tried to include SCTP and SSL but both failed to compile for missing headers.

I tested the 

TAILQ_FOREACH(t, &(test->server_output_list), textlineentries) {
		    strlcat(output, t->line, buflen+1);		 
            printf("otuput line: %s\n", t->line);
		}

section by forcing

        struct iperf_textline *line1 = malloc(sizeof(*line1));
        struct iperf_textline *line2 = malloc(sizeof(*line2));
        
        line1->line = strdup("First line\n");
        line2->line = strdup("Second line\n");
        
        TAILQ_INSERT_TAIL(&(test->server_output_list), line1, textlineentries);
        TAILQ_INSERT_TAIL(&(test->server_output_list), line2, textlineentries);

beforehand. Tested error path by forcing error in server, force the IEDAEMON error with errno=999. Error string was as expected.




_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

