### PR TITLE
GitHub actions: Remove deprecated CI runner, add more diverse set of …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,11 @@ jobs:
       run: |
         sudo apt-get -y update && sudo apt-get install -y cppcheck && \
         cppcheck . --force --inline-suppr
-  build-test-latest:
-    runs-on: ubuntu-latest
+  build-test-ubuntu-ish:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: install dependencies
@@ -21,15 +24,18 @@ jobs:
         ./configure && make && make check
         timeout 300 src/iperf3 -s &
         ./test_commands.sh localhost
-  build-test-ubuntu-20_04:
-    runs-on: ubuntu-20.04
+  build-test-macos-ish:
+    strategy:
+      matrix:
+        os: [macos-15, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - name: install dependencies
       run: |
-        sudo apt-get -y update && sudo apt-get install -y build-essential 
+        brew install coreutils
     - name: build
       run: |
         ./configure && make && make check
-        timeout 300 src/iperf3 -s &
+        gtimeout 300 src/iperf3 -s &
         ./test_commands.sh localhost

--- a/test_commands.sh
+++ b/test_commands.sh
@@ -67,7 +67,7 @@ host=$1
 ./src/iperf3 -c "$host" -A 2/2 -u -b1G
 # Burst mode
 ./src/iperf3 -c "$host" -u -b1G/100
-# change MSS
-./src/iperf3 -c "$host" -M 1000 -V
 # test congestion control option (linux only)
 ./src/iperf3 -c "$host" -C reno -V
+# change MSS
+./src/iperf3 -c "$host" -M 1000 -V


### PR DESCRIPTION
…runners.

Reorder test cases so that the last test is platform-independent, to prevent Github action failures on macOS runners.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): None

* Brief description of code changes (suitable for use as a commit message):

