### PR TITLE
UDP continute receiving in TEST_END state to allow receing last packets

### DIFF
--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -74,7 +74,7 @@ iperf_udp_recv(struct iperf_stream *sp)
         return r;
 
     /* Only count bytes received while we're in the correct state. */
-    if (test->state == TEST_RUNNING) {
+    if (test->state == TEST_RUNNING || test->state == TEST_END) {
 
 	/*
 	 * For jitter computation below, it's important to know if this


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master (3.18+)

* Issues fixed (if any): #1865

* Brief description of code changes (suitable for use as a commit message):

In UDP test, continue to receive packets during `TEST_END` state (until `PARAMETERS_EXCHANGE` state).  In reverse or bi-directional mode, that allows the Client statistics to properly take into account the packets that were sent from the Server between the time the Client switched to `TEST_END` and the time the server received and switched to this state.

