### PR TITLE
Correct typo in net.c

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -386,7 +386,7 @@ Nread(int fd, char *buf, size_t count, int prot)
      *
      * This check could go inside the while() loop below, except we're
      * currently considering whether it might make sense to support a
-     * codepath that bypassese this check, for situations where we
+     * codepath that bypass this check, for situations where we
      * already know that fd has data on it (for example if we'd gotten
      * to here as the result of a select() call.
      */


### PR DESCRIPTION
Correction of typo.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
  master

* Issues fixed (if any):
  None, it's a typographical error.

* Brief description of code changes (suitable for use as a commit message):
  Corrected typographical error.
