### PR TITLE
Minor fix-ups from #1717

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -1,4 +1,4 @@
-.TH IPERF3 1 "May 2024" ESnet "User Manuals"
+.TH IPERF3 1 "May 2025" ESnet "User Manuals"
 .SH NAME
 iperf3 \- perform network throughput tests
 .SH SYNOPSIS
@@ -409,6 +409,10 @@ Set number of SCTP streams.
 .BR -Z ", " --zerocopy " "
 Use a "zero copy" method of sending data, such as sendfile(2),
 instead of the usual write(2).
+.TP
+.BR --skip-rx-copy
+Ignored received packet data, using the MSG_TRUNC flag to the
+recv(2) system call.
 .TP
 .BR -O ", " --omit " \fIn\fR"
 Perform pre-test for N seconds and omit the pre-test statistics, to skip past the TCP slow-start

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -1,5 +1,5 @@
 /*
- * iperf, Copyright (c) 2014-2023, The Regents of the University of
+ * iperf, Copyright (c) 2014-2025, The Regents of the University of
  * California, through Lawrence Berkeley National Laboratory (subject
  * to receipt of any required approvals from the U.S. Dept. of
  * Energy).  All rights reserved.
@@ -101,8 +101,8 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_JSON_STREAM 28
 #define OPT_SND_TIMEOUT 29
 #define OPT_USE_PKCS1_PADDING 30
-#define OPT_SKIP_RX_COPY 32
 #define OPT_CNTL_KA 31
+#define OPT_SKIP_RX_COPY 32
 
 /* states */
 #define TEST_START 1


### PR DESCRIPTION
* Add an entry in the manual page for --skip-rx-copy

* Re-sort command-line flag constants in src/iperf_api.h

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

