### PR TITLE
Fix two minor memory / file descriptor leaks in iperf_tcp_connect().

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -474,6 +474,8 @@ iperf_tcp_connect(struct iperf_test *test)
 	printf("SNDBUF is %u, expecting %u\n", sndbuf_actual, test->settings->socket_bufsize);
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > sndbuf_actual) {
+        close(s);
+        freeaddrinfo(server_res);
 	i_errno = IESETBUF2;
 	return -1;
     }
@@ -492,6 +494,8 @@ iperf_tcp_connect(struct iperf_test *test)
 	printf("RCVBUF is %u, expecting %u\n", rcvbuf_actual, test->settings->socket_bufsize);
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > rcvbuf_actual) {
+        close(s);
+        freeaddrinfo(server_res);
 	i_errno = IESETBUF2;
 	return -1;
     }


### PR DESCRIPTION
Recreating and extending #1823 by @maks-mishin.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): #1823

* Brief description of code changes (suitable for use as a commit message):

Recreating PR #1823 plus review feedback.
