### PR TITLE
RELNOTES: fix Multipath-TCP flag

### DIFF
--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -7,7 +7,7 @@ iperf-3.19 2025-05-16
 * Notable user-visible changes
 
     * iperf3 now supports the use of Multi-Path TCP (MPTCPv1) on Linux
-      with the use of the `--multipath` flag. (PR #1661)
+      with the use of the `-m` or `--mptcp` flag. (PR #1661)
 
     * iperf3 now supports a `--cntl-ka` option to enable TCP keepalives
       on the control connection. (#812, #835, PR #1423)


### PR DESCRIPTION
Thank you for the recent v3.19 release! 

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: 3.19

* Issues fixed (if any): /

* Brief description of code changes (suitable for use as a commit message): The option for Multipath-TCP support is apparently `--mptcp`, not `--multipath`. See: 

https://github.com/esnet/iperf/blob/57396df3c19227741b8cd40c24b105d28672b6f7/src/iperf_api.c#L1165

While at it, mention `-m` which is the short option.

Note that the text in the release section also needs to be updated: https://github.com/esnet/iperf/releases/tag/3.19


