### PR TITLE
Fix a compilation issue with uClibc due to a missing include file.

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -53,7 +53,6 @@
 #include <sys/stat.h>
 #include <sched.h>
 #include <setjmp.h>
-#include <stdarg.h>
 #include <math.h>
 
 #if defined(HAVE_CPUSET_SETAFFINITY)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -30,6 +30,7 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <setjmp.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdint.h>
 #ifdef __cplusplus


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): build error with uclibc
`In file included from t_auth.c:35:
iperf_api.h:395:77: error: unknown type name ‘va_list’
  395 | void iperf_exit(struct iperf_test *test, int exit_code, const char *format, va_list argp) __attribute__ ((noreturn));
	  |                                                                             ^~~~~~~
iperf_api.h:33:1: note: ‘va_list’ is defined in header ‘<stdarg.h>’; did you forget to ‘#include <stdarg.h>’?
   32 | #include <setjmp.h>
  +++ |+#include <stdarg.h>
   33 | #include <stdio.h>`

* Brief description of code changes (suitable for use as a commit message):
Added missing <stdarg.h> header in the iperf_api.h.
