### PR TITLE
Server JSON Output Does Not Report Client's Results

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -275,13 +275,13 @@ iperf_handle_message_server(struct iperf_test *test)
                 FD_CLR(sp->socket, &test->write_set);
                 close(sp->socket);
             }
-            test->reporter_callback(test);
             if (iperf_set_send_state(test, EXCHANGE_RESULTS) != 0)
                 return -1;
             if (iperf_exchange_results(test) < 0)
                 return -1;
             if (iperf_set_send_state(test, DISPLAY_RESULTS) != 0)
                 return -1;
+            test->reporter_callback(test);
             if (test->on_test_finish)
                 test->on_test_finish(test);
             break;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): [iperf/#1410
](https://github.com/esnet/iperf/issues/1410)
* Brief description of code changes (suitable for use as a commit message):

On the `iperf` server, no results are displayed from the client's side, even though this information is sent to the server. It appears that the reporter callback was called prior to setting the test state to `DISPLAY_RESULTS`. Moving the call to the reporter callback function to after that state is set seems to fix the issue, as I can now see the client's results displayed in the server's JSON output.

<details>

<summary>Server JSON</summary>

```json
{
        "start":        {
                "connected":    [{
                                "socket":       5,
                                "local_host":   "127.0.0.1",
                                "local_port":   5202,
                                "remote_host":  "127.0.0.1",
                                "remote_port":  54714
                        }],
                "version":      "iperf 3.19+",
                "system_info":  "Linux windows-nexus 6.6.87.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC 2025 x86_64",
                "sock_bufsize": 0,
                "sndbuf_actual":        16384,
                "rcvbuf_actual":        131072,
                "timestamp":    {
                        "time": "Mon, 14 Jul 2025 17:47:32 GMT",
                        "timesecs":     1752515252,
                        "timemillisecs":        1752515252430
                },
                "accepted_connection":  {
                        "host": "127.0.0.1",
                        "port": 54708
                },
                "cookie":       "6qnxxmqahsmytu7tr3spkqhgrk7irlyktagx",
                "tcp_mss_default":      0,
                "target_bitrate":       0,
                "fq_rate":      500000000,
                "test_start":   {
                        "protocol":     "TCP",
                        "num_streams":  1,
                        "blksize":      131072,
                        "omit": 1,
                        "duration":     2,
                        "bytes":        0,
                        "blocks":       0,
                        "reverse":      0,
                        "tos":  0,
                        "target_bitrate":       0,
                        "bidir":        0,
                        "fqrate":       500000000,
                        "interval":     1
                }
        },
        "intervals":    [{
                        "streams":      [{
                                        "socket":       5,
                                        "start":        0,
                                        "end":  1.001054,
                                        "seconds":      1.001054048538208,
                                        "bytes":        62914560,
                                        "bits_per_second":      502786518.6050337,
                                        "omitted":      true,
                                        "sender":       false
                                }],
                        "sum":  {
                                "start":        0,
                                "end":  1.001054,
                                "seconds":      1.001054048538208,
                                "bytes":        62914560,
                                "bits_per_second":      502786518.6050337,
                                "omitted":      true,
                                "sender":       false
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        1.3e-05,
                                        "end":  1.000991,
                                        "seconds":      1.0010039806365967,
                                        "bytes":        62521344,
                                        "bits_per_second":      499669093.90501356,
                                        "omitted":      false,
                                        "sender":       false
                                }],
                        "sum":  {
                                "start":        1.3e-05,
                                "end":  1.000991,
                                "seconds":      1.0010039806365967,
                                "bytes":        62521344,
                                "bits_per_second":      499669093.90501356,
                                "omitted":      false,
                                "sender":       false
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        1.000991,
                                        "end":  2.001042,
                                        "seconds":      1.0000510215759277,
                                        "bytes":        62390272,
                                        "bits_per_second":      499096711.29924917,
                                        "omitted":      false,
                                        "sender":       false
                                }],
                        "sum":  {
                                "start":        1.000991,
                                "end":  2.001042,
                                "seconds":      1.0000510215759277,
                                "bytes":        62390272,
                                "bits_per_second":      499096711.29924917,
                                "omitted":      false,
                                "sender":       false
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        2.001042,
                                        "end":  2.002375,
                                        "seconds":      0.0013330000219866633,
                                        "bytes":        131072,
                                        "bits_per_second":      786628644.189543,
                                        "omitted":      false,
                                        "sender":       false
                                }],
                        "sum":  {
                                "start":        2.001042,
                                "end":  2.002375,
                                "seconds":      0.0013330000219866633,
                                "bytes":        131072,
                                "bits_per_second":      786628644.189543,
                                "omitted":      false,
                                "sender":       false
                        }
                }],
        "end":  {
                "streams":      [{
                                "sender":       {
                                        "socket":       5,
                                        "start":        0,
                                        "end":  2.002327,
                                        "seconds":      2.002327,
                                        "bytes":        124649472,
                                        "bits_per_second":      498018443.54094,
                                        "retransmits":  0,
                                        "reorder":      0,
                                        "max_snd_cwnd": 0,
                                        "max_snd_wnd":  0,
                                        "max_rtt":      0,
                                        "min_rtt":      0,
                                        "mean_rtt":     0,
                                        "sender":       false
                                },
                                "receiver":     {
                                        "socket":       5,
                                        "start":        0,
                                        "end":  2.002375,
                                        "seconds":      2.002375,
                                        "bytes":        125042688,
                                        "bits_per_second":      499577503.71433926,
                                        "sender":       false
                                }
                        }],
                "sum_sent":     {
                        "start":        0,
                        "end":  2.002327,
                        "seconds":      2.002327,
                        "bytes":        124649472,
                        "bits_per_second":      498018443.54094,
                        "retransmits":  0,
                        "sender":       false
                },
                "sum_received": {
                        "start":        0,
                        "end":  2.002375,
                        "seconds":      2.002375,
                        "bytes":        125042688,
                        "bits_per_second":      499577503.71433926,
                        "sender":       false
                },
                "cpu_utilization_percent":      {
                        "host_total":   2.0814591122934472,
                        "host_user":    0.16557515140820453,
                        "host_system":  1.9158839608852427,
                        "remote_total": 1.5036114967449765,
                        "remote_user":  0.023864735875288281,
                        "remote_system":        1.4797800450201419
                },
                "sender_tcp_congestion":        "cubic",
                "receiver_tcp_congestion":      "cubic"
        }
}
```

</details>

<details>

<summary>Client JSON</summary>

```json
{
        "start":        {
                "connected":    [{
                                "socket":       5,
                                "local_host":   "127.0.0.1",
                                "local_port":   54714,
                                "remote_host":  "127.0.0.1",
                                "remote_port":  5202
                        }],
                "version":      "iperf 3.19+",
                "system_info":  "Linux windows-nexus 6.6.87.2-microsoft-standard-WSL2 #1 SMP PREEMPT_DYNAMIC Thu Jun  5 18:30:46 UTC 2025 x86_64",
                "timestamp":    {
                        "time": "Mon, 14 Jul 2025 17:47:32 GMT",
                        "timesecs":     1752515252,
                        "timemillisecs":        1752515252430
                },
                "connecting_to":        {
                        "host": "127.0.0.1",
                        "port": 5202
                },
                "cookie":       "6qnxxmqahsmytu7tr3spkqhgrk7irlyktagx",
                "tcp_mss_default":      32768,
                "target_bitrate":       0,
                "fq_rate":      500000000,
                "sock_bufsize": 0,
                "sndbuf_actual":        16384,
                "rcvbuf_actual":        131072,
                "test_start":   {
                        "protocol":     "TCP",
                        "num_streams":  1,
                        "blksize":      131072,
                        "omit": 1,
                        "duration":     2,
                        "bytes":        0,
                        "blocks":       0,
                        "reverse":      0,
                        "tos":  0,
                        "target_bitrate":       0,
                        "bidir":        0,
                        "fqrate":       500000000,
                        "interval":     1
                }
        },
        "intervals":    [{
                        "streams":      [{
                                        "socket":       5,
                                        "start":        0,
                                        "end":  1.000937,
                                        "seconds":      1.0009369850158691,
                                        "bytes":        65404928,
                                        "bits_per_second":      522749615.44327831,
                                        "retransmits":  0,
                                        "snd_cwnd":     654830,
                                        "snd_wnd":      6127872,
                                        "rtt":  1083,
                                        "rttvar":       9,
                                        "pmtu": 65535,
                                        "reorder":      0,
                                        "omitted":      true,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        0,
                                "end":  1.000937,
                                "seconds":      1.0009369850158691,
                                "bytes":        65404928,
                                "bits_per_second":      522749615.44327831,
                                "retransmits":  0,
                                "omitted":      true,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        8.6e-05,
                                        "end":  1.00049,
                                        "seconds":      1.0005760192871094,
                                        "bytes":        62259200,
                                        "bits_per_second":      497786865.16479534,
                                        "retransmits":  0,
                                        "snd_cwnd":     654830,
                                        "snd_wnd":      6127872,
                                        "rtt":  1083,
                                        "rttvar":       7,
                                        "pmtu": 65535,
                                        "reorder":      0,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        8.6e-05,
                                "end":  1.00049,
                                "seconds":      1.0005760192871094,
                                "bytes":        62259200,
                                "bits_per_second":      497786865.16479534,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }, {
                        "streams":      [{
                                        "socket":       5,
                                        "start":        1.00049,
                                        "end":  2.002327,
                                        "seconds":      1.0018370151519775,
                                        "bytes":        62390272,
                                        "bits_per_second":      498206962.26150489,
                                        "retransmits":  0,
                                        "snd_cwnd":     654830,
                                        "snd_wnd":      6127872,
                                        "rtt":  1091,
                                        "rttvar":       20,
                                        "pmtu": 65535,
                                        "reorder":      0,
                                        "omitted":      false,
                                        "sender":       true
                                }],
                        "sum":  {
                                "start":        1.00049,
                                "end":  2.002327,
                                "seconds":      1.0018370151519775,
                                "bytes":        62390272,
                                "bits_per_second":      498206962.26150489,
                                "retransmits":  0,
                                "omitted":      false,
                                "sender":       true
                        }
                }],
        "end":  {
                "streams":      [{
                                "sender":       {
                                        "socket":       5,
                                        "start":        0,
                                        "end":  2.002327,
                                        "seconds":      2.002327,
                                        "bytes":        124649472,
                                        "bits_per_second":      498018443.54094,
                                        "retransmits":  0,
                                        "reorder":      0,
                                        "max_snd_cwnd": 654830,
                                        "max_snd_wnd":  6127872,
                                        "max_rtt":      1091,
                                        "min_rtt":      1083,
                                        "mean_rtt":     1085,
                                        "sender":       true
                                },
                                "receiver":     {
                                        "socket":       5,
                                        "start":        0,
                                        "end":  2.002375,
                                        "seconds":      2.002327,
                                        "bytes":        125042688,
                                        "bits_per_second":      499577503.71433926,
                                        "sender":       true
                                }
                        }],
                "sum_sent":     {
                        "start":        0,
                        "end":  2.002327,
                        "seconds":      2.002327,
                        "bytes":        124649472,
                        "bits_per_second":      498018443.54094,
                        "retransmits":  0,
                        "sender":       true
                },
                "sum_received": {
                        "start":        0,
                        "end":  2.002375,
                        "seconds":      2.002375,
                        "bytes":        125042688,
                        "bits_per_second":      499577503.71433926,
                        "sender":       true
                },
                "cpu_utilization_percent":      {
                        "host_total":   1.5036114967449765,
                        "host_user":    0.023864735875288281,
                        "host_system":  1.4797800450201419,
                        "remote_total": 2.0814591122934472,
                        "remote_user":  0.16557515140820453,
                        "remote_system":        1.9158839608852427
                },
                "sender_tcp_congestion":        "cubic",
                "receiver_tcp_congestion":      "cubic"
        }
}
```

</details>





