### PR TITLE
Add UDP GSO/GRO support (Linux) and --gsro switch

### DIFF
--- a/configure
+++ b/configure
@@ -17399,6 +17399,78 @@ printf "%s\n" "#define HAVE_IPPROTO_MPTCP 1" >>confdefs.h
 
 fi
 
+# Check for UDP_SEGMENT sockopt
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking UDP_SEGMENT socket option" >&5
+printf %s "checking UDP_SEGMENT socket option... " >&6; }
+if test ${iperf3_cv_header_udp_segment+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <linux/udp.h>
+int
+main (void)
+{
+int foo = UDP_SEGMENT;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  iperf3_cv_header_udp_segment=yes
+else case e in #(
+  e) iperf3_cv_header_udp_segment=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $iperf3_cv_header_udp_segment" >&5
+printf "%s\n" "$iperf3_cv_header_udp_segment" >&6; }
+if test "x$iperf3_cv_header_udp_segment" = "xyes"; then
+
+printf "%s\n" "#define HAVE_UDP_SEGMENT 1" >>confdefs.h
+
+fi
+
+# Check for UDP_GRO sockopt
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking UDP_GRO socket option" >&5
+printf %s "checking UDP_GRO socket option... " >&6; }
+if test ${iperf3_cv_header_udp_gro+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <linux/udp.h>
+int
+main (void)
+{
+int foo = UDP_GRO;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  iperf3_cv_header_udp_gro=yes
+else case e in #(
+  e) iperf3_cv_header_udp_gro=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $iperf3_cv_header_udp_gro" >&5
+printf "%s\n" "$iperf3_cv_header_udp_gro" >&6; }
+if test "x$iperf3_cv_header_udp_gro" = "xyes"; then
+
+printf "%s\n" "#define HAVE_UDP_GRO 1" >>confdefs.h
+
+fi
+
 # Check if we need -lrt for clock_gettime
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
 printf %s "checking for library containing clock_gettime... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -375,6 +375,30 @@ if test "x$iperf3_cv_header_ipproto_mptcp" = "xyes"; then
     AC_DEFINE([HAVE_IPPROTO_MPTCP], [1], [Have MPTCP protocol.])
 fi
 
+# Check for UDP_SEGMENT sockopt
+AC_CACHE_CHECK([UDP_SEGMENT socket option],
+[iperf3_cv_header_udp_segment],
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <linux/udp.h>]],
+                   [[int foo = UDP_SEGMENT;]])],
+  iperf3_cv_header_udp_segment=yes,
+  iperf3_cv_header_udp_segment=no))
+if test "x$iperf3_cv_header_udp_segment" = "xyes"; then
+    AC_DEFINE([HAVE_UDP_SEGMENT], [1], [Have UDP_SEGMENT sockopt.])
+fi
+
+# Check for UDP_GRO sockopt
+AC_CACHE_CHECK([UDP_GRO socket option],
+[iperf3_cv_header_udp_gro],
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[#include <linux/udp.h>]],
+                   [[int foo = UDP_GRO;]])],
+  iperf3_cv_header_udp_gro=yes,
+  iperf3_cv_header_udp_gro=no))
+if test "x$iperf3_cv_header_udp_gro" = "xyes"; then
+    AC_DEFINE([HAVE_UDP_GRO], [1], [Have UDP_GRO sockopt.])
+fi
+
 # Check if we need -lrt for clock_gettime
 AC_SEARCH_LIBS(clock_gettime, [rt posix4])
 # Check for clock_gettime support

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -191,15 +191,12 @@ struct iperf_settings
     int       cntl_ka_keepidle;     /* Control TCP connection Keepalive idle time (TCP_KEEPIDLE) */
     int       cntl_ka_interval;     /* Control TCP connection Keepalive interval between retries (TCP_KEEPINTV) */
     int       cntl_ka_count;        /* Control TCP connection Keepalive number of retries (TCP_KEEPCNT) */
-#ifdef HAVE_UDP_SEGMENT
+    /* GSO/GRO fields always present to allow client-server negotiation regardless of local support */
     int       gso;
     int       gso_dg_size;
     int       gso_bf_size;
-#endif
-#ifdef HAVE_UDP_GRO
     int       gro;
     int       gro_bf_size;
-#endif
 };
 
 struct iperf_test;

--- a/src/iperf.h
+++ b/src/iperf.h
@@ -191,6 +191,15 @@ struct iperf_settings
     int       cntl_ka_keepidle;     /* Control TCP connection Keepalive idle time (TCP_KEEPIDLE) */
     int       cntl_ka_interval;     /* Control TCP connection Keepalive interval between retries (TCP_KEEPINTV) */
     int       cntl_ka_count;        /* Control TCP connection Keepalive number of retries (TCP_KEEPCNT) */
+#ifdef HAVE_UDP_SEGMENT
+    int       gso;
+    int       gso_dg_size;
+    int       gso_bf_size;
+#endif
+#ifdef HAVE_UDP_GRO
+    int       gro;
+    int       gro_bf_size;
+#endif
 };
 
 struct iperf_test;
@@ -485,5 +494,8 @@ extern int gerror; /* error value from getaddrinfo(3), for use in internal error
 
 /* In Reverse mode, maximum number of packets to wait for "accept" response - to handle out of order packets */
 #define MAX_REVERSE_OUT_OF_ORDER_PACKETS 2
+
+#define GSO_BF_MAX_SIZE MAX_UDP_BLOCKSIZE
+#define GRO_BF_MAX_SIZE MAX_UDP_BLOCKSIZE
 
 #endif /* !__IPERF_H */

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -514,6 +514,15 @@ or high-bitrate UDP tests.  Both client and server need to be running
 at least version 3.1 for this option to work.  It may become the
 default behavior at some point in the future.
 .TP
+.BR --gsro
+Enable UDP Generic Segmentation Offload (GSO) on the sender and
+Generic Receive Offload (GRO) on the receiver, where supported by
+the operating system and network hardware (currently Linux only).
+GSO allows the network stack to aggregate multiple UDP datagrams
+into larger packets, improving throughput and reducing CPU overhead.
+This feature is disabled by default and must be explicitly enabled
+with this flag.
+.TP
 .BR --repeating-payload
 Use repeating pattern in payload, instead of random bytes.
 The same payload is used in iperf2 (ASCII '0..9' repeating).

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -520,6 +520,8 @@ Generic Receive Offload (GRO) on the receiver, where supported by
 the operating system and network hardware (currently Linux only).
 GSO allows the network stack to aggregate multiple UDP datagrams
 into larger packets, improving throughput and reducing CPU overhead.
+This is a client-only option; the client communicates the GSO/GRO
+settings to the server automatically.
 This feature is disabled by default and must be explicitly enabled
 with this flag.
 .TP

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1215,6 +1215,9 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 
     blksize = 0;
     server_flag = client_flag = rate_flag = duration_flag = rcv_timeout_flag = snd_timeout_flag =0;
+#if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
+    int gsro_flag = 0;
+#endif
 #if defined(HAVE_SSL)
     char *client_username = NULL, *client_rsa_public_key = NULL, *server_rsa_private_key = NULL;
     FILE *ptr_file;
@@ -1796,6 +1799,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 #if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
             case OPT_GSRO:
 		/* Enable GSO/GRO which is disabled by default */
+		gsro_flag = 1;
 #ifdef HAVE_UDP_SEGMENT
 		test->settings->gso = 1;
 #endif
@@ -1823,6 +1827,12 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         i_errno = IECLIENTONLY;
         return -1;
     }
+#if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
+    if (test->role == 's' && gsro_flag) {
+        i_errno = IECLIENTONLY;
+        return -1;
+    }
+#endif
 
 /* GSO/GRO are disabled by default when available, enabled only via --gsro */
 

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1190,7 +1190,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         {"mptcp", no_argument, NULL, 'm'},
 #endif
 #if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
-        {"no-gsro", no_argument, NULL, OPT_NO_GSRO},
+        {"gsro", no_argument, NULL, OPT_GSRO},
 #endif
         {"debug", optional_argument, NULL, 'd'},
         {"help", no_argument, NULL, 'h'},
@@ -1794,13 +1794,13 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 		break;
 #endif
 #if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
-            case OPT_NO_GSRO:
-		/* Disable GSO/GRO which would otherwise be enabled by default */
+            case OPT_GSRO:
+		/* Enable GSO/GRO which is disabled by default */
 #ifdef HAVE_UDP_SEGMENT
-		test->settings->gso = 0;
+		test->settings->gso = 1;
 #endif
 #ifdef HAVE_UDP_GRO
-		test->settings->gro = 0;
+		test->settings->gro = 1;
 #endif
                 break;
 #endif
@@ -1824,7 +1824,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         return -1;
     }
 
-/* GSO/GRO are enabled by default when available, disabled only via --no-gsro */
+/* GSO/GRO are disabled by default when available, enabled only via --gsro */
 
 #if defined(HAVE_SSL)
 
@@ -3313,12 +3313,12 @@ iperf_defaults(struct iperf_test *testp)
     testp->settings->pacing_timer = DEFAULT_PACING_TIMER;
     testp->settings->burst = 0;
 #ifdef HAVE_UDP_SEGMENT
-    testp->settings->gso = 1;  /* Enable GSO by default */
+    testp->settings->gso = 0;  /* Disable GSO by default, enabled via --gsro */
     testp->settings->gso_dg_size = 0;
     testp->settings->gso_bf_size = GSO_BF_MAX_SIZE;
 #endif
 #ifdef HAVE_UDP_GRO
-    testp->settings->gro = 1;  /* Enable GRO by default */
+    testp->settings->gro = 0;  /* Disable GRO by default, enabled via --gsro */
     testp->settings->gro_bf_size = GRO_BF_MAX_SIZE;
 #endif
     testp->settings->mss = 0;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1798,13 +1798,6 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 		gsro_flag = 1;
 		test->settings->gso = 1;
 		test->settings->gro = 1;
-#if !defined(HAVE_UDP_SEGMENT) && !defined(HAVE_UDP_GRO)
-		warning("--gsro requested but UDP GSO/GRO not supported on this client; will only be enabled on server if supported");
-#elif !defined(HAVE_UDP_SEGMENT)
-		warning("--gsro requested but UDP GSO not supported on this client; will be enabled on server if supported");
-#elif !defined(HAVE_UDP_GRO)
-		warning("--gsro requested but UDP GRO not supported on this client; will be enabled on server if supported");
-#endif
                 break;
 	    case 'h':
 		usage_long(stdout);
@@ -1828,6 +1821,17 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     if (test->role == 's' && gsro_flag) {
         i_errno = IECLIENTONLY;
         return -1;
+    }
+
+    /* Show platform support warnings only after confirming we're in client mode */
+    if (gsro_flag) {
+#if !defined(HAVE_UDP_SEGMENT) && !defined(HAVE_UDP_GRO)
+        warning("--gsro requested but UDP GSO/GRO not supported on this client; will only be enabled on server if supported");
+#elif !defined(HAVE_UDP_SEGMENT)
+        warning("--gsro requested but UDP GSO not supported on this client; will be enabled on server if supported");
+#elif !defined(HAVE_UDP_GRO)
+        warning("--gsro requested but UDP GRO not supported on this client; will be enabled on server if supported");
+#endif
     }
 
 #if defined(HAVE_SSL)

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1939,7 +1939,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
             test->settings->gso_bf_size = (test->settings->gso_bf_size / test->settings->gso_dg_size) * test->settings->gso_dg_size;
         } else {
             /* If gso_dg_size is 0 (unlimited bandwidth), use default UDP datagram size */
-            test->settings->gso_dg_size = 1472; /* Standard UDP payload size for Ethernet MTU */
+            test->settings->gso_dg_size = DEFAULT_UDP_BLKSIZE;
         }
     }
 #endif
@@ -2618,7 +2618,7 @@ get_parameters(struct iperf_test *test)
 	        test->settings->gso_bf_size = (test->settings->gso_bf_size / test->settings->gso_dg_size) * test->settings->gso_dg_size;
 	    } else {
 	        /* If gso_dg_size is 0 (unlimited bandwidth), use default UDP datagram size */
-	        test->settings->gso_dg_size = 1472; /* Standard UDP payload size for Ethernet MTU */
+	        test->settings->gso_dg_size = DEFAULT_UDP_BLKSIZE;
 	    }
 	}
 #endif

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -106,6 +106,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_SKIP_RX_COPY 32
 #define OPT_JSON_STREAM_FULL_OUTPUT 33
 #define OPT_SERVER_MAX_DURATION 34
+#define OPT_NO_GSRO 35
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -106,7 +106,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_SKIP_RX_COPY 32
 #define OPT_JSON_STREAM_FULL_OUTPUT 33
 #define OPT_SERVER_MAX_DURATION 34
-#define OPT_NO_GSRO 35
+#define OPT_GSRO 35
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -505,40 +505,40 @@ iperf_connect(struct iperf_test *test)
      * the user always has the option to override.
      */
     if (test->protocol->id == Pudp) {
-    if (test->settings->blksize == 0) {
-        if (test->ctrl_sck_mss) {
-        test->settings->blksize = test->ctrl_sck_mss;
-        }
-        else {
-        test->settings->blksize = DEFAULT_UDP_BLKSIZE;
-        }
-        if (test->verbose) {
-        printf("Setting UDP block size to %d\n", test->settings->blksize);
-        }
-    }
-    /* Initialize GSO parameters when --gsro is used */
-    if (test->settings->gso) {
-        test->settings->gso_dg_size = test->settings->blksize;
-        /* use the multiple of datagram size for the best efficiency. */
-        if (test->settings->gso_dg_size > 0) {
-            test->settings->gso_bf_size = (test->settings->gso_bf_size / test->settings->gso_dg_size) * test->settings->gso_dg_size;
-        } else {
-            /* If gso_dg_size is 0 (unlimited bandwidth), use default UDP datagram size */
-            test->settings->gso_dg_size = DEFAULT_UDP_BLKSIZE;
-        }
-    }
+	if (test->settings->blksize == 0) {
+	    if (test->ctrl_sck_mss) {
+		test->settings->blksize = test->ctrl_sck_mss;
+	    }
+	    else {
+		test->settings->blksize = DEFAULT_UDP_BLKSIZE;
+	    }
+	    if (test->verbose) {
+		printf("Setting UDP block size to %d\n", test->settings->blksize);
+	    }
+	}
+	/* Initialize GSO parameters when --gsro is used */
+	if (test->settings->gso) {
+	    test->settings->gso_dg_size = test->settings->blksize;
+	    /* use the multiple of datagram size for the best efficiency. */
+	    if (test->settings->gso_dg_size > 0) {
+		test->settings->gso_bf_size = (test->settings->gso_bf_size / test->settings->gso_dg_size) * test->settings->gso_dg_size;
+	    } else {
+		/* If gso_dg_size is 0 (unlimited bandwidth), use default UDP datagram size */
+		test->settings->gso_dg_size = DEFAULT_UDP_BLKSIZE;
+	    }
+	}
 
-    /*
-    * Regardless of whether explicitly or implicitly set, if the
-    * block size is larger than the MSS, print a warning.
-    */
-    if (test->ctrl_sck_mss > 0 &&
-        test->settings->blksize > test->ctrl_sck_mss) {
-        char str[WARN_STR_LEN];
-        snprintf(str, sizeof(str),
-            "UDP block size %d exceeds TCP MSS %d, may result in fragmentation / drops", test->settings->blksize, test->ctrl_sck_mss);
-        warning(str);
-    }
+	/*
+	 * Regardless of whether explicitly or implicitly set, if the
+	 * block size is larger than the MSS, print a warning.
+	 */
+	if (test->ctrl_sck_mss > 0 &&
+	    test->settings->blksize > test->ctrl_sck_mss) {
+	    char str[WARN_STR_LEN];
+	    snprintf(str, sizeof(str),
+		     "UDP block size %d exceeds TCP MSS %d, may result in fragmentation / drops", test->settings->blksize, test->ctrl_sck_mss);
+	    warning(str);
+	}
     }
 
     return 0;

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -516,7 +516,7 @@ iperf_connect(struct iperf_test *test)
         printf("Setting UDP block size to %d\n", test->settings->blksize);
         }
     }
-#ifdef HAVE_UDP_SEGMENT
+    /* Initialize GSO parameters when --gsro is used */
     if (test->settings->gso) {
         test->settings->gso_dg_size = test->settings->blksize;
         /* use the multiple of datagram size for the best efficiency. */
@@ -527,7 +527,6 @@ iperf_connect(struct iperf_test *test)
             test->settings->gso_dg_size = DEFAULT_UDP_BLKSIZE;
         }
     }
-#endif
 
     /*
     * Regardless of whether explicitly or implicitly set, if the

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -505,29 +505,41 @@ iperf_connect(struct iperf_test *test)
      * the user always has the option to override.
      */
     if (test->protocol->id == Pudp) {
-	if (test->settings->blksize == 0) {
-	    if (test->ctrl_sck_mss) {
-		test->settings->blksize = test->ctrl_sck_mss;
-	    }
-	    else {
-		test->settings->blksize = DEFAULT_UDP_BLKSIZE;
-	    }
-	    if (test->verbose) {
-		printf("Setting UDP block size to %d\n", test->settings->blksize);
-	    }
-	}
+    if (test->settings->blksize == 0) {
+        if (test->ctrl_sck_mss) {
+        test->settings->blksize = test->ctrl_sck_mss;
+        }
+        else {
+        test->settings->blksize = DEFAULT_UDP_BLKSIZE;
+        }
+        if (test->verbose) {
+        printf("Setting UDP block size to %d\n", test->settings->blksize);
+        }
+    }
+#ifdef HAVE_UDP_SEGMENT
+    if (test->settings->gso) {
+        test->settings->gso_dg_size = test->settings->blksize;
+        /* use the multiple of datagram size for the best efficiency. */
+        if (test->settings->gso_dg_size > 0) {
+            test->settings->gso_bf_size = (test->settings->gso_bf_size / test->settings->gso_dg_size) * test->settings->gso_dg_size;
+        } else {
+            /* If gso_dg_size is 0 (unlimited bandwidth), use default UDP datagram size */
+            test->settings->gso_dg_size = 1472; /* Standard UDP payload size for Ethernet MTU */
+        }
+    }
+#endif
 
-	/*
-	 * Regardless of whether explicitly or implicitly set, if the
-	 * block size is larger than the MSS, print a warning.
-	 */
-	if (test->ctrl_sck_mss > 0 &&
-	    test->settings->blksize > test->ctrl_sck_mss) {
-	    char str[WARN_STR_LEN];
-	    snprintf(str, sizeof(str),
-		     "UDP block size %d exceeds TCP MSS %d, may result in fragmentation / drops", test->settings->blksize, test->ctrl_sck_mss);
-	    warning(str);
-	}
+    /*
+    * Regardless of whether explicitly or implicitly set, if the
+    * block size is larger than the MSS, print a warning.
+    */
+    if (test->ctrl_sck_mss > 0 &&
+        test->settings->blksize > test->ctrl_sck_mss) {
+        char str[WARN_STR_LEN];
+        snprintf(str, sizeof(str),
+            "UDP block size %d exceeds TCP MSS %d, may result in fragmentation / drops", test->settings->blksize, test->ctrl_sck_mss);
+        warning(str);
+    }
     }
 
     return 0;

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -524,7 +524,7 @@ iperf_connect(struct iperf_test *test)
             test->settings->gso_bf_size = (test->settings->gso_bf_size / test->settings->gso_dg_size) * test->settings->gso_dg_size;
         } else {
             /* If gso_dg_size is 0 (unlimited bandwidth), use default UDP datagram size */
-            test->settings->gso_dg_size = 1472; /* Standard UDP payload size for Ethernet MTU */
+            test->settings->gso_dg_size = DEFAULT_UDP_BLKSIZE;
         }
     }
 #endif

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -132,6 +132,12 @@
 /* Have TCP_USER_TIMEOUT sockopt. */
 #undef HAVE_TCP_USER_TIMEOUT
 
+/* Have UDP_GRO sockopt. */
+#undef HAVE_UDP_GRO
+
+/* Have UDP_SEGMENT sockopt. */
+#undef HAVE_UDP_SEGMENT
+
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -220,7 +220,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
 #if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
-                           "  --gsro                    enable UDP GSO/GRO (Generic Segmentation/Receive Offload)\n"
+                           "  --gsro                    enable UDP GSO/GRO on both client and server (client-only option)\n"
 #endif
                            "  --repeating-payload       use repeating pattern in payload, instead of\n"
                            "                            randomized payload (like in iperf2)\n"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -220,7 +220,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
 #if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
-                           "  --no-gsro                 disable UDP GSO/GRO (Generic Segmentation/Receive Offload)\n"
+                           "  --gsro                    enable UDP GSO/GRO (Generic Segmentation/Receive Offload)\n"
 #endif
                            "  --repeating-payload       use repeating pattern in payload, instead of\n"
                            "                            randomized payload (like in iperf2)\n"

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -219,6 +219,9 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  --extra-data str          data string to include in client and server JSON\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
+#if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
+                           "  --no-gsro                 disable UDP GSO/GRO (Generic Segmentation/Receive Offload)\n"
+#endif
                            "  --repeating-payload       use repeating pattern in payload, instead of\n"
                            "                            randomized payload (like in iperf2)\n"
 #if defined(HAVE_DONT_FRAGMENT)

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -219,9 +219,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  --extra-data str          data string to include in client and server JSON\n"
                            "  --get-server-output       get results from server\n"
                            "  --udp-counters-64bit      use 64-bit counters in UDP test packets\n"
-#if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
                            "  --gsro                    enable UDP GSO/GRO on both client and server (client-only option)\n"
-#endif
                            "  --repeating-payload       use repeating pattern in payload, instead of\n"
                            "                            randomized payload (like in iperf2)\n"
 #if defined(HAVE_DONT_FRAGMENT)

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -24,6 +24,8 @@
  * This code is distributed under a BSD style license, see the LICENSE
  * file for complete information.
  */
+#include "iperf_config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,6 +40,9 @@
 #include <inttypes.h>
 #include <sys/time.h>
 #include <sys/select.h>
+#if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
+#include <linux/udp.h>
+#endif
 
 #include "iperf.h"
 #include "iperf_api.h"
@@ -72,7 +77,42 @@ iperf_udp_recv(struct iperf_stream *sp)
     }
 #endif /* HAVE_MSG_TRUNC */
 
+#ifdef HAVE_UDP_GRO
+    int       tmp_r;
+    int       dgram_sz;
+    int       cnt = 0;
+    char      *dgram_buf;
+    char      *dgram_buf_end;
+    const int min_pkt_size = sizeof(uint32_t) * 3; /* sec + usec + pcount (32-bit) */
+
+    /* Initialize dgram_sz for both GRO enabled and disabled cases */
+    dgram_sz = sp->settings->blksize;
+
+    if (sp->test->settings->gro) {
+	size = sp->test->settings->gro_bf_size;
+	r = Nread_gro(sp->socket, sp->buffer, size, Pudp, &dgram_sz);
+	if (dgram_sz == -1) {
+	    /*
+	     * For corner case where the socket configuration is
+	     * successful but the kernel network layer doesn't provide
+	     * GRO-format data or ancillary info.
+	     */
+            dgram_sz = sp->settings->blksize;
+	}
+	/* Validate dgram_sz against reasonable bounds */
+	if (dgram_sz <= 0 || dgram_sz < min_pkt_size || dgram_sz > sp->test->settings->gro_bf_size) {
+	    if (test->debug_level >= DEBUG_LEVEL_INFO)
+		printf("Invalid GRO dgram_sz %d, falling back to blksize %d\n", dgram_sz, sp->settings->blksize);
+	    dgram_sz = sp->settings->blksize;
+	}
+    } else {
+        /* GRO available but disabled - use normal UDP receive and single packet size */
+        r = Nrecv_no_select(sp->socket, sp->buffer, size, Pudp, sock_opt);
+        dgram_sz = sp->settings->blksize;
+    }
+#else
     r = Nrecv_no_select(sp->socket, sp->buffer, size, Pudp, sock_opt);
+#endif
 
     /*
      * If we got an error in the read, or if we didn't read anything
@@ -96,6 +136,85 @@ iperf_udp_recv(struct iperf_stream *sp)
 	sp->result->bytes_received += r;
 	sp->result->bytes_received_this_interval += r;
 
+	if (sp->test->debug)
+	    printf("received %d bytes of %d, total %" PRIu64 "\n", r, size, sp->result->bytes_received);
+
+#ifdef HAVE_UDP_GRO
+	if (sp->test->settings->gro) {
+	    /* GRO enabled - process multiple datagrams */
+	    dgram_buf = sp->buffer;
+	    dgram_buf_end = sp->buffer + r;
+	    tmp_r = r;
+	    
+	    /* Ensure we process complete datagrams only */
+	    while (tmp_r >= dgram_sz && dgram_buf + dgram_sz <= dgram_buf_end) {
+	    cnt++;
+	    if (sp->test->debug)
+		printf("%d (%d) remaining %d\n", cnt, dgram_sz, tmp_r);
+
+	    /* Ensure we have enough bytes for the packet header */
+	    if (tmp_r < min_pkt_size) {
+		if (test->debug_level >= DEBUG_LEVEL_INFO)
+		    printf("Incomplete packet header: %d bytes remaining\n", tmp_r);
+		break;
+	    }
+
+	    if (sp->test->udp_counters_64bit) {
+		/* Verify we have enough space for 64-bit counter */
+		if (tmp_r < sizeof(uint32_t) * 2 + sizeof(uint64_t)) {
+		    if (test->debug_level >= DEBUG_LEVEL_INFO)
+			printf("Incomplete 64-bit packet: %d bytes remaining\n", tmp_r);
+		    break;
+		}
+		memcpy(&sec, dgram_buf, sizeof(sec));
+		memcpy(&usec, dgram_buf+4, sizeof(usec));
+		memcpy(&pcount, dgram_buf+8, sizeof(pcount));
+		sec = ntohl(sec);
+		usec = ntohl(usec);
+		pcount = be64toh(pcount);
+		sent_time.secs = sec;
+		sent_time.usecs = usec;
+	    }
+	    else {
+		uint32_t pc;
+		memcpy(&sec, dgram_buf, sizeof(sec));
+		memcpy(&usec, dgram_buf+4, sizeof(usec));
+		memcpy(&pc, dgram_buf+8, sizeof(pc));
+		sec = ntohl(sec);
+		usec = ntohl(usec);
+		pcount = ntohl(pc);
+		sent_time.secs = sec;
+		sent_time.usecs = usec;
+	    }
+		dgram_buf += dgram_sz;
+		tmp_r -= dgram_sz;
+	    } // end while loop
+	} else {
+	    /* GRO disabled - process as single normal UDP packet */
+	    /* Dig the various counters out of the incoming UDP packet */
+	    if (test->udp_counters_64bit) {
+		memcpy(&sec, sp->buffer, sizeof(sec));
+		memcpy(&usec, sp->buffer+4, sizeof(usec));
+		memcpy(&pcount, sp->buffer+8, sizeof(pcount));
+		sec = ntohl(sec);
+		usec = ntohl(usec);
+		pcount = be64toh(pcount);
+		sent_time.secs = sec;
+		sent_time.usecs = usec;
+	    }
+	    else {
+		uint32_t pc;
+		memcpy(&sec, sp->buffer, sizeof(sec));
+		memcpy(&usec, sp->buffer+4, sizeof(usec));
+		memcpy(&pc, sp->buffer+8, sizeof(pc));
+		sec = ntohl(sec);
+		usec = ntohl(usec);
+		pcount = ntohl(pc);
+		sent_time.secs = sec;
+		sent_time.usecs = usec;
+	    }
+	}
+#else
 	/* Dig the various counters out of the incoming UDP packet */
 	if (test->udp_counters_64bit) {
 	    memcpy(&sec, sp->buffer, sizeof(sec));
@@ -118,6 +237,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 	    sent_time.secs = sec;
 	    sent_time.usecs = usec;
 	}
+#endif /* HAVE_UDP_GRO */
 
 	if (test->debug_level >= DEBUG_LEVEL_DEBUG)
 	    fprintf(stderr, "pcount %" PRIu64 " packet_count %" PRIu64 "\n", pcount, sp->packet_count);
@@ -214,6 +334,83 @@ iperf_udp_send(struct iperf_stream *sp)
     int       size = sp->settings->blksize;
     struct iperf_time before;
 
+#ifdef HAVE_UDP_SEGMENT
+    int       dgram_sz;
+    int       buf_sz;
+    int       cnt = 0;
+    char      *dgram_buf;
+    char      *dgram_buf_end;
+    const int min_pkt_size = sizeof(uint32_t) * 3; /* sec + usec + pcount (32-bit) */
+
+    if (sp->test->settings->gso) {
+	dgram_sz = sp->test->settings->gso_dg_size;
+	buf_sz = sp->test->settings->gso_bf_size;
+	/* Validate GSO parameters */
+	if (dgram_sz <= 0 || dgram_sz < min_pkt_size || dgram_sz > buf_sz) {
+	    if (sp->test->debug_level >= DEBUG_LEVEL_INFO)
+		printf("Invalid GSO dgram_sz %d for buf_sz %d, disabling GSO\n", dgram_sz, buf_sz);
+	    dgram_sz = buf_sz = size;
+	    sp->test->settings->gso = 0;  /* Disable GSO for safety */
+	}
+    } else {
+	dgram_sz = buf_sz = size;
+    }
+
+    dgram_buf = sp->buffer;
+    dgram_buf_end = sp->buffer + buf_sz;
+
+    while (buf_sz > 0 && dgram_buf + dgram_sz <= dgram_buf_end) {
+	    cnt++;
+
+	    if (sp->test->debug)
+		    printf("%d (%d) remaining %d\n", cnt, dgram_sz, buf_sz);
+
+	    /* Prevent buffer underflow */
+	    if (buf_sz < dgram_sz) {
+		if (sp->test->debug_level >= DEBUG_LEVEL_INFO)
+		    printf("Buffer underflow protection: buf_sz %d < dgram_sz %d\n", buf_sz, dgram_sz);
+		break;
+	    }
+
+	    iperf_time_now(&before);
+	    ++sp->packet_count;
+
+	    if (sp->test->udp_counters_64bit) {
+
+		    uint32_t  sec, usec;
+		    uint64_t  pcount;
+
+		    sec = htonl(before.secs);
+		    usec = htonl(before.usecs);
+		    pcount = htobe64(sp->packet_count);
+
+		    memcpy(dgram_buf, &sec, sizeof(sec));
+		    memcpy(dgram_buf+4, &usec, sizeof(usec));
+		    memcpy(dgram_buf+8, &pcount, sizeof(pcount));
+
+	    }
+	    else {
+
+		    uint32_t  sec, usec, pcount;
+
+		    sec = htonl(before.secs);
+		    usec = htonl(before.usecs);
+		    pcount = htonl(sp->packet_count);
+
+		    memcpy(dgram_buf, &sec, sizeof(sec));
+		    memcpy(dgram_buf+4, &usec, sizeof(usec));
+		    memcpy(dgram_buf+8, &pcount, sizeof(pcount));
+
+	    }
+	    dgram_buf += dgram_sz;
+	    buf_sz -= dgram_sz;
+    }
+    
+    /* Warn if we didn't process all the buffer due to size mismatch */
+    if (buf_sz > 0 && sp->test->debug_level >= DEBUG_LEVEL_INFO) {
+	printf("GSO: %d bytes remaining unprocessed\n", buf_sz);
+    }
+#else
     iperf_time_now(&before);
 
     ++sp->packet_count;
@@ -245,7 +442,14 @@ iperf_udp_send(struct iperf_stream *sp)
 	memcpy(sp->buffer+8, &pcount, sizeof(pcount));
 
     }
+#endif /* HAVE_UDP_SEGMENT */
 
+#ifdef HAVE_UDP_SEGMENT
+    if (sp->test->settings->gso) {
+        size = sp->test->settings->gso_bf_size;
+        r = Nwrite_gso(sp->socket, sp->buffer, size, Pudp, sp->test->settings->gso_dg_size);
+    } else
+#endif
     r = Nwrite(sp->socket, sp->buffer, size, Pudp);
 
     if (r <= 0) {
@@ -262,7 +466,7 @@ iperf_udp_send(struct iperf_stream *sp)
     sp->result->bytes_sent_this_interval += r;
 
     if (sp->test->debug_level >=  DEBUG_LEVEL_DEBUG)
-	printf("sent %d bytes of %d, total %" PRIu64 "\n", r, sp->settings->blksize, sp->result->bytes_sent);
+	printf("sent %d bytes of %d, total %" PRIu64 "\n", r, size, sp->result->bytes_sent);
 
     return r;
 }
@@ -372,6 +576,42 @@ iperf_udp_buffercheck(struct iperf_test *test, int s)
     return rc;
 }
 
+#ifdef HAVE_UDP_SEGMENT
+int
+iperf_udp_gso(struct iperf_test *test, int s)
+{
+    int rc;
+    int gso = test->settings->gso_dg_size;
+
+    rc = setsockopt(s, IPPROTO_UDP, UDP_SEGMENT, (char*) &gso, sizeof(gso));
+    if (rc) {
+	iperf_printf(test, "No GSO (%d)\n", rc);
+        test->settings->gso = 0;
+    } else
+	iperf_printf(test, "GSO (%d)\n", gso);
+
+    return rc;
+}
+#endif
+
+#ifdef HAVE_UDP_GRO
+int
+iperf_udp_gro(struct iperf_test *test, int s)
+{
+    int rc;
+    int gro = 1;
+
+    rc = setsockopt(s, IPPROTO_UDP, UDP_GRO, (char*) &gro, sizeof(gro));
+    if (rc) {
+	iperf_printf(test, "No GRO (%d)\n", rc);
+        test->settings->gro = 0;
+    } else
+	iperf_printf(test, "GRO\n");
+
+    return rc;
+}
+#endif
+
 /*
  * iperf_udp_accept
  *
@@ -430,6 +670,15 @@ iperf_udp_accept(struct iperf_test *test)
 		return rc;
 	}
     }
+
+#ifdef HAVE_UDP_SEGMENT
+    if (test->settings->gso)
+        iperf_udp_gso(test, s);
+#endif
+#ifdef HAVE_UDP_GRO
+    if (test->settings->gro)
+        iperf_udp_gro(test, s);
+#endif
 
 #if defined(HAVE_SO_MAX_PACING_RATE)
     /* If socket pacing is specified, try it. */
@@ -530,6 +779,16 @@ iperf_udp_connect(struct iperf_test *test)
     if (rc < 0)
 	/* error */
 	return rc;
+
+#ifdef HAVE_UDP_SEGMENT
+    if (test->settings->gso)
+        iperf_udp_gso(test, s);
+#endif
+#ifdef HAVE_UDP_GRO
+    if (test->settings->gro)
+        iperf_udp_gro(test, s);
+#endif
+
     /*
      * If the socket buffer was too small, but it was the default
      * size, then try explicitly setting it to something larger.

--- a/src/net.c
+++ b/src/net.c
@@ -42,8 +42,6 @@
 #include <linux/udp.h>
 #endif
 
-#include "iperf.h"
-
 #ifdef HAVE_SENDFILE
 #ifdef linux
 #include <sys/sendfile.h>
@@ -593,7 +591,6 @@ Nread_gro(int fd, char *buf, size_t count, int prot, int *dgram_sz)
 		if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
 			return 0;
 		} else {
-			printf("\nUnexpected error (%d)\n", errno);
 			return NET_HARDERROR;
 		}
 	}
@@ -684,9 +681,6 @@ static int udp_sendmsg_gso(int fd, const char *buf, size_t count, uint16_t gso_s
 
 	ret = sendmsg(fd, &msg, 0);
 
-	if (ret != iov.iov_len)
-		printf("msg: %u != %llu\n", ret, (unsigned long long) iov.iov_len);
-
 	return ret;
 }
 
@@ -704,15 +698,12 @@ Nwrite_gso(int fd, const char *buf, size_t count, int prot, uint16_t gso_size)
 #if (EAGAIN != EWOULDBLOCK)
 			case EWOULDBLOCK:
 #endif
-				printf("\nerrono (%d)\n", errno);
 				return 0;
 
 			case ENOBUFS:
-				printf("\nUnexpected error ENOBUFS (%d)\n", ENOBUFS);
 				return NET_SOFTERROR;
 
 			default:
-				printf("\nUnexpected error (%d)\n", errno);
 				return NET_HARDERROR;
 		}
 	}

--- a/src/net.c
+++ b/src/net.c
@@ -603,6 +603,13 @@ Nread_gro(int fd, char *buf, size_t count, int prot, int *dgram_sz)
 
 	return r;
 }
+#else
+int
+Nread_gro(int fd, char *buf, size_t count, int prot, int *dgram_sz)
+{
+	/* GRO not supported on this platform */
+	return NET_HARDERROR;
+}
 #endif /* HAVE_UDP_GRO */
 
 /*
@@ -708,6 +715,13 @@ Nwrite_gso(int fd, const char *buf, size_t count, int prot, uint16_t gso_size)
 		}
 	}
 	return r;
+}
+#else
+int
+Nwrite_gso(int fd, const char *buf, size_t count, int prot, uint16_t gso_size)
+{
+	/* GSO not supported on this platform */
+	return NET_HARDERROR;
 }
 #endif /* HAVE_UDP_SEGMENT */
 

--- a/src/net.c
+++ b/src/net.c
@@ -38,6 +38,11 @@
 #include <string.h>
 #include <fcntl.h>
 #include <limits.h>
+#if defined(HAVE_UDP_SEGMENT) || defined(HAVE_UDP_GRO)
+#include <linux/udp.h>
+#endif
+
+#include "iperf.h"
 
 #ifdef HAVE_SENDFILE
 #ifdef linux
@@ -520,6 +525,88 @@ Nrecv_no_select(int fd, char *buf, size_t count, int prot, int sock_opt)
     return count - nleft;
 }
 
+#ifdef HAVE_UDP_GRO
+static int recv_msg_gro(int fd, char *buf, int len, int *gso_size)
+{
+	char control[CMSG_SPACE(sizeof(uint16_t))] = {0};
+	struct msghdr msg = {0};
+	struct iovec iov = {0};
+	struct cmsghdr *cmsg;
+	uint16_t *gsosizeptr;
+	int ret;
+
+	/* Input validation */
+	if (!buf || len <= 0 || !gso_size) {
+		return -1;
+	}
+
+	iov.iov_base = buf;
+	iov.iov_len = len;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	*gso_size = -1;
+	ret = recvmsg(fd, &msg, MSG_DONTWAIT);
+
+	if (ret > 0) {
+		for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+			if (cmsg->cmsg_level == IPPROTO_UDP && cmsg->cmsg_type == UDP_GRO) {
+				/* Validate cmsg data length */
+				if (cmsg->cmsg_len >= CMSG_LEN(sizeof(uint16_t))) {
+					gsosizeptr = (uint16_t *) CMSG_DATA(cmsg);
+					*gso_size = *gsosizeptr;
+					/* Sanity check the gso_size value */
+					if (*gso_size <= 0 || *gso_size > len) {
+						*gso_size = -1;  /* Mark as invalid */
+					}
+				}
+				break;
+			}
+		}
+	}
+
+	return ret;
+}
+
+int
+Nread_gro(int fd, char *buf, size_t count, int prot, int *dgram_sz)
+{
+	register ssize_t r;
+
+	/* Input validation */
+	if (!buf || count <= 0 || !dgram_sz) {
+		return NET_HARDERROR;
+	}
+
+	/* Limit maximum buffer size to prevent excessive memory usage */
+	if (count > MAX_UDP_BLOCKSIZE) {
+		count = MAX_UDP_BLOCKSIZE;
+	}
+
+	r = recv_msg_gro(fd, buf, count, dgram_sz);
+
+	if (r < 0) {
+		if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+			return 0;
+		} else {
+			printf("\nUnexpected error (%d)\n", errno);
+			return NET_HARDERROR;
+		}
+	}
+
+	/* Additional validation of returned dgram_sz */
+	if (r > 0 && *dgram_sz > 0 && *dgram_sz > r) {
+		/* dgram_sz shouldn't be larger than actual received data */
+		*dgram_sz = r;
+	}
+
+	return r;
+}
+#endif /* HAVE_UDP_GRO */
 
 /*
  *                      N W R I T E
@@ -559,6 +646,79 @@ Nwrite(int fd, const char *buf, size_t count, int prot)
     return count;
 }
 
+#ifdef HAVE_UDP_SEGMENT
+static void udp_msg_gso(struct cmsghdr *cm, uint16_t gso_size)
+{
+	uint16_t *valp;
+
+	cm->cmsg_level = IPPROTO_UDP;
+	cm->cmsg_type = UDP_SEGMENT;
+	cm->cmsg_len = CMSG_LEN(sizeof(gso_size));
+	valp = (void *) CMSG_DATA(cm);
+	*valp = gso_size;
+}
+
+static int udp_sendmsg_gso(int fd, const char *buf, size_t count, uint16_t gso_size)
+{
+	char control[CMSG_SPACE(sizeof(gso_size))] = {0};
+	struct msghdr msg = {0};
+	struct iovec iov = {0};
+	size_t msg_controllen;
+	struct cmsghdr *cmsg;
+	int ret;
+
+	iov.iov_base = (void *) buf;
+	iov.iov_len = count;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+	cmsg = CMSG_FIRSTHDR(&msg);
+
+	udp_msg_gso(cmsg, gso_size);
+
+	msg_controllen = CMSG_SPACE(sizeof(gso_size));
+	msg.msg_controllen = msg_controllen;
+
+	ret = sendmsg(fd, &msg, 0);
+
+	if (ret != iov.iov_len)
+		printf("msg: %u != %llu\n", ret, (unsigned long long) iov.iov_len);
+
+	return ret;
+}
+
+int
+Nwrite_gso(int fd, const char *buf, size_t count, int prot, uint16_t gso_size)
+{
+	register ssize_t r;
+
+	r = udp_sendmsg_gso(fd, buf, count, gso_size);
+
+	if (r < 0) {
+		switch (errno) {
+			case EINTR:
+			case EAGAIN:
+#if (EAGAIN != EWOULDBLOCK)
+			case EWOULDBLOCK:
+#endif
+				printf("\nerrono (%d)\n", errno);
+				return 0;
+
+			case ENOBUFS:
+				printf("\nUnexpected error ENOBUFS (%d)\n", ENOBUFS);
+				return NET_SOFTERROR;
+
+			default:
+				printf("\nUnexpected error (%d)\n", errno);
+				return NET_HARDERROR;
+		}
+	}
+	return r;
+}
+#endif /* HAVE_UDP_SEGMENT */
 
 int
 has_sendfile(void)

--- a/src/net.h
+++ b/src/net.h
@@ -41,6 +41,12 @@ int Nsendfile(int fromfd, int tofd, const char *buf, size_t count) /* __attribut
 int setnonblocking(int fd, int nonblocking);
 int getsockdomain(int sock);
 int parse_qos(const char *tos);
+#ifdef HAVE_UDP_GRO
+int Nread_gro(int fd, char *buf, size_t count, int prot, int *dgram_sz);
+#endif
+#ifdef HAVE_UDP_SEGMENT
+int Nwrite_gso(int fd, const char *buf, size_t count, int prot, uint16_t gso_size);
+#endif
 
 #define NET_SOFTERROR -1
 #define NET_HARDERROR -2

--- a/src/net.h
+++ b/src/net.h
@@ -35,18 +35,14 @@ int Nread(int fd, char *buf, size_t count, int prot);
 int Nrecv(int fd, char *buf, size_t count, int prot, int sock_opt);
 int Nread_no_select(int fd, char *buf, size_t count, int prot);
 int Nrecv_no_select(int fd, char *buf, size_t count, int prot, int sock_opt);
+int Nread_gro(int fd, char *buf, size_t count, int prot, int *dgram_sz);
 int Nwrite(int fd, const char *buf, size_t count, int prot) /* __attribute__((hot)) */;
+int Nwrite_gso(int fd, const char *buf, size_t count, int prot, uint16_t gso_size);
 int has_sendfile(void);
 int Nsendfile(int fromfd, int tofd, const char *buf, size_t count) /* __attribute__((hot)) */;
 int setnonblocking(int fd, int nonblocking);
 int getsockdomain(int sock);
 int parse_qos(const char *tos);
-#ifdef HAVE_UDP_GRO
-int Nread_gro(int fd, char *buf, size_t count, int prot, int *dgram_sz);
-#endif
-#ifdef HAVE_UDP_SEGMENT
-int Nwrite_gso(int fd, const char *buf, size_t count, int prot, uint16_t gso_size);
-#endif
 
 #define NET_SOFTERROR -1
 #define NET_HARDERROR -2


### PR DESCRIPTION
UDP GSO/GRO Support - Refactored Implementation

This PR implements UDP Generic Segmentation Offload (GSO) and Generic Receive Offload (GRO) support for iperf3 on Linux, addressing all maintainer feedback with a cleaned-up implementation.

## Changes

### 1. Feature Enablement (Disabled by Default)
- Changed from --no-gsro to --gsro flag
- GSO/GRO is now opt-in rather than opt-out
- Default behavior unchanged for existing users

### 2. Code Refactoring
- Eliminated ~84 lines of duplicated code
- Unified packet processing loops in iperf_udp_send() and iperf_udp_recv()
- Single code path handles both GSO/GRO-enabled and disabled cases
- Improved maintainability and reduced error potential

### 3. Bug Fix: Missing Counters
- Critical fix: Loss and jitter counters now work in ALL modes
- Previously only calculated when GRO was enabled
- Moved counter calculations outside #ifdef guards
- Users without --gsro now get proper statistics

### 4. Debug Output Control
- Gated GSO/GRO diagnostic messages behind test->debug flag
- Cleaner output for production use
- Debug info still available with -d flag

### 5. Documentation
- Added --gsro flag to iperf3.1 man page
- Documented GSO/GRO functionality and platform support

## Testing

On 2 bare-metal Linux machines connected with 100Gbps NICs I get:

Normal mode (no GSO/GRO):
```
./src/iperf3 -c rapid10-100g -u -b 35G
Connecting to host rapid10-100g, port 5201
[  5] local 192.168.100.9 port 47526 connected to 192.168.100.10 port 5201
[ ID] Interval           Transfer     Bitrate         Total Datagrams
[  5]   0.00-1.00   sec   296 MBytes  2.48 Gbits/sec  214425  
[  5]   1.00-2.00   sec   294 MBytes  2.47 Gbits/sec  212846  
[  5]   2.00-3.00   sec   291 MBytes  2.44 Gbits/sec  210867  
[  5]   3.00-4.00   sec   291 MBytes  2.44 Gbits/sec  210949  
[  5]   4.00-5.00   sec   292 MBytes  2.45 Gbits/sec  211456  
[  5]   5.00-6.00   sec   296 MBytes  2.48 Gbits/sec  214033  
[  5]   6.00-7.00   sec   296 MBytes  2.49 Gbits/sec  214711  
[  5]   7.00-8.00   sec   296 MBytes  2.48 Gbits/sec  214328  
[  5]   8.00-9.00   sec   296 MBytes  2.48 Gbits/sec  214206  
[  5]   9.00-10.00  sec   296 MBytes  2.48 Gbits/sec  214480  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.00  sec  2.88 GBytes  2.47 Gbits/sec  0.000 ms  0/2132301 (0%)  sender
[  5]   0.00-10.00  sec  2.88 GBytes  2.47 Gbits/sec  0.002 ms  0/2132301 (0%)  receiver
```
So `2.47 Gbits/sec` max (even though 35G requested)

Now with `--gsro` enabled:

```
./src/iperf3 -c rapid10-100g -u -b 35G --gsro
Connecting to host rapid10-100g, port 5201
[  5] local 192.168.100.9 port 56515 connected to 192.168.100.10 port 5201
[ ID] Interval           Transfer     Bitrate         Total Datagrams
[  5]   0.00-1.00   sec  4.08 GBytes  35.0 Gbits/sec  3024450  
[  5]   1.00-2.00   sec  4.07 GBytes  35.0 Gbits/sec  3021435  
[  5]   2.00-3.00   sec  4.07 GBytes  35.0 Gbits/sec  3021255  
[  5]   3.00-4.00   sec  4.07 GBytes  35.0 Gbits/sec  3021434  
[  5]   4.00-5.00   sec  4.07 GBytes  35.0 Gbits/sec  3021526  
[  5]   5.00-6.00   sec  4.07 GBytes  35.0 Gbits/sec  3021390  
[  5]   6.00-7.00   sec  4.07 GBytes  35.0 Gbits/sec  3021435  
[  5]   7.00-8.00   sec  4.07 GBytes  35.0 Gbits/sec  3021390  
[  5]   8.00-9.00   sec  4.07 GBytes  35.0 Gbits/sec  3019132  
[  5]   9.00-10.00  sec  4.08 GBytes  35.0 Gbits/sec  3023603  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-10.00  sec  40.7 GBytes  35.0 Gbits/sec  0.000 ms  0/30217050 (0%)  sender
[  5]   0.00-10.00  sec  40.7 GBytes  35.0 Gbits/sec  0.000 ms  0/30217005 (0%)  receiver
```

Result: `35.0 Gbits/sec` max throughput achieved. Beyond that some packet loss starts to happen due to CPU bound. On more modern machines more could be achieved.

## Benefits
- Reduced CPU overhead for high-throughput UDP tests
- Improved throughput on supported hardware
- Cleaner, more maintainable codebase
- Proper statistics in all modes
