### PR TITLE
docs: clarify --get-server-output needs the test to complete

### DIFF
--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -447,6 +447,8 @@ the executable.
                  will  be  in  human-readable format).  If the client is run with
                  --json, the server output is included in a JSON  object;  other-
                  wise it is appended at the bottom of the human-readable output.
+				 Note that the server output is available only if the test
+				 completes, not if it is interrupted.
    
           --udp-counters-64bit
                  Use 64-bit counters in UDP test packets.  The use of this option

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -437,7 +437,8 @@ server was invoked with the \fB--json\fR flag, the output will be in
 JSON format, otherwise it will be in human-readable format).
 If the client is run with \fB--json\fR, the server output is included
 in a JSON object; otherwise it is appended at the bottom of the
-human-readable output.
+human-readable output. Note that the server output is available only
+if the test completes, not if it is interrupted.
 .TP
 .BR --udp-counters-64bit
 Use 64-bit counters in UDP test packets.


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): Documentation clarification.

* Brief description of code changes (suitable for use as a commit message):

When using '--get-output-server', it's not immediately clear that the client will get the server output only if the test runs to completion.

To avoid people spending time debugging why they sometimes don't get the server output, mention it explicitly in the doc as well as in the man page.
