### PR TITLE
Improve Server Max Bit Rate Violation Messaging To Client

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2250,6 +2250,25 @@ iperf_exchange_parameters(struct iperf_test *test)
         if (get_parameters(test) < 0)
             return -1;
 
+        /* Ensure that total requested data rate is not above limit */
+        iperf_size_t total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
+        if (test->settings->bitrate_limit && total_requested_rate > test->settings->bitrate_limit) {
+            if (iperf_set_send_state(test, SERVER_ERROR) != 0)
+                return -1;
+            i_errno = IETOTALREQUESTEDRATE;
+            err = htonl(i_errno);
+            if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+                i_errno = IECTRLWRITE;
+                return -1;
+            }
+            err = htonl(errno);
+            if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+                i_errno = IECTRLWRITE;
+                return -1;
+            }
+            return -1;
+        }
+
 #if defined(HAVE_SSL)
         if (test_is_authorized(test) < 0){
             if (iperf_set_send_state(test, SERVER_ERROR) != 0)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -435,6 +435,7 @@ enum {
     IEUDPFILETRANSFER = 34, // Cannot transfer file using UDP
     IESERVERAUTHUSERS = 35,  // Cannot access authorized users file
     IECNTLKA = 36,          // Control connection Keepalive period should be larger than the full retry period (interval * count)
+    IETOTALREQUESTEDRATE = 37, // Total requested bandwidth exceeds the server's bitrate limit
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -305,6 +305,8 @@ iperf_handle_message_client(struct iperf_test *test)
     int rval;
     int32_t err;
 
+  
+
     if (NULL == test)
     {
         iperf_err(NULL, "No test\n");

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -482,6 +482,9 @@ iperf_strerror(int int_errno)
 	case IETOTALRATE:
 	    snprintf(errstr, len, "total required bandwidth is larger than server limit");
             break;
+    case IETOTALREQUESTEDRATE:
+        snprintf(errstr, len, "client's requested bit rate exceeds the server's bitrate limit");
+            break;
         case IESKEWTHRESHOLD:
 	    snprintf(errstr, len, "skew threshold must be a positive number");
             break;

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -609,6 +609,7 @@ iperf_run_server(struct iperf_test *test)
             i_errno = IECTRLWRITE;
             return -1;
         }
+
         err = htonl(errno);
         if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
             cleanup_server(test);

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -548,6 +548,7 @@ iperf_run_server(struct iperf_test *test)
     int64_t t_usecs;
     int64_t timeout_us;
     int64_t rcv_timeout_us;
+    int32_t err;
 
     if (test->logfile) {
         if (iperf_open_logfile(test) < 0)
@@ -594,11 +595,29 @@ iperf_run_server(struct iperf_test *test)
 
     while (test->state != IPERF_DONE) {
 
-        // Check if average transfer rate was exceeded (condition set in the callback routines)
+    // Check if average transfer rate was exceeded (condition set in the callback routines)
 	if (test->bitrate_limit_exceeded) {
-	    cleanup_server(test);
-            i_errno = IETOTALRATE;
+        i_errno = IETOTALRATE;
+        if (iperf_set_send_state(test, SERVER_ERROR) != 0) {
+            cleanup_server(test);
             return -1;
+        }
+
+        err = htonl(i_errno);
+        if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+            cleanup_server(test);
+            i_errno = IECTRLWRITE;
+            return -1;
+        }
+        err = htonl(errno);
+        if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+            cleanup_server(test);
+            i_errno = IECTRLWRITE;
+            return -1;
+        }
+
+        cleanup_server(test);
+        return -1;
 	}
 
         memcpy(&read_set, &test->read_set, sizeof(fd_set));


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any): #937

* Brief description of code changes (suitable for use as a commit message):

As per the ongoing discussion in [iperf/#1684](https://github.com/esnet/iperf/pull/1684), as part of an effort to enhance the user experience of `iperf3` clients, the enhancement proposed is to validate the client's input parameter for `--bitrate` when it is set and reject the measurement when it violates the server's configured `--server-bitrate-limit` value. When the client does not provide a limit and the test violates the configured bit rate, then the server should send an informative message to the client to indicate why the test was abruptly stopped.

## Client's Requested Bit Rate Exceeds Server's Max

<details>

<summary>server</summary>

```bash
./src/iperf3 -s --server-bitrate-limit 5Mbit/1sec
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
iperf3: error - client's requested bit rate exceeds the server's bitrate limit
-----------------------------------------------------------
Server listening on 5201 (test #2)
-----------------------------------------------------------
```

</details>

<details>

<summary>client</summary>

```bash
./src/iperf3 -c 127.0.0.1 --time 5 --parallel 4 --bitrate 10Mbit/1sec
Connecting to host 127.0.0.1, port 5201
iperf3: error - client's requested bit rate exceeds the server's bitrate limit
```

</details>

## Client's Bit Rate Exceeds Server's Max Circumstantially

<details>

<summary>server</summary>

```bash
./src/iperf3 -s --server-bitrate-limit 5Mbit/1sec
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
Accepted connection from 127.0.0.1, port 33512
[  5] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 33518
[  8] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 33526
[ 10] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 33540
[ 12] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 33544
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.01   sec  1.15 GBytes  9.86 Gbits/sec
[  8]   0.00-1.01   sec  1.33 GBytes  11.4 Gbits/sec
[ 10]   0.00-1.01   sec  1.32 GBytes  11.2 Gbits/sec
[ 12]   0.00-1.01   sec  1.23 GBytes  10.5 Gbits/sec
[SUM]   0.00-1.01   sec  5.03 GBytes  43.0 Gbits/sec
iperf3: error - total required bandwidth is larger than server limit
-----------------------------------------------------------
Server listening on 5201 (test #2)
-----------------------------------------------------------
```

</details>

<details>

<summary>client</summary>

```bash
./src/iperf3 -c 127.0.0.1 --time 5 --parallel 4
Connecting to host 127.0.0.1, port 5201
[  5] local 127.0.0.1 port 33518 connected to 127.0.0.1 port 5201
[  7] local 127.0.0.1 port 33526 connected to 127.0.0.1 port 5201
[  9] local 127.0.0.1 port 33540 connected to 127.0.0.1 port 5201
[ 11] local 127.0.0.1 port 33544 connected to 127.0.0.1 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  1.15 GBytes  9.86 Gbits/sec    0   1.12 MBytes
[  7]   0.00-1.01   sec  1.33 GBytes  11.3 Gbits/sec    0   1023 KBytes
[  9]   0.00-1.01   sec  1.32 GBytes  11.2 Gbits/sec    0   1.69 MBytes
[ 11]   0.00-1.01   sec  1.24 GBytes  10.6 Gbits/sec    0   1.56 MBytes
[SUM]   0.00-1.00   sec  5.05 GBytes  43.2 Gbits/sec    0
iperf3: error - total required bandwidth is larger than server limit
```

</details>