### PR TITLE
Send Server's get_Parameters() errors to the client

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2247,8 +2247,21 @@ iperf_exchange_parameters(struct iperf_test *test)
 
     } else {
 
-        if (get_parameters(test) < 0)
+        if (get_parameters(test) < 0) {
+            if (iperf_set_send_state(test, SERVER_ERROR) != 0)
+                return -1;
+            err = htonl(i_errno);
+            if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+                i_errno = IECTRLWRITE;
+                return -1;
+            }
+            err = htonl(errno);
+            if (Nwrite(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
+                i_errno = IECTRLWRITE;
+                return -1;
+            }
             return -1;
+        }
 
 #if defined(HAVE_SSL)
         if (test_is_authorized(test) < 0){


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

In case `get_parameters()` failure, send `SERVER_ERROR` state to the client, following by the error code (`i_errno`) set inside `get_parameters` (e.g. the `IEUDPFILETRANSFER` error in #1909).

This is actually a generalization of already existing mechanism for specific error codes.  E.g., with this PR changes, PR #1684 can just set the `IEMAXSERVERTESTDURATIONEXCEEDED` error in `get_parameters()`, without adding sending `SERVER_ERROR`, etc. specifically for that error.

