### PR TITLE
Add multi-CPU Affinity option per stream/thread support for Linux

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -202,6 +202,7 @@ struct iperf_stream
     pthread_t thr;
     int thread_created;
     int       done;
+    int       affinity;
 
     /* configurable members */
     int       local_port;
@@ -386,7 +387,8 @@ struct iperf_test
     double cpu_util[3];                            /* cpu utilization of the test - total, user, system */
     double remote_cpu_util[3];                     /* cpu utilization for the remote host/client - total, user, system */
 
-    int       num_streams;                      /* total streams in the test (-P) */
+    int       num_streams;                         /* total streams in the test (-P) */
+    int       stream_affinity[1024];               /* CPU affinity for the stream */
 
     atomic_iperf_size_t bytes_sent;
     atomic_iperf_size_t blocks_sent;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1145,6 +1145,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         {"timestamps", optional_argument, NULL, OPT_TIMESTAMPS},
 #if defined(HAVE_CPU_AFFINITY)
         {"affinity", required_argument, NULL, 'A'},
+        {"stream-affinity", required_argument, NULL, OPT_STREAM_AFFINITY},
 #endif /* HAVE_CPU_AFFINITY */
         {"title", required_argument, NULL, 'T'},
 #if defined(HAVE_TCP_CONGESTION)
@@ -1630,6 +1631,29 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 return -1;
 #endif /* HAVE_CPU_AFFINITY */
                 break;
+            case OPT_STREAM_AFFINITY:
+#if defined(HAVE_CPU_AFFINITY)
+        char *token;
+        int i = 0;
+        int cpu_num;
+
+        // Handling comma-separated list of integers: 0,1,2,3
+        token = strtok(optarg, ",");
+        while (token != NULL) {
+            cpu_num = atoi(token);
+            if (cpu_num < 0 || cpu_num > 1024) {
+                i_errno = IEAFFINITY; // TODO: Evaluate error code
+                return -1;
+            }
+            test->stream_affinity[i] = cpu_num;
+            token = strtok(NULL, ",");
+            i++;
+        }
+#else /* HAVE_CPU_AFFINITY */
+                i_errno = IEUNIMP;
+                return -1;
+#endif /* HAVE_CPU_AFFINITY */
+                break;
             case 'T':
                 test->title = strdup(optarg);
 		client_flag = 1;
@@ -1903,6 +1927,17 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
         (duration_flag && test->settings->blocks != 0) ||
 	(test->settings->bytes != 0 && test->settings->blocks != 0)) {
         i_errno = IEENDCONDITIONS;
+        return -1;
+    }
+
+    /**
+     * Ensure that stream CPU core affinity is only configured
+     * up to the number of parallel streams. For example, when
+     * running a test with 2 parallel streams, configuring stream
+     * affinity for 3 streams is invalid: --parallel 2 --stream-affinity 0,2,5
+     */
+    if (test->stream_affinity[test->num_streams] > -1) {
+        i_errno = IEAFFINITY; // TODO: Evaluate error code
         return -1;
     }
 
@@ -3196,6 +3231,11 @@ iperf_defaults(struct iperf_test *testp)
     /* Set up protocol list */
     SLIST_INIT(&testp->streams);
     SLIST_INIT(&testp->protocols);
+
+    /* Stream affinity is disabled by default */
+    for (int i = 0; i < 1024; i++) {
+        testp->stream_affinity[i] = -1;
+    }
 
     tcp = protocol_new();
     if (!tcp)

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -105,6 +105,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_CNTL_KA 31
 #define OPT_SKIP_RX_COPY 32
 #define OPT_JSON_STREAM_FULL_OUTPUT 33
+#define OPT_STREAM_AFFINITY 34
 
 /* states */
 #define TEST_START 1

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -106,7 +106,8 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "  -F, --file name           xmit/recv the specified file\n"
 #if defined(HAVE_CPU_AFFINITY)
                            "  -A, --affinity n[,m]      set CPU affinity core number to n (the core the process will use)\n"
-                          "                             (optional Client only m - the Server's core number for this test)\n"
+                           "                            (optional Client only m - the Server's core number for this test)\n"
+                           "  --stream-affinity list    set CPU affinity cores that each parallel stream (thread) will use\n"
 #endif /* HAVE_CPU_AFFINITY */
 #if defined(HAVE_SO_BINDTODEVICE)
                            "  -B, --bind <host>[%%<dev>] bind to the interface associated with the address <host>\n"


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): #1738

* Brief description of code changes (suitable for use as a commit message):

This is an idea that expands on the enhancement request for supporting a list of CPUs to pin the the `iperf3` process to now that multithreading is supported. At the time of raising these changes, this is not a complete feature, and the PR has been marked as a draft. There is already an open PR, [iperf/#1778](https://github.com/esnet/iperf/pull/1778), which seeks to implement the enhancement, as requested. These code changes take a different approach in the sense that when the user uses the `--parallel` flag to create multiple streams for the tests, then they can additionally use the `--stream-affinity` flag to pin each stream (thread) to a target CPU. This enables me, the user, to create 8 streams/threads on my 8-core system and pin each stream/thread to 1 core. I'll leave the code here for reference, but continue the conversation in the feature request.
