### PR TITLE
Fix typo in iperf3 documentation

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -43,7 +43,7 @@ iperf3 clients (in other words, the iperf3 program run in client
 mode).
 The client mode can be started using the -c command-line option,
 which also requires a host to which iperf3 should connect.
-The host can by specified by hostname, IPv4 literal, or IPv6 literal:
+The host can be specified by hostname, IPv4 literal, or IPv6 literal:
 .IP
 \fCiperf3 -c iperf3.example.com\fR
 .IP


### PR DESCRIPTION
* Version: master
* Issues fixed: a typo in the man page
* Brief description of code changes:
```
- The host can by specified by hostname
+ The host can be specified by hostname
```