### PR TITLE
server: ignore rcv-timeout in BIDIRECTIONAL mode

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -672,7 +672,7 @@ iperf_run_server(struct iperf_test *test)
                  * Running a test. If we're receiving, be sure we're making
                  * progress (sender hasn't died/crashed).
                  */
-                else if (test->mode != SENDER && t_usecs > rcv_timeout_us) {
+                else if (test->mode != SENDER && test->mode != BIDIRECTIONAL && t_usecs > rcv_timeout_us) {
                     /* Idle timeout if no new blocks received */
                     if (test->blocks_received == last_receive_blocks) {
                         test->server_forced_no_msg_restarts_count += 1;


### PR DESCRIPTION
### What & Why
In `--bidir` tests, the server could prematurely abort due to `rcv-timeout`.  
However, when running in **BIDIRECTIONAL mode**, the receive timeout should not apply, since the send side is governed by `--snd-timeout`.

This addresses [#1766](https://github.com/esnet/iperf/issues/1766):  
`iperf3: error - control socket has closed unexpectedly (iperf 3.17.1) on Debian 12.7`.

### Fix
Exclude BIDIRECTIONAL in the rcv-timeout condition:

```diff
- else if (test->mode != SENDER && t_usecs > rcv_timeout_us) {
+ else if (test->mode != SENDER && test->mode != BIDIRECTIONAL && t_usecs > rcv_timeout_us) {
```

### Behavior Change

* **Unchanged:** Pure receiver mode (`client → server` one-way) still uses `rcv-timeout`.
* **Changed:** In `--bidir`, the server no longer aborts on `rcv-timeout`; termination follows normal end conditions (or `--snd-timeout` if specified).

### Reproduction / Verification

**Server:**

```bash
iperf3 -s --rcv-timeout 5000 --snd-timeout 15000 -1 -J
```

**Client:**

```bash
iperf3 -c <server> --bidir -t 10 -J
```

* **Before (unpatched):** Server may terminate early with an `rcv-timeout`.
* **After (patched):** No premature termination under `--bidir`.

### Notes

* Built and tested locally using:

  ```bash
  ./bootstrap.sh   # only if ./configure fails
  ./configure
  make
  ```
* Minimal one-line change, consistent with intended semantics of `--bidir`.
* Closes #1766 

