### PR TITLE
docs: We use Ubuntu, not CentOS, for primary Linux development.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ original iperf.  These include, for example, a zero-copy mode and
 optional JSON output.  Note that iperf3 is *not* backwards compatible
 with the original iperf.
 
-Primary development for iperf3 takes place on CentOS Linux, FreeBSD,
+Primary development for iperf3 takes place on Ubuntu Linux, FreeBSD,
 and macOS.  At this time, these are the only officially
 supported platforms, however there have been some reports of success
 with OpenBSD, Android, and other Linux distributions.

--- a/docs/obtaining.rst
+++ b/docs/obtaining.rst
@@ -74,7 +74,7 @@ GitHub using:
 
 ``git clone https://github.com/esnet/iperf.git``
 
-Primary development for iperf3 takes place on CentOS 7 Linux, FreeBSD 11,
-and macOS 10.12. At this time, these are the only officially supported
+Primary development for iperf3 takes place on Ubuntu Linux, FreeBSD,
+and macOS. At this time, these are the only officially supported
 platforms, however there have been some reports of success with
 NetBSD, OpenBSD, Windows, Solaris, Android, and iOS.


### PR DESCRIPTION
Fixes #1891.

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): #1891

* Brief description of code changes (suitable for use as a commit message):

