### PR TITLE
Fix small release notes errors for 3.20

### DIFF
--- a/RELNOTES.md
+++ b/RELNOTES.md
@@ -30,10 +30,10 @@ releases, including iperf-3.19.1.
       flag (PR #1903)
 
     * Sends with `--zerocopy` are now properly seeded with data
-      instead of being all-zeroes. (PR #1909)
+      instead of being all-zeroes. (PR #1949)
 
-    * The `--time` flag is now allowed on the iperf3 server to impose
-      a maximum duration on timed tests. (PR #1684, PR #1931)
+    * The `--server-max-duration` flag is now allowed on the iperf3 server to impose
+      a maximum duration on timed tests. (PR #1684)
 
     * The `--rcv-timeout` flag is now ignored for `--bidir`
       tests. This change prevents premature termination of


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `3.20`

* Issues fixed (if any): `N/A`

* Brief description of code changes (suitable for use as a commit message):
  * Small adjustments to the release notes
  * Seems that #1931 was mentioned in the release notes but not merged. Removed this link.
  * Changed `--time` to `--server-max-duration` for the server-side time limiting feature
