### PR TITLE
Minor improvement in man page for --server-max-duration flag

### DIFF
--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -250,7 +250,7 @@ Restart the server after \fIn\fR seconds in case it gets stuck.
 In one-off mode, this is the number of seconds the server will wait
 before exiting.
 .TP
-.BR --server-max-duration " "
+.BR --server-max-duration " \fIn\fR"
 The maximum time, in seconds, that an iperf client can run against the server.
 When the sum of the client's time and omit values exceeds the max duration set by the server
 or the client's time value is 0, the measurement is rejected.


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): `N/A`

* Brief description of code changes (suitable for use as a commit message):
  * Small improvement to `man` page to show that the `--server-max-duration` flag requires an argument
