### PR TITLE
Add warning about loose Ethernet connections causing iperf3 failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Building iperf3
 
 ### Prerequisites: ###
 
-Ensure all physical connections are secure. iperf3 tests require a stable and reliable physical link between the server and client. Loose or partial connections between iperf server and client can cause test failures or inconsistent results. High-speed Ethernet communication relies on precise impedance matching across the cable and connectors. When a connector is not fully seated, the electrical path is disrupted, leading to Impedance mismatch, Increased bit errors, Link flapping or negotiation failures.
+Ensure all physical connections are secure. iperf3 tests require a stable and reliable physical link between the server and client. Loose or partial connections between iperf server and client can cause test failures or inconsistent results. High-speed Ethernet communication relies on precise impedance matching across the cable and connectors. When a connector is not fully seated, the electrical path is disrupted, it can lead to Impedance mismatch, Increased bit errors, Link flapping or negotiation failures.
 
 ### Building ###
 


### PR DESCRIPTION
Added a warning section to README.md explaining that iperf3 tests may fail if ethernet cables or intermediate connections are not fully seated. Loose or partially connected cables introduce impedance mismatches, causing signal reflections, bit errors, link instability, and throughput degradation during high‑speed testing.


* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
  iperf-3.20

* Issues fixed (if any): 
added a warning for user to know that if iperf intermittently fail then it is possible that physical connections between iperf server and client may be loosened. This will save user's lot of time.

* Brief description of code changes (suitable for use as a commit message):
Only added a warning in readme.md
