### PR TITLE
Fix backward compatibility issue of client incorrectly print 0 UDP packets loss

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2762,7 +2762,9 @@ get_results(struct iperf_test *test)
     cJSON *j_server_output;
     cJSON *j_start_time, *j_end_time;
     int sid;
-    int64_t cerror, pcount, omitted_cerror, omitted_pcount;
+    int64_t cerror, pcount;
+    // Init as seems to not be au-initialized to 0 by default, maybe because later init is only under if statement
+    int64_t omitted_cerror = 0, omitted_pcount = 0;
     double jitter;
     iperf_size_t bytes_transferred;
     int retransmits;
@@ -4310,7 +4312,9 @@ iperf_print_results(struct iperf_test *test)
                      * data here.
                      */
                     if (! test->json_output) {
-                        if (receiver_packet_count - receiver_omitted_packet_count > 0 && sp->omitted_cnt_error > -1) {
+                        if (test->omit == 0 && receiver_packet_count > 0) {
+                            lost_percent = 100.0 * sp->cnt_error / receiver_packet_count;
+                        } else if (receiver_packet_count - receiver_omitted_packet_count > 0 && sp->omitted_cnt_error > -1) {
                             lost_percent = 100.0 * (sp->cnt_error - sp->omitted_cnt_error) / (receiver_packet_count - receiver_omitted_packet_count);
                         }
                         else {
@@ -4322,7 +4326,9 @@ iperf_print_results(struct iperf_test *test)
                                 iperf_printf(test, report_receiver_not_available_format, sp->socket);
                         }
                         else {
-                            if (sp->omitted_cnt_error > -1) {
+                            if (test->omit == 0) {
+                                iperf_printf(test, report_bw_udp_format, sp->socket, mbuf, start_time, receiver_time, ubuf, nbuf, sp->jitter * 1000.0, sp->cnt_error, receiver_packet_count, lost_percent, report_receiver);
+                            } else if (sp->omitted_cnt_error > -1) {
                                 iperf_printf(test, report_bw_udp_format, sp->socket, mbuf, start_time, receiver_time, ubuf, nbuf, sp->jitter * 1000.0, (sp->cnt_error - sp->omitted_cnt_error), (receiver_packet_count - receiver_omitted_packet_count), lost_percent, report_receiver);
                             } else {
                                 iperf_printf(test, report_bw_udp_format_no_omitted_error, sp->socket, mbuf, start_time, receiver_time, ubuf, nbuf, sp->jitter * 1000.0, (receiver_packet_count - receiver_omitted_packet_count), report_receiver);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): #1984

* Brief description of code changes (suitable for use as a commit message):

Fix backward compatibility issue of client showing UDP 0 packets loss, although packets were lost.  The issue is with older iperf3 servers that did not send omitted packets info.

The main issue was that for some reason, the omitted error count variable was not auto initialized to zero.  However, when I added a `printf()` of its value, it was initialized to 0.  Maybe a compiler issue, as the later initialization of the variable is done under `if` statement with no `else`.

For robustness, also ignored the omitted values if omitting time is not specified.  That allows showing the real packets loss when server does not support sending the omitting info.
