### PR TITLE
Remove data sockets closing from server_timer_proc to avoid crash

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -319,19 +319,11 @@ static void
 server_timer_proc(TimerClientData client_data, struct iperf_time *nowP)
 {
     struct iperf_test *test = client_data.p;
-    struct iperf_stream *sp;
 
     test->timer = NULL;
     if (test->done)
         return;
     test->done = 1;
-    /* Free streams */
-    while (!SLIST_EMPTY(&test->streams)) {
-        sp = SLIST_FIRST(&test->streams);
-        SLIST_REMOVE_HEAD(&test->streams, streams);
-        close(sp->socket);
-        iperf_free_stream(sp);
-    }
     close(test->ctrl_sck);
     test->ctrl_sck = -1;
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

While evaluation Issue #1986 and simulating disconnect between the client and server, the **server crashed** after the call to `server_timer_proc()`.  Using gdb I found that the problem was that the `sp->test` address in the data thread was garbled.  I believe that this was because of race condition between the main and data threads:
1. `server_timer_proc()` closed the data stream and freed the `sp` buffers.
2. The `sp` buffer was used for something else, garbling the `test` address` (if this step happens later, depending on the threads race conditions, the crash will not happen).
3. Since the data stream was closed, the data thread `read()/recv()` returned 0 - end of file.
4. `iperf_tcp_recv()` in the data thread performs the `if (sp->test->state == TEST_RUNNING)` test that cause the server crash because the `sp->test` is garbled.

The suggested fix is that `server_timer_proc()` will only close the control socket, but not the data streams.  This causes the `select()` to fail and then the threads/sockets are closed in the usual way after failure.

Another approach was that `server_timer_proc()` will close the threads before closing the streams, but I think just closing the control channel is better.

Also, I noted that `server_timer_proc()` does not issue any error message.  I didn't add such message as I am not sure if this is not intentional.
