### PR TITLE
Fix UBSan with `-i0`: avoid division by zero

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1967,7 +1967,8 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     /* Set Total-rate average interval to multiplicity of State interval */
     if (test->settings->bitrate_limit_interval != 0) {
 	test->settings->bitrate_limit_stats_per_interval =
-	    (test->settings->bitrate_limit_interval <= test->stats_interval ?
+	    (test->settings->bitrate_limit_interval <= test->stats_interval ||
+	     test->stats_interval == 0 ?
 	    1 : round(test->settings->bitrate_limit_interval/test->stats_interval) );
     }
 


### PR DESCRIPTION

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

```
Fix UBSan with `-i0`: avoid division by zero

The interval is explicity allowed to be zero, but we are trying to
divide by the interval without checking if it's zero, which will cause
an UBSan failure.

This commit fixed the issue by verify the interval is not zero before
division.
```

* Actual UBSan report:
```
iperf3/src/iperf_api.c:1962:6: runtime error: inf is outside the range of representable values of type 'int'
    #0 0x555b386f6125 in iperf_parse_arguments iperf3/src/iperf_api.c:1962:6
    #1 0x555b386ef30a in main iperf3/src/main.c:117:9
<snip>

SUMMARY: UndefinedBehaviorSanitizer: float-cast-overflow iperf3/src/iperf_api.c:1962:6
```