### PR TITLE
Cancel periodic timers at test end

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -773,6 +773,20 @@ iperf_run_client(struct iperf_test * test)
 	         (test->settings->blocks != 0 && (test->blocks_sent >= test->settings->blocks ||
 						  test->blocks_received >= test->settings->blocks)))) {
 
+                /*
+                 * Cancel the periodic timers.  As the timers are not re-set in this stage their expiration time
+                 * is in the past, so without the cancellation the select() timeout is set to 0,
+                 * and it enters a loop while waiting the exchanged results, etc.
+                 */
+                if (test->stats_timer != NULL) {
+                    tmr_cancel(test->stats_timer);
+                    test->stats_timer = NULL;
+                }
+                if (test->reporter_timer != NULL) {
+                    tmr_cancel(test->reporter_timer);
+                    test->reporter_timer = NULL;
+                }
+
                 /* Cancel outstanding sender threads */
                 SLIST_FOREACH(sp, &test->streams, streams) {
                     if (sp->sender) {


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
main 3.21+

* Issues fixed (if any): #2018 

* Brief description of code changes (suitable for use as a commit message):
Canceling the `stats_timer` and `reporter_timer` at the end of the test, to prevent `select()` busy loop with zero timeout while waiting for exchanged results, etc. The zero timeout was because at the end of the test these times are not re-set, so their timeout is in the past.

