### PR TITLE
No delay of Client final interval report

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -4628,8 +4628,12 @@ iperf_reporter_callback(struct iperf_test *test)
             iperf_print_intermediate(test);
             break;
         case TEST_END:
-        case DISPLAY_RESULTS:
             iperf_print_intermediate(test);
+            if (test->role == 's') {
+                iperf_print_results(test);
+            }
+            break;
+        case DISPLAY_RESULTS:
             iperf_print_results(test);
             break;
     }

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -810,6 +810,7 @@ iperf_run_client(struct iperf_test * test)
 		test->stats_callback(test);
 		if (iperf_set_send_state(test, TEST_END) != 0)
                     goto cleanup_and_fail;
+                test->reporter_callback(test); // [DBO] ???
 	    }
 	}
     }

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -810,7 +810,7 @@ iperf_run_client(struct iperf_test * test)
 		test->stats_callback(test);
 		if (iperf_set_send_state(test, TEST_END) != 0)
                     goto cleanup_and_fail;
-                test->reporter_callback(test); // [DBO] ???
+                test->reporter_callback(test);
 	    }
 	}
     }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master 3.21+

* Issues fixed (if any): #2019

* Brief description of code changes (suitable for use as a commit message):

Print final interval report from Client on `TEST_END` (like the Server) instead of `DISPLAY_RESULTS`.  This is to prevent the problem that the last Client's interval report is delayed on high-latency links (like cellular systems).