### PR TITLE
iperf_tcp: replace connect() with timeout_connect()

### DIFF
--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -589,7 +589,8 @@ iperf_tcp_connect(struct iperf_test *test)
     /* Set common socket options */
     iperf_common_sockopts(test, s);
 
-    if (connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen) < 0 && errno != EINPROGRESS) {
+    if (timeout_connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen,
+                        DEFAULT_NO_MSG_RCVD_TIMEOUT) < 0 && errno != EINPROGRESS) {
 	saved_errno = errno;
 	close(s);
 	freeaddrinfo(server_res);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: **master**

* Issues fixed (if any): https://github.com/esnet/iperf/issues/2029

* Brief description of code changes (suitable for use as a commit message):

In --bidir mode, iperf_tcp_connect() was called twice: first for the sender stream, then for the receiver. The old connect() call returned immediately on EINPROGRESS, so both TCP handshakes completed in parallel.
Under load with RSS, the server's accept() could return them out of order, causing both sides to assign the same role (both sender or both receiver) and deadlock.

Replace connect() with timeout_connect() so each handshake fully completes before the next connect() is issued, ensuring deterministic accept() order.

