### PR TITLE
Limit UDP GSO number of segments in a message to the allowed value

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -494,6 +494,7 @@ extern int gerror; /* error value from getaddrinfo(3), for use in internal error
 /* In Reverse mode, maximum number of packets to wait for "accept" response - to handle out of order packets */
 #define MAX_REVERSE_OUT_OF_ORDER_PACKETS 2
 
+#define GSO_MAX_DG_IN_BF (1 << 7UL) // 128 - the Linux Kernel limit hardcoded as `UDP_MAX_SEGMENTS (1 << 7UL)` in `udpgso.c`
 #define GSO_BF_MAX_SIZE MAX_UDP_BLOCKSIZE
 #define GRO_BF_MAX_SIZE MAX_UDP_BLOCKSIZE
 

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -420,7 +420,7 @@ iperf_handle_message_client(struct iperf_test *test)
 int
 iperf_connect(struct iperf_test *test)
 {
-    int opt;
+    int opt, n;
     socklen_t len;
 
     if (NULL == test)
@@ -526,7 +526,11 @@ iperf_connect(struct iperf_test *test)
 	    test->settings->gso_dg_size = test->settings->blksize;
 	    /* use the multiple of datagram size for the best efficiency. */
 	    if (test->settings->gso_dg_size > 0) {
-		test->settings->gso_bf_size = (test->settings->gso_bf_size / test->settings->gso_dg_size) * test->settings->gso_dg_size;
+                n = test->settings->gso_bf_size / test->settings->gso_dg_size;
+                if (n > GSO_MAX_DG_IN_BF) {
+                    n = GSO_MAX_DG_IN_BF;
+                }
+		test->settings->gso_bf_size = n * test->settings->gso_dg_size;
 	    } else {
 		/* If gso_dg_size is 0 (unlimited bandwidth), use default UDP datagram size */
 		test->settings->gso_dg_size = DEFAULT_UDP_BLKSIZE;


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master 3.21+

* Issues fixed (if any): #2032

* Brief description of code changes (suitable for use as a commit message):

Suggested fix to PR #1925 to limit the number of segments in UDP GSO message to 128, which is the maximum allowed.  The problem was with messages length 507 or less, as 507 is the maximum length where `MAX_UDP_BLOCKSIZE/length >= 129`.

The limit `GSO_MAX_DG_IN_BF` is defined as a constant as I didn't find a reliable way to determine it dynamically.  From what I found, the value is defined in Linux as `UDP_MAX_SEGMENTS`.  Although it seems that in some (newer?) Linux distributions it is defined in `udp.h`, as in [here](https://github.com/torvalds/linux/blob/f1a5e78a55ebf2b05777fd5eb738038ddae609d6/include/linux/udp.h#L127), at least in WSL Linux that I use it is not defined in a header file, and probably it is defined in `udpgso.c` like in [here](https://github.com/torvalds/linux/blob/6fe0be6dc7faf984599b1e356ead1c49b64ed3ca/tools/testing/selftests/net/udpgso.c#L36-L38).