### PR TITLE
fix: GCC 15 / C23 compatibility — uint, u_char, _DEFAULT_SOURCE

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -29,6 +29,11 @@
 
 #include "iperf_config.h"
 
+/* uint was removed from <sys/types.h> in C23 (GCC 15 default). */
+#ifndef uint
+typedef unsigned int uint;
+#endif
+
 #include <sys/time.h>
 #include <sys/types.h>
 #include <stdint.h>

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -24,6 +24,8 @@
  * This code is distributed under a BSD style license, see the LICENSE
  * file for complete information.
  */
+
+#define _DEFAULT_SOURCE 1
 #include <errno.h>
 #include <setjmp.h>
 #include <stdio.h>

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -1,5 +1,12 @@
 /* src/iperf_config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* C23 (GCC 15 default) removes implicit _DEFAULT_SOURCE;
+   define it explicitly so POSIX functions (daemon, gai_strerror,
+   fileno, getline, etc.) remain visible. */
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE 1
+#endif
+
 /* Can bind to device via SO_BINDTODEVICE or IP_BOUND_IF. */
 #undef CAN_BIND_TO_DEVICE
 

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -24,6 +24,8 @@
  * This code is distributed under a BSD style license, see the LICENSE
  * file for complete information.
  */
+
+#include "iperf_config.h"
 #include <stdio.h>
 #include <errno.h>
 #include <netdb.h>

--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -25,8 +25,10 @@
  * file for complete information.
  */
 /* iperf_server_api.c: Functions to be used by an iperf server
-*/
+ */
 
+#define _DEFAULT_SOURCE 1
+#include "iperf_config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -24,6 +24,8 @@
  * This code is distributed under a BSD style license, see the LICENSE
  * file for complete information.
  */
+
+#define _DEFAULT_SOURCE 1
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
  * This code is distributed under a BSD style license, see the LICENSE
  * file for complete information.
  */
+
 #include "iperf_config.h"
 
 #include <stdio.h>

--- a/src/units.c
+++ b/src/units.c
@@ -300,7 +300,7 @@ extern    "C"
 	{
 	    inNum *= 8;
 	}
-	switch    (toupper((u_char)inFormat))
+    switch    (toupper((unsigned char)inFormat))
 	{
 	case 'B':
 	    conv = UNIT_CONV;


### PR DESCRIPTION
GCC 15 defaults to `-std=gnu23` (C23), which removes `uint` and `u_char` from `<sys/types.h>` and no longer implicitly defines `_DEFAULT_SOURCE`. This hides POSIX functions like `daemon(3)`, `gai_strerror(3)`, `fileno(3)`, `getaddrinfo(3)`, and others behind feature-test macros.

**Changes:**
- **`src/iperf.h`**: Add `typedef unsigned int uint` compatibility fallback
- **`src/iperf_config.h.in`**: Define `_DEFAULT_SOURCE` globally so all files that include it pick it up
- **`src/iperf_client_api.c`, `iperf_server_api.c`, `iperf_tcp.c`**: Add `_DEFAULT_SOURCE` before system headers (these files include system headers before `iperf_config.h`)
- **`src/units.c`**: Replace `u_char` with `unsigned char` in a `toupper()` cast

**Tested:**
- ✅ `gcc -std=c2x -Werror` — clean build (C23 mode)
- ✅ Default flags — clean build (no regression)

Fixes #1838.