### PR TITLE
iperf_client_api: align default TCP block size to MSS

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -162,6 +162,7 @@ struct iperf_settings
     int       domain;               /* AF_INET or AF_INET6 */
     int       socket_bufsize;       /* window size for TCP */
     int       blksize;              /* size of read/writes (-l) */
+    int       blksize_set;          /* nonzero iff user explicitly set blksize (-l or API) */
     iperf_size_t  rate;                 /* target data rate for application pacing*/
     iperf_size_t  bitrate_limit;   /* server's maximum allowed total data rate for all streams*/
     double        bitrate_limit_interval;  /* interval for averaging total data rate */

--- a/src/iperf3.1
+++ b/src/iperf3.1
@@ -381,7 +381,13 @@ options are mutually exclusive.
 .TP
 .BR -l ", " --length " \fIn\fR[KMGT]"
 Set the length of the buffer to read or write.  For TCP tests, the
-default value is 128KB.
+default value is 128KB; when
+.B -l
+is not specified, iperf3 rounds this default down to the largest
+multiple of the MSS (taken from
+.B -M
+if given, otherwise from the control connection) so that each write
+produces an integer number of full-sized segments.
 In the case of UDP, iperf3 tries to dynamically determine a reasonable
 sending size based on the path MTU; if that cannot be determined it
 uses 1460 bytes as a sending size.

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3770,6 +3770,7 @@ iperf_reset_test(struct iperf_test *test)
     test->num_streams = 1;
     test->settings->socket_bufsize = 0;
     test->settings->blksize = DEFAULT_TCP_BLKSIZE;
+    test->settings->blksize_set = 0;
     test->settings->rate = 0;
     test->settings->fqrate = 0;
     test->settings->burst = 0;

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -496,6 +496,7 @@ void
 iperf_set_test_blksize(struct iperf_test *ipt, int blksize)
 {
     ipt->settings->blksize = blksize;
+    ipt->settings->blksize_set = 1;
 }
 
 void
@@ -1414,6 +1415,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                     return -1;
                 }
                 // NOTE: blksize is unsigned, can't be less than 0
+		test->settings->blksize_set = 1;
 		client_flag = 1;
                 break;
             case 'P':

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -555,7 +555,7 @@ iperf_connect(struct iperf_test *test)
      * down to the largest multiple of the MSS so that each write decomposes
      * into integer-many full-sized wire segments after TSO/GSO splits it.
      * Prefer a user-specified -M value (settings->mss); otherwise fall back
-     * to the kernel-reported control-socket MSS. See issue #1771.
+     * to the kernel-reported control-socket MSS.
      */
     if (test->protocol->id == Ptcp && !test->settings->blksize_set) {
 	int mss = test->settings->mss ? test->settings->mss : test->ctrl_sck_mss;

--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -550,6 +550,27 @@ iperf_connect(struct iperf_test *test)
 	}
     }
 
+    /*
+     * For TCP, when the user did not pass -l, round the default block size
+     * down to the largest multiple of the MSS so that each write decomposes
+     * into integer-many full-sized wire segments after TSO/GSO splits it.
+     * Prefer a user-specified -M value (settings->mss); otherwise fall back
+     * to the kernel-reported control-socket MSS. See issue #1771.
+     */
+    if (test->protocol->id == Ptcp && !test->settings->blksize_set) {
+	int mss = test->settings->mss ? test->settings->mss : test->ctrl_sck_mss;
+	if (mss > 0) {
+	    int aligned = (DEFAULT_TCP_BLKSIZE / mss) * mss;
+	    if (aligned < mss)
+		aligned = mss;
+	    test->settings->blksize = aligned;
+	    if (test->verbose) {
+		printf("Setting TCP block size to %d (MSS %d)\n",
+		       test->settings->blksize, mss);
+	    }
+	}
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
When the user has not specified -l, round the default 128 KiB block size down to the largest multiple of the MSS so each per-write chunk decomposes into integer-many full-sized wire segments after TSO/GSO segmentation, eliminating the short trailing segment per chunk.  When -M is set, align to settings->mss (the requested value); otherwise align to the control-socket MSS already read in iperf_connect().  Mirrors the pre-existing UDP block-size auto-sizing in the same function.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

