### PR TITLE
iperf_sctp: disable delayed-SACK by default to fix slow single-flow SCTP throughput

### DIFF
--- a/configure
+++ b/configure
@@ -16897,6 +16897,16 @@ printf '%s\n' "#define HAVE_STRUCT_SCTP_ASSOC_VALUE 1" >>confdefs.h
 
 fi
 
+ac_fn_c_check_type "$LINENO" "struct sctp_sack_info" "ac_cv_type_struct_sctp_sack_info" "#include <netinet/sctp.h>
+"
+if test "x$ac_cv_type_struct_sctp_sack_info" = xyes
+then :
+
+printf '%s\n' "#define HAVE_STRUCT_SCTP_SACK_INFO 1" >>confdefs.h
+
+
+fi
+
 fi
 
 done

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,8 @@ AC_CHECK_HEADERS([netinet/sctp.h],
 		 AC_DEFINE([HAVE_SCTP_H], [1], [Have SCTP support.])
 		 AC_SEARCH_LIBS(sctp_bindx, [sctp])
 		 AC_CHECK_TYPES([struct sctp_assoc_value], [], [],
+				[[#include <netinet/sctp.h>]])
+		 AC_CHECK_TYPES([struct sctp_sack_info], [], [],
 				[[#include <netinet/sctp.h>]]),
 		 [],
 		 [#ifdef HAVE_SYS_SOCKET_H

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -506,6 +506,7 @@ enum {
     IESETCNTLKACOUNT = 158,    // Unable to set/get socket keepalive TCP number of retries (TCP_KEEPCNT) option
     IEPTHREADSIGMASK=159,      // Unable to initialize sub thread signal mask (check perror)
     IESERVERTESTDURATIONEXPIRED = 160, // Server test duration expired
+    IESETSCTPDELAYEDSACK = 161, // Unable to set SCTP_DELAYED_SACK (check perror)
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_config.h.in
+++ b/src/iperf_config.h.in
@@ -117,6 +117,9 @@
 /* Define to 1 if the system has the type 'struct sctp_assoc_value'. */
 #undef HAVE_STRUCT_SCTP_ASSOC_VALUE
 
+/* Define to 1 if the system has the type 'struct sctp_sack_info'. */
+#undef HAVE_STRUCT_SCTP_SACK_INFO
+
 /* Define to 1 if you have the <sys/endian.h> header file. */
 #undef HAVE_SYS_ENDIAN_H
 

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -469,6 +469,10 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "unable to set SCTP_DISABLE_FRAGMENTS");
             perr = 1;
             break;
+        case IESETSCTPDELAYEDSACK:
+            snprintf(errstr, len, "unable to set SCTP_DELAYED_SACK");
+            perr = 1;
+            break;
         case IESETSCTPNSTREAM:
             snprintf(errstr, len, "unable to set SCTP_INIT num of SCTP streams\n");
             perr = 1;

--- a/src/iperf_sctp.c
+++ b/src/iperf_sctp.c
@@ -125,6 +125,38 @@ iperf_sctp_accept(struct iperf_test * test)
         return -1;
     }
 
+    if (test->no_delay) {
+        int opt = 1;
+        if (setsockopt(s, IPPROTO_SCTP, SCTP_NODELAY, &opt, sizeof(opt)) < 0) {
+            i_errno = IESETNODELAY;
+            close(s);
+            return -1;
+        }
+    }
+
+#ifdef HAVE_STRUCT_SCTP_SACK_INFO
+    /*
+     * Apply SCTP_DELAYED_SACK on the accepted association.  On Linux the
+     * SCTP_DELAYED_SACK setting on the listener does NOT propagate to
+     * accepted associations, so the per-association setting must be applied
+     * here for the receiver-side fix to take effect.  ENOPROTOOPT is
+     * non-fatal so this is safe on platforms without support.
+     */
+    {
+        struct sctp_sack_info sack;
+        memset(&sack, 0, sizeof(sack));
+        sack.sack_assoc_id = 0;
+        sack.sack_delay = 0;
+        sack.sack_freq = 1;
+        if (setsockopt(s, IPPROTO_SCTP, SCTP_DELAYED_SACK, &sack, sizeof(sack)) < 0 &&
+            errno != ENOPROTOOPT) {
+            i_errno = IESETSCTPDELAYEDSACK;
+            close(s);
+            return -1;
+        }
+    }
+#endif /* HAVE_STRUCT_SCTP_SACK_INFO */
+
     if (Nread(s, cookie, COOKIE_SIZE, Psctp) < 0) {
         i_errno = IERECVCOOKIE;
         close(s);
@@ -247,6 +279,52 @@ iperf_sctp_listen(struct iperf_test *test)
         i_errno = IEREUSEADDR;
         return -1;
     }
+
+    if (test->no_delay) {
+        opt = 1;
+        if (setsockopt(s, IPPROTO_SCTP, SCTP_NODELAY, &opt, sizeof(opt)) < 0) {
+            saved_errno = errno;
+            close(s);
+            freeaddrinfo(res);
+            errno = saved_errno;
+            i_errno = IESETNODELAY;
+            return -1;
+        }
+    }
+
+#ifdef HAVE_STRUCT_SCTP_SACK_INFO
+    /*
+     * Disable SCTP delayed-SACK on future accepted associations.  With the
+     * default sack_freq=2/sack_delay=200ms, a sender that writes blocks
+     * producing exactly one DATA chunk stalls for 200 ms waiting for a SACK
+     * that the receiver is in turn delaying.  iperf3 is a throughput
+     * benchmark, so request an immediate SACK on every packet.  On Linux
+     * the endpoint default set here does not propagate to accepted
+     * associations -- iperf_sctp_accept() repeats the call on the per-
+     * association socket.  ENOPROTOOPT (platform without support) is
+     * non-fatal.
+     */
+    {
+        struct sctp_sack_info sack;
+        memset(&sack, 0, sizeof(sack));
+#ifdef SCTP_FUTURE_ASSOC
+        sack.sack_assoc_id = SCTP_FUTURE_ASSOC;
+#else
+        sack.sack_assoc_id = 0;
+#endif
+        sack.sack_delay = 0;
+        sack.sack_freq = 1;
+        if (setsockopt(s, IPPROTO_SCTP, SCTP_DELAYED_SACK, &sack, sizeof(sack)) < 0 &&
+            errno != ENOPROTOOPT) {
+            saved_errno = errno;
+            close(s);
+            freeaddrinfo(res);
+            errno = saved_errno;
+            i_errno = IESETSCTPDELAYEDSACK;
+            return -1;
+        }
+    }
+#endif /* HAVE_STRUCT_SCTP_SACK_INFO */
 
     /* servers must call sctp_bindx() _instead_ of bind() */
     if (!TAILQ_EMPTY(&test->xbind_addrs)) {
@@ -540,6 +618,33 @@ iperf_sctp_connect(struct iperf_test *test)
         i_errno = IESETSCTPDISABLEFRAG;
         return -1;
     }
+
+#ifdef HAVE_STRUCT_SCTP_SACK_INFO
+    /*
+     * Disable SCTP delayed-SACK on this association (see iperf_sctp_listen()
+     * for rationale).  Applied here as well so that --reverse, which makes
+     * the client the receiver, still gets immediate SACKs.  The socket is
+     * already connected and 1:1-style, so sack_assoc_id=0 unambiguously
+     * targets the current association on every platform (RFC 6458 §8.1).
+     * ENOPROTOOPT is treated as non-fatal.
+     */
+    {
+        struct sctp_sack_info sack;
+        memset(&sack, 0, sizeof(sack));
+        sack.sack_assoc_id = 0;
+        sack.sack_delay = 0;
+        sack.sack_freq = 1;
+        if (setsockopt(s, IPPROTO_SCTP, SCTP_DELAYED_SACK, &sack, sizeof(sack)) < 0 &&
+            errno != ENOPROTOOPT) {
+            saved_errno = errno;
+            close(s);
+            freeaddrinfo(server_res);
+            errno = saved_errno;
+            i_errno = IESETSCTPDELAYEDSACK;
+            return -1;
+        }
+    }
+#endif /* HAVE_STRUCT_SCTP_SACK_INFO */
 
     freeaddrinfo(server_res);
     return s;


### PR DESCRIPTION
Single-flow SCTP throughput collapses to a few Mbits/sec on Linux (~300× slower than TCP on the same loopback) because  the receiver's delayed-SACK timer (sack_delay=200 ms, sack_freq=2) waits for a second DATA chunk that the blocked sender will not produce — each iperf3 64 KB block lands as one DATA chunk and stalls 200 ms per I/O cycle.  Reproducible on both arm64 and x86_64; not architecture-specific.

iperf3 is a throughput benchmark, so disable delayed-SACK by setting SCTP_DELAYED_SACK with sack_delay=0, sack_freq=1
  on all three SCTP socket entry points:

  - iperf_sctp_listen — endpoint default (FreeBSD-style SCTP_FUTURE_ASSOC)
  - iperf_sctp_accept — required on Linux; the listener-side setting does not propagate to accepted associations
  - iperf_sctp_connect — covers --reverse where the client becomes the receiver

Also propagate SCTP_NODELAY to both the server's listen and accepted sockets when -N is given, closing a pre-existing  asymmetry with iperf_tcp_listen's handling of TCP_NODELAY.

configure gains an AC_CHECK_TYPES probe for struct sctp_sack_info; new code is guarded by HAVE_STRUCT_SCTP_SACK_INFO and ENOPROTOOPT is treated as non-fatal, so platforms without support are silently unaffected.

master and fix performance
```
SCTP iperf3 -c localhost --sctp -t 10 │ 2.67 Mbits/sec │ 1.42 Gbits/sec
```

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any): #1815 

* Brief description of code changes (suitable for use as a commit message): disable delayed-SACK by default to fix slow single-flow SCTP throughput (#1815)

