### PR TITLE
Ensure DSCP/ToS is set in the first UDP/TCP streams packets

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1519,7 +1519,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 	    case OPT_DSCP:
                 test->settings->tos = parse_qos(optarg);
 		if(test->settings->tos < 0) {
-			i_errno = IEBADTOS;
+			i_errno = IEBADDSCP;
 			return -1;
 		}
 		client_flag = 1;

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -445,6 +445,7 @@ enum {
     IECNTLKA = 36,          // Control connection Keepalive period should be larger than the full retry period (interval * count)
     IEMAXSERVERTESTDURATIONEXCEEDED = 37, // Client's duration exceeds server's maximum duration
     IEUNITVAL = 38,         // Invalid unit value or suffix
+    IEBADDSCP = 39,         // Bad DSCP value
     /* Test errors */
     IENEWTEST = 100,        // Unable to create a new test (check perror)
     IEINITTEST = 101,       // Test initialization failed (check perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -210,8 +210,11 @@ iperf_strerror(int int_errno)
         case IEBADTOS:
             snprintf(errstr, len, "bad TOS value (must be between 0 and 255 inclusive)");
             break;
+        case IEBADDSCP:
+            snprintf(errstr, len, "bad DSCP value (numeric: 0-63 inclusive, symbolic: one of [af11-13, af21-23, af31-33, af41-43, cs1-7, ef, va, lowdelay, throughput, reliability])");
+            break;
         case IESETCLIENTAUTH:
-             snprintf(errstr, len, "you must specify a username, password, and path to a valid RSA public key");
+            snprintf(errstr, len, "you must specify a username, password, and path to a valid RSA public key");
             break;
         case IESETSERVERAUTH:
              snprintf(errstr, len, "you must specify a path to a valid RSA private key and a user credential file");

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -204,9 +204,9 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
                            "                            The usual prefixes for octal and hex can be used,\n"
                            "                            i.e. 52, 064 and 0x34 all specify the same value.\n"
 
-                           "  --dscp N or --dscp val    set the IP dscp value, either 0-63 or symbolic.\n"
-                           "                            Numeric values can be specified in decimal,\n"
-                           "                            octal and hex (see --tos above).\n"
+                           "  --dscp N or --dscp val    set the IP dscp value, either 0-63 or symbolic (one of: af11-13, af21-23,\n"
+                           "                            af31-33, af41-43, cs1-7, ef, va, lowdelay, throughput, reliability).\n"
+                           "                            Numeric values can be decimal, octal and hex (see --tos above).\n"
 #if defined(HAVE_FLOWLABEL)
                            "  -L, --flowlabel N         set the IPv6 flow label (only supported on Linux)\n"
 #endif /* HAVE_FLOWLABEL */

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -365,8 +365,14 @@ iperf_tcp_listen(struct iperf_test *test)
     }
     if (test->settings->socket_bufsize && test->settings->socket_bufsize > rcvbuf_actual) {
 	i_errno = IESETBUF2;
-    close(s);
+        close(s);
 	return -1;
+    }
+
+    /* Set common socket options */
+    if (iperf_common_sockopts(test, s) < 0) {
+        close(s);
+        return -1;
     }
 
     if (test->json_output) {
@@ -587,7 +593,13 @@ iperf_tcp_connect(struct iperf_test *test)
     }
 
     /* Set common socket options */
-    iperf_common_sockopts(test, s);
+    if (iperf_common_sockopts(test, s) < 0) {
+        saved_errno = errno;
+	close(s);
+	freeaddrinfo(server_res);
+	errno = saved_errno;
+        return -1;
+    }
 
     if (timeout_connect(s, (struct sockaddr *) server_res->ai_addr, server_res->ai_addrlen,
                         DEFAULT_NO_MSG_RCVD_TIMEOUT) < 0 && errno != EINPROGRESS) {

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -602,6 +602,11 @@ iperf_udp_accept(struct iperf_test *test)
 	}
     }
 
+    /* Set common socket options */
+    if (iperf_common_sockopts(test, s) < 0) {
+        return -1;
+    }
+
     /*
      * Create a new "listening" socket to replace the one we were using before.
      */
@@ -726,7 +731,9 @@ iperf_udp_connect(struct iperf_test *test)
     }
 
     /* Set common socket options */
-    iperf_common_sockopts(test, s);
+    if (iperf_common_sockopts(test, s) < 0) {
+        return -1;
+    }
 
 #ifdef SO_RCVTIMEO
     /* 30 sec timeout for a case when there is a network problem. */


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master 3.21+

* Issues fixed (if any): #830, #510

* Brief description of code changes (suitable for use as a commit message):

Suggested fix to ensure that DSCP/ToS is set in the first streams packets (with DSCP option help message enhancement).
Currently, DSCP is not set in the first stream packets from the server: first UDP response and the first two TCP messages (ACKs).

(Note this PR is not related to the control channel - PR #1985 suggests adding an option to set its DSCP/ToS.)

