### PR TITLE
Do not allow setting zero parallel streams

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -2655,7 +2655,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 0){
                 i_errno = IEBLOCKSIZE;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->blksize = j_p->valueint;
             }
         }
@@ -2702,7 +2702,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 0 || j_p->valueint > 1){
                 i_errno = IERECVPARAMS;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->gro = j_p->valueint;
             }
         }
@@ -2710,7 +2710,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 0){
                 i_errno = IERECVPARAMS;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->gro_bf_size = j_p->valueint;
             }
         }
@@ -2718,7 +2718,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 0){
                 i_errno = IERECVPARAMS;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->rate = j_p->valueint;
             }
         }
@@ -2726,7 +2726,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 0){
                 i_errno = IERECVPARAMS;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->fqrate = j_p->valueint;
             }
         }
@@ -2734,7 +2734,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 0){
                 i_errno = IERECVPARAMS;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->pacing_timer = j_p->valueint;
             }
         }
@@ -2742,7 +2742,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint <= 0 || j_p->valueint > MAX_BURST){
                 i_errno = IEBURST;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->burst = j_p->valueint;
             }
         }
@@ -2750,7 +2750,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 0 || j_p->valueint > 255){
                 i_errno = IEBADTOS;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->tos = j_p->valueint;
             }
         }
@@ -2759,7 +2759,7 @@ get_parameters(struct iperf_test *test)
             if (j_p->valueint < 1 || j_p->valueint > 0xfffff ){
                 i_errno = IESETFLOW;
                 r = -1;
-            }else {
+            } else {
 	        test->settings->flowlabel = j_p->valueint;
             }
         }

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1418,7 +1418,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
                 break;
             case 'P':
                 test->num_streams = atoi(optarg);
-                if (test->num_streams < 0 || test->num_streams > MAX_STREAMS) {
+                if (test->num_streams < 1 || test->num_streams > MAX_STREAMS) {
                     i_errno = IENUMSTREAMS;
                     return -1;
                 }
@@ -2627,7 +2627,7 @@ get_parameters(struct iperf_test *test)
 	if ((j_p = iperf_cJSON_GetObjectItemType(j, "nodelay", cJSON_True)) != NULL)
 	    test->no_delay = 1;
 	if ((j_p = iperf_cJSON_GetObjectItemType(j, "parallel", cJSON_Number)) != NULL){
-            if (j_p->valueint < 0  || j_p->valueint > MAX_STREAMS) {
+            if (j_p->valueint < 1  || j_p->valueint > MAX_STREAMS) {
                 i_errno = IENUMSTREAMS;
                 r = -1;
             } else {
@@ -2823,25 +2823,25 @@ get_parameters(struct iperf_test *test)
        }
 
 
-    /* Ensure that the client does not request to run longer than the server's configured max */
-    if ((test->max_server_duration > 0) && (((test->duration + test->omit) > test->max_server_duration) || (test->duration == 0))) {
-        i_errno = IEMAXSERVERTESTDURATIONEXCEEDED;
-        r = -1;
-    }
+        /* Ensure that the client does not request to run longer than the server's configured max */
+        if ((test->max_server_duration > 0) && (((test->duration + test->omit) > test->max_server_duration) || (test->duration == 0))) {
+            i_errno = IEMAXSERVERTESTDURATIONEXCEEDED;
+            r = -1;
+        }
 
 
-    /* Ensure that total requested data rate is not above the server's limit */
-    iperf_size_t total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
-    if (test->settings->bitrate_limit && total_requested_rate > test->settings->bitrate_limit) {
-        i_errno = IETOTALRATE;
-        r = -1;
-    }
+        /* Ensure that total requested data rate is not above the server's limit */
+        iperf_size_t total_requested_rate = test->num_streams * test->settings->rate * (test->mode == BIDIRECTIONAL? 2 : 1);
+        if (test->settings->bitrate_limit && total_requested_rate > test->settings->bitrate_limit) {
+            i_errno = IETOTALRATE;
+            r = -1;
+        }
 
-    total_requested_rate = test->num_streams * test->settings->fqrate * (test->mode == BIDIRECTIONAL? 2 : 1);
-    if (test->settings->bitrate_limit && total_requested_rate > test->settings->bitrate_limit) {
-        i_errno = IETOTALRATE;
-        r = -1;
-    }
+        total_requested_rate = test->num_streams * test->settings->fqrate * (test->mode == BIDIRECTIONAL? 2 : 1);
+        if (test->settings->bitrate_limit && total_requested_rate > test->settings->bitrate_limit) {
+            i_errno = IETOTALRATE;
+            r = -1;
+        }
     }
 
     return r;

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -190,7 +190,7 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "test duration valid values are 0 to %d seconds", MAX_TIME);
             break;
         case IENUMSTREAMS:
-            snprintf(errstr, len, "number of parallel streams too large (maximum = %d)", MAX_STREAMS);
+            snprintf(errstr, len, "invalid number of parallel streams (min = 1, max = %d)", MAX_STREAMS);
             break;
         case IEBLOCKSIZE:
             snprintf(errstr, len, "block size too large (maximum = %d bytes)", MAX_BLOCKSIZE);


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master 3.21+

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

Dot not allow `--parallel` to be zero (noticed this issue as the latest verification change caused a conflict in an old PR I submitted).  Changed the error message accordingly.

(Also includes a cosmetic changes: indentation fix and changing `}else` to `} else`.)

