### PR TITLE
clamp BIO_read length in encrypt/decrypt_rsa_message

### DIFF
--- a/src/iperf_auth.c
+++ b/src/iperf_auth.c
@@ -284,7 +284,10 @@ int encrypt_rsa_message(const char *plaintext, EVP_PKEY *public_key, unsigned ch
     encryptedtext_len = output_buffer_len;
 
     BIO *bioBuff   = BIO_new_mem_buf((void*)plaintext, (int)plaintext_len);
-    rsa_buffer_len = BIO_read(bioBuff, rsa_buffer, plaintext_len);
+    /* rsa_buffer only holds output_buffer_len bytes, so never read more than
+       that even when the input is longer (the truncation warned about above). */
+    int read_len = plaintext_len > (size_t)output_buffer_len ? output_buffer_len : (int)plaintext_len;
+    rsa_buffer_len = BIO_read(bioBuff, rsa_buffer, read_len);
 
     int padding = RSA_PKCS1_OAEP_PADDING;
     if (use_pkcs1_padding){
@@ -346,7 +349,10 @@ int decrypt_rsa_message(const unsigned char *encryptedtext, const int encryptedt
     *plaintext = (unsigned char*)OPENSSL_malloc(output_buffer_len + 1);
 
     BIO *bioBuff   = BIO_new_mem_buf((void*)encryptedtext, encryptedtext_len);
-    rsa_buffer_len = BIO_read(bioBuff, rsa_buffer, encryptedtext_len);
+    /* rsa_buffer only holds output_buffer_len bytes, so never read more than
+       that even when the input is longer (the truncation warned about above). */
+    int read_len = encryptedtext_len > output_buffer_len ? output_buffer_len : encryptedtext_len;
+    rsa_buffer_len = BIO_read(bioBuff, rsa_buffer, read_len);
 
     int padding = RSA_PKCS1_OAEP_PADDING;
     if (use_pkcs1_padding){


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: master

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

both encrypt_rsa_message and decrypt_rsa_message warn that input longer than the rsa key size will be truncated, but they then hand the full length to BIO_read while rsa_buffer is only output_buffer_len bytes, so an over-long input writes past the allocation. on a server started with authentication the client-supplied authtoken is base64 decoded and passed straight into decrypt_rsa_message, so a long token overflows that heap buffer (asan reports a write of the full decoded length into the RSA_size buffer). this caps the read to output_buffer_len in both helpers, which is the truncation the existing warning already describes.