### PR TITLE
Server reset errno when starting new test

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3693,7 +3693,8 @@ iperf_reset_test(struct iperf_test *test)
     struct iperf_stream *sp;
     int i;
 
-    iperf_close_logfile(test);
+    // Do not use errno from previous test, for error cases that do not set errno (e.g. server receive illegal parameter from the client)
+    errno = 0;    iperf_close_logfile(test);
 
     /* Free streams */
     while (!SLIST_EMPTY(&test->streams)) {

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3340,6 +3340,12 @@ iperf_new_test()
     struct iperf_test *test;
     int rc;
 
+    /* Do not use errno & i_errno from previous (client) test, for error cases that do not set them.
+     * E.g. i_errno when using the library and preveusely the client receive illegal parameter from the server.
+     */
+    errno = 0;
+    i_errno = 0;
+
     test = (struct iperf_test *) malloc(sizeof(struct iperf_test));
     if (!test) {
         i_errno = IENEWTEST;
@@ -3693,8 +3699,12 @@ iperf_reset_test(struct iperf_test *test)
     struct iperf_stream *sp;
     int i;
 
-    // Do not use errno from previous test, for error cases that do not set errno (e.g. server receive illegal parameter from the client)
-    errno = 0;    
+    /* Do not use errno & i_errno from previous test, for error cases that do not set them.
+     * E.g. errno when server receive illegal parameter from the client, or
+     * i_errno when using the library and preveusely the client receive illegal parameter from the server.
+     */
+    errno = 0;
+    i_errno = 0;
     iperf_close_logfile(test);
 
     /* Free streams */

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3694,7 +3694,8 @@ iperf_reset_test(struct iperf_test *test)
     int i;
 
     // Do not use errno from previous test, for error cases that do not set errno (e.g. server receive illegal parameter from the client)
-    errno = 0;    iperf_close_logfile(test);
+    errno = 0;    
+    iperf_close_logfile(test);
 
     /* Free streams */
     while (!SLIST_EMPTY(&test->streams)) {


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master 3.21+

* Issues fixed (if any): #2063

* Brief description of code changes (suitable for use as a commit message):

Reset `errno` and `i_errno` when test is reset (`iperf_reset_test()` by the server) and when new test starts (`iperf_new_test()` by client that uses the library) .

Regarding client's `i_errno` - see issue details and how to reproduce it in issue #2063.
E.g., when reproducing the issue, the server can use `--server-bitrate-limit 1M` and the client can run with `b 2M` - in the second test run by the client, `iperf_parse_arguments()` fails on the `total required bandwidth is larger than server limit` error from the first test.

Regarding server's `errno`, currently, if test 1 is terminated when `errno` is set and then test 2 is terminated without setting `errno`, the server send to the client `errno` from test 1.  The issue can reproduced by e.g. `iperf3 -s --server-max-duration 10` and then:
1. First test: `iperf3 -c ... -t 5` and terminating the client before the test ends (e.g. using ^C).  Server's `errno` is set to `Connection reset by peer`.
2. Second test: `iperf3 -c ... -t 20`.  The server's error about exceeding the maximum test duration is returned with `errno` from the first test.
