### PR TITLE
Only one Client error log about Server error

### DIFF
--- a/src/iperf_client_api.c
+++ b/src/iperf_client_api.c
@@ -394,17 +394,12 @@ iperf_handle_message_client(struct iperf_test *test)
                 i_errno = IECTRLREAD;
                 return -1;
             }
-	    i_errno = ntohl(err);
+            i_errno = -ntohl(err); // Error value negation indicates this is a Server's error
             if (Nread(test->ctrl_sck, (char*) &err, sizeof(err), Ptcp) < 0) {
                 i_errno = IECTRLREAD;
                 return -1;
             }
             errno = ntohl(err);
-            if (errno > 0) {    
-                iperf_err(test, "SERVER ERROR - %s, errno: %s", iperf_strerror(i_errno), strerror(errno));
-            } else {
-                iperf_err(test, "SERVER ERROR - %s", iperf_strerror(i_errno));
-            }
             return -1;
         default:
             i_errno = IEMESSAGE;
@@ -609,6 +604,7 @@ iperf_run_client(struct iperf_test * test)
     int64_t timeout_us;
     int64_t rcv_timeout_us;
     int i_errno_save;
+    int errno_save;
 
     if (NULL == test)
     {
@@ -882,6 +878,7 @@ iperf_run_client(struct iperf_test * test)
   cleanup_and_fail:
     /* Cancel all outstanding threads */
     i_errno_save = i_errno;
+    errno_save = errno;
     SLIST_FOREACH(sp, &test->streams, streams) {
         if (sp->done) {
             continue;
@@ -911,6 +908,7 @@ iperf_run_client(struct iperf_test * test)
         iperf_printf(test, "All threads stopped\n");
     }
     i_errno = i_errno_save;
+    errno = errno_save;
 
     iperf_client_end(test);
     if (test->json_output) {

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -163,12 +163,27 @@ const char *errarg = NULL;
 char *
 iperf_strerror(int int_errno)
 {
-    static char errstr[256];
-    int len, perr, herr;
+    static char errstr_buf[256];
+    char *errstr;
+    int len, perr, herr, i;
+
     perr = herr = 0;
 
-    len = sizeof(errstr);
+    len = sizeof(errstr_buf);
+    errstr = errstr_buf;
     memset(errstr, 0, len);
+
+    if (int_errno < 0) { // Handle Server error (received as the negative value of the internal error)
+        int_errno = -int_errno;
+        if (errno > 0) { // If server also sent its errno - print it
+            perr = 1;
+        }
+        i = snprintf(errstr, len, "%s", "SERVER ERROR - ");
+        if (i > 0) {
+            len -= i;
+            errstr += i;
+        }
+    }
 
     switch (int_errno) {
         case IENONE:
@@ -579,5 +594,5 @@ iperf_strerror(int int_errno)
 	gerror = 0;
     }
 
-    return errstr;
+    return errstr_buf;
 }


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master 3.21+

* Issues fixed (if any): #2051

* Brief description of code changes (suitable for use as a commit message):

Suggested fix to the issue that the client logs two error messages when receiving an error from the server, which may be a problem in JSON output.

The suggested solution is that the `SERVER ERROR` prefix to the error text is added by `iperf_strerror()`, instead of logging a special error message (which causes the duplicate log).  This is by **negating** the error code received from the server, which indicates to `iperf_strerror()` that this is a server error.  In addition, handling of the `errno` received from the server was also added to `iperf_strerror()`