### PR TITLE
nul-terminate cookie read from control connection in iperf_accept

### DIFF
--- a/src/iperf_server_api.c
+++ b/src/iperf_server_api.c
@@ -199,6 +199,12 @@ iperf_accept(struct iperf_test *test)
             i_errno = IERECVCOOKIE;
             goto error_handling;
         }
+        /*
+         * The cookie is later handled as a NUL-terminated string (printed
+         * and copied into JSON output), but a peer can send COOKIE_SIZE
+         * non-NUL bytes, so make sure it is terminated before it is used.
+         */
+        test->cookie[COOKIE_SIZE - 1] = '\0';
         FD_SET(test->ctrl_sck, &test->read_set);
         if (test->ctrl_sck > test->max_fd) test->max_fd = test->ctrl_sck;
 


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

on the server, `iperf_accept()` reads exactly `COOKIE_SIZE` bytes from the client's control connection into `test->cookie` (a `char[COOKIE_SIZE]`) but never forces a terminating NUL, whereas a well behaved client only sends 36 characters plus a trailing NUL. A peer that sends 37 non-NUL bytes leaves the buffer unterminated, and it is then handled as a C string in `iperf_on_connect()` (copied into the JSON `cookie` field and printed via `report_cookie`), so `strlen` reads past the array into the following struct members. This terminates the cookie right after it is read so the later string handling stays in bounds.
