### PR TITLE
Add control read timeout for slower links. Default unchanged.

### DIFF
--- a/docs/invoking.rst
+++ b/docs/invoking.rst
@@ -314,7 +314,16 @@ the executable.
                  ating  system's  timeout for TCP connection establishment.  Pro-
                  viding a shorter value may speed up detection of a  down  iperf3
                  server.
-   
+
+          --ctrl-timeout n
+                 Set  timeout,  in seconds, for reads on the control connection --
+                 the exchange of state messages, cookie, and end-of-test results
+                 (default  10  seconds).   This  does not affect the bulk data path.
+                 Raising  it  can  prevent  a  spurious  "unable  to  receive re-
+                 sults" failure when the control connection stalls briefly over a
+                 slow or lossy link (for example a cellular interface  selected
+                 with --bind-dev).
+
           -b, --bitrate n[KMGT]
                  Set  target  bitrate  to n bits/sec (default 1 Mbit/sec for UDP,
                  unlimited for TCP/SCTP).  If  there  are  multiple  streams  (-P

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -1184,6 +1184,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 	{"fq-rate", required_argument, NULL, OPT_FQ_RATE},
 	{"pacing-timer", required_argument, NULL, OPT_PACING_TIMER},
 	{"connect-timeout", required_argument, NULL, OPT_CONNECT_TIMEOUT},
+        {"ctrl-timeout", required_argument, NULL, OPT_CTRL_TIMEOUT},
         {"idle-timeout", required_argument, NULL, OPT_IDLE_TIMEOUT},
         {"rcv-timeout", required_argument, NULL, OPT_RCV_TIMEOUT},
         {"snd-timeout", required_argument, NULL, OPT_SND_TIMEOUT},
@@ -1800,6 +1801,15 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 		}
 		client_flag = 1;
 		break;
+	    case OPT_CTRL_TIMEOUT: {
+		int ctrl_timeout_in = atoi(optarg);
+		if (ctrl_timeout_in < 1 || ctrl_timeout_in > MAX_TIME) {
+		    i_errno = IECTRLTIMEOUT;
+		    return -1;
+		}
+		set_ctrl_read_timeout(ctrl_timeout_in);
+		break;
+	    }
 #if defined(HAVE_IPPROTO_MPTCP)
 	    case 'm':
 		set_protocol(test, Ptcp);
@@ -3192,7 +3202,13 @@ JSON_read(int fd, int max_size)
      * Read a four-byte integer, which is the length of the JSON to follow.
      * Then read the JSON into a buffer and parse it.  Return a parsed JSON
      * structure, NULL if there was an error.
+     *
+     * Clear errno first: Nrecv() can fail by timing out or seeing a clean
+     * EOF, neither of which sets errno.  Without this reset a stale errno
+     * from an earlier, unrelated syscall would be reported by callers that
+     * append strerror(errno) (e.g. IERECVRESULTS -> "Bad file descriptor").
      */
+    errno = 0;
     rc = Nread(fd, (char*) &nsize, sizeof(nsize), Ptcp);
     if (rc == sizeof(nsize)) {
         hsize = ntohl(nsize);
@@ -3235,6 +3251,14 @@ JSON_read(int fd, int max_size)
         snprintf(msg_buf, sizeof(msg_buf), "Failed to read JSON data size - read returned %d; errno=%d", rc, errno);
         warning(msg_buf);
     }
+
+    /*
+     * If the read failed but no syscall set errno (Nrecv() read timeout, or
+     * the peer closed the control connection without sending data), report a
+     * meaningful cause rather than whatever stale value errno happens to hold.
+     */
+    if (json == NULL && errno == 0)
+        errno = ETIMEDOUT;
     return json;
 }
 

--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -107,6 +107,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
 #define OPT_JSON_STREAM_FULL_OUTPUT 33
 #define OPT_SERVER_MAX_DURATION 34
 #define OPT_GSRO 35
+#define OPT_CTRL_TIMEOUT 36
 
 /* states */
 #define TEST_START 1
@@ -506,6 +507,7 @@ enum {
     IESETCNTLKACOUNT = 158,    // Unable to set/get socket keepalive TCP number of retries (TCP_KEEPCNT) option
     IEPTHREADSIGMASK=159,      // Unable to initialize sub thread signal mask (check perror)
     IESERVERTESTDURATIONEXPIRED = 160, // Server test duration expired
+    IECTRLTIMEOUT = 161,       // Invalid control connection read timeout (--ctrl-timeout)
     /* Stream errors */
     IECREATESTREAM = 200,   // Unable to create a new stream (check herror/perror)
     IEINITSTREAM = 201,     // Unable to initialize stream (check herror/perror)

--- a/src/iperf_error.c
+++ b/src/iperf_error.c
@@ -563,6 +563,9 @@ iperf_strerror(int int_errno)
             snprintf(errstr, len, "server test duration expired");
             perr = 1;
             break;
+        case IECTRLTIMEOUT:
+            snprintf(errstr, len, "control connection read timeout value is incorrect or not in range");
+            break;
 	    default:
             snprintf(errstr, len, "int_errno=%d", int_errno);
             perr = 1;

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -169,6 +169,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
 #endif /* HAVE_SCTP_H */
                            "  -u, --udp                 use UDP rather than TCP\n"
                            "  --connect-timeout #       timeout for control connection setup (ms)\n"
+                           "  --ctrl-timeout #          timeout for control connection reads/results (seconds, default 10)\n"
                            "  -b, --bitrate #[KMG][/#]  target bitrate in bits/sec (0 for unlimited)\n"
                            "                            (default %d Mbit/sec for UDP, unlimited for TCP)\n"
                            "                            (optional slash and packet count for burst mode)\n"

--- a/src/net.c
+++ b/src/net.c
@@ -76,6 +76,22 @@ static int nread_read_timeout = 10;
 static int nread_overall_timeout = 30;
 
 /*
+ * Override the control-connection read timeouts (in seconds).  These govern
+ * how long Nrecv() will wait for control-socket data (state messages, cookie
+ * and results exchange) before giving up; they do not affect the bulk data
+ * path, which uses Nrecv_no_select().  A value <= 0 leaves the defaults.
+ */
+void
+set_ctrl_read_timeout(int seconds)
+{
+    if (seconds <= 0)
+        return;
+    nread_read_timeout = seconds;
+    if (nread_overall_timeout < seconds)
+        nread_overall_timeout = seconds;
+}
+
+/*
  * Declaration of gerror in iperf_error.c.  Most other files in iperf3 can get this
  * by including "iperf.h", but net.c lives "below" this layer.  Clearly the
  * presence of this declaration is a sign we need to revisit this layering.

--- a/src/net.h
+++ b/src/net.h
@@ -45,6 +45,7 @@ int getsockdomain(int sock);
 int parse_qos(const char *tos);
 int bind_to_device(int s, int domain, const char *bind_dev);
 void iperf_sync_close_socket(int sock);
+void set_ctrl_read_timeout(int seconds);
 
 #define NET_SOFTERROR -1
 #define NET_HARDERROR -2


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3: `master`

* Issues fixed (if any): Adds --ctrl-timeout parameter (server and client) to extend the control channel timeout for slow links. e.g. Cellular.
* n.b. the defaults are left unchanged when --ctrl-timeout is not specified.

* Brief description of code changes (suitable for use as a commit message):
Add --ctrl-timeout parameter to extend control channel processing on high latency links.
