### PR TITLE
Unify handling of `stdatomic.h` not being available

### DIFF
--- a/src/iperf_api.h
+++ b/src/iperf_api.h
@@ -44,8 +44,8 @@ extern "C" { /* open extern "C" */
 #ifdef HAVE_STDATOMIC_H
 #include <stdatomic.h>
 #else
-#warning "No <stdatomic.h> available"
-typedef u_int64_t atomic_uint_fast64_t;
+#warning "No <stdatomic.h> available."
+typedef uint64_t atomic_uint_fast64_t;
 #endif // HAVE_STDATOMIC_H
 
 struct iperf_test;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master`

* Issues fixed (if any): Resolves https://github.com/esnet/iperf/issues/2060.

* Brief description of code changes (suitable for use as a commit message): Unify handling of `stdatomic.h` not being available between `iperf.h` and `iperf_api.h`

The patch results from copy-pasting the paragraph from `iperf.h` to `iperf_api.h`.

