### PR TITLE
Log UDP received debug message only in debug-level debug (4)

### DIFF
--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -118,7 +118,7 @@ iperf_udp_recv(struct iperf_stream *sp)
 	sp->result->bytes_received += r;
 	sp->result->bytes_received_this_interval += r;
 
-	if (sp->test->debug)
+	if (sp->test->debug_level >= DEBUG_LEVEL_DEBUG)
 	    printf("received %d bytes of %d, total %" PRIu64 "\n", r, size, sp->result->bytes_received);
 
 	/* Unified loop: processes single packet when GRO off, multiple when GRO on */


### PR DESCRIPTION
* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:
master 3.21+

* Issues fixed (if any): none

* Brief description of code changes (suitable for use as a commit message):

Log UDP packet received debug message only in debug-level debug (4), as otherwise it makes it difficult to see the other debug messages.

