### PR TITLE
Free rendered JSON output when resetting server tests

### DIFF
--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3826,6 +3826,10 @@ iperf_reset_test(struct iperf_test *test)
 	free(test->extra_data);
 	test->extra_data = NULL;
     }
+    if (test->json_output_string) {
+	free(test->json_output_string);
+	test->json_output_string = NULL;
+    }
 
     /* Free output line buffers, if any (on the server only) */
     struct iperf_textline *t;


### PR DESCRIPTION
_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies: `master` at `c9b74229d0d9bfec6d2307b66b43c29a7665ad0b`

* Issues fixed (if any): None.

* Brief description of code changes (suitable for use as a commit message):
  Release the test-owned rendered JSON string when resetting a server test.

## Summary

A persistent server reuses one `iperf_test` across runs. Full JSON rendering stores a heap copy in `test->json_output_string`, but reset did not release it before the next result replaced the pointer. This change frees and clears that test-owned string in `iperf_reset_test`.

## Evidence

- [`iperf_json_finish`](https://github.com/esnet/iperf/blob/c9b74229d0d9bfec6d2307b66b43c29a7665ad0b/src/iperf_api.c#L5486-L5518) duplicates the rendered document into `json_output_string`.
- [`iperf_reset_test`](https://github.com/esnet/iperf/blob/c9b74229d0d9bfec6d2307b66b43c29a7665ad0b/src/iperf_api.c#L3706-L3838) did not release that string before persistent-server reuse.
- On Ubuntu 24.04.4/glibc, a persistent `-J` server receiving sequential one-second, 32-stream localhost tests retained 628 KiB over warm runs 20–40, or 31.4 KiB/run. A representative rendered document was 32,134 bytes.

## Changes

- Free and clear `json_output_string` at the reset lifecycle boundary.
- Preserve the rendered result through the completed run and leave JSON serialization, emitted output, callbacks, protocol behavior, and the public getter unchanged.

## Risks and boundaries

- `iperf_reset_test` already invalidates test-owned result state for the next run; this applies the same lifetime to the rendered string.
- The correction uses the destructor's existing `free`-and-NULL pattern and adds no new abstraction or platform-specific behavior.

## Verification

- Persistent full JSON candidate: warm RSS growth fell to 40 KiB over runs 20–40 and 16 KiB over runs 40–60, versus 628 KiB over baseline runs 20–40.
- Baseline and candidate one-off documents had identical sorted JSON structure and scalar types after normalizing live values.
- Two `--json-stream --json-stream-full-output` runs emitted JSON accepted by `jq empty`.
- `make -s check` — 5/5 tests passed.
- `test_commands.sh 127.0.0.1` — completed with status 0 in an isolated network namespace; IPv6 was unavailable for the IPv4-only target.

I checked the relevant issues, comments, pull requests, discussions, and `iperf-dev` search results; this pull request is not a duplicate.

### Disclosure

Investigated thoroughly with GPT-5.6 (extra high reasoning effort), using [Oh My Pi](https://github.com/can1357/oh-my-pi) as the agent framework.

This report is not generic or unreviewed AI-generated output. Its claims were checked against the cited evidence, and it includes the relevant detail intended to help maintainers resolve the issue.

If reports like this are not useful to the project, please let me know and I will refrain from submitting similar ones. My intent is to help without wasting maintainer time or energy or discouraging their work.

Thank you for your work.