### PR TITLE
fix zerocopy on Solaris

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -43,7 +43,7 @@
 #endif
 
 #ifdef HAVE_SENDFILE
-#ifdef linux
+#if defined(linux) || defined(__sun)
 #include <sys/sendfile.h>
 #else
 #ifdef __FreeBSD__
@@ -784,7 +784,7 @@ Nsendfile(int fromfd, int tofd, const char *buf, size_t count)
     nleft = count;
     while (nleft > 0) {
 	offset = count - nleft;
-#ifdef linux
+#if defined(linux) || defined(__sun)
 	r = sendfile(tofd, fromfd, &offset, nleft);
 	if (r > 0)
 	    nleft -= r;
@@ -820,7 +820,7 @@ Nsendfile(int fromfd, int tofd, const char *buf, size_t count)
 		return NET_HARDERROR;
 	    }
 	}
-#ifdef linux
+#if defined(linux) || defined(__sun)
 	else if (r == 0)
 	    return NET_SOFTERROR;
 #endif


### PR DESCRIPTION
Currently, `-Z`/`--zerocopy` argument doesn't work on Solaris. `HAVE_SENDFILE` is defined, but then there is no `sendfile` implementation to be used, which results in nothing ever being sent:
```
Accepted connection from 127.0.0.1, port 59470
[  5] local 127.0.0.1 port 5201 connected to 127.0.0.1 port 55152
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  0.00 Bytes  0.00 bits/sec
[  5]   1.00-2.00   sec  0.00 Bytes  0.00 bits/sec
[  5]   2.00-3.00   sec  0.00 Bytes  0.00 bits/sec
[  5]   3.00-4.00   sec  0.00 Bytes  0.00 bits/sec
[  5]   4.00-5.00   sec  0.00 Bytes  0.00 bits/sec
.....
```
This PR send Solaris the Linux way, which fixes the issue.